### PR TITLE
chore(check): the staleness guard asks the shared script

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -54,6 +54,17 @@ against the mirror alone (what the tests do). `board sync` copies the file
 store into Supabase once, ids kept, for the migration that already happened
 on 2026-09-03.
 
+## When the guard itself breaks
+
+It fails open, on purpose. Anything unexpected inside `guard.py` exits 0
+(Claude Code reads that as "no opinion") after appending one line to
+`<workspace>/.board/hook-errors.log`, so a check that did not run looks
+different from one that passed and the orchestrator can see it. A missing
+board, a missing switch file or unreadable input are also "no opinion". The
+only deliberate refusals are the exit-2 paths, and each ends with the exact
+command to run, the session id already filled in. A gate that locked every
+session out on its own bug would be worse than no gate.
+
 ## Tests
 
 `host-tests/bugflow/run.sh` drives every branch of the guard with fixture

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -155,6 +155,8 @@ E="$WORK/emu"; mkdir -p "$E/src" "$E/site/emulator"; ( cd "$E" && git init -q -b
 bash "$STALE" "$E" >/dev/null && ok "a newer source makes the emulator stale" || bad "stale not detected"
 ( cd "$E" && sleep 1 && echo w2 > site/emulator/crossplay.wasm && git add -A && git commit -qm "chore: emulator rebuilt" )
 bash "$STALE" "$E" >/dev/null && bad "a rebuilt emulator still reads stale" || ok "a rebuilt emulator reads fresh"
+bash "$STALE" --paths | grep -qx "src" && bash "$STALE" --paths | grep -qx "tools_local/wasm" && ok "--paths names the source list" || bad "--paths is missing sources"
+grep -q 'emulator-stale.sh' "$HERE/../../scripts_local/check.sh" && ok "check.sh asks the shared script" || bad "check.sh still carries its own staleness test"
 
 echo
 echo "$((PASS+FAIL)) checks, $FAIL failed"

--- a/host-tests/checksh/run.sh
+++ b/host-tests/checksh/run.sh
@@ -62,6 +62,8 @@ build_repo() {  # artifact_epoch, source_epoch
     git init --quiet -b xteink
     git config user.email t@t; git config user.name t
     mkdir -p site/emulator src
+    # The gate asks scripts_local/emulator-stale.sh, so the fixture carries it.
+    mkdir -p scripts_local && cp "$HERE/../../scripts_local/emulator-stale.sh" scripts_local/
     stamp() {  # epoch, path, message
       echo x >"$2"
       git add -A
@@ -93,6 +95,7 @@ run_gate() {  # runs the gate in $WORK/repo, echoes "fired" or "silent"
     cd "$WORK/repo"
     FAILED=0
     DEPLOY_BRANCH=xteink
+    REPO="$WORK/repo"
     if [ -n "${CARRY:-}" ]; then
       export CHECK_OUTER_BRANCH="$CARRY"
     else

--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -857,14 +857,17 @@ fi
 # Any branch that changes firmware AND ships site/emulator now gets the
 # warning; only $DEPLOY_BRANCH treats it as a failure, because a feature
 # branch legitimately rebuilds the 6-minute artifact once, at the end.
+# The test itself lives in scripts_local/emulator-stale.sh, shared with the CI
+# job that rebuilds the artifact after a merge, so the two cannot disagree
+# about which paths count as sources.
 if true; then
-  ART=$(git log -1 --format=%ct -- site/emulator 2>/dev/null)
-  SRC=$(git log -1 --format=%ct -- src lib assets_local tools_local/wasm 2>/dev/null)
-  if [ -n "$ART" ] && [ -n "$SRC" ] && [ "$ART" -lt "$SRC" ]; then
+  EMU_SOURCES=$(bash "$REPO/scripts_local/emulator-stale.sh" --paths | tr '\n' ' ')
+  if bash "$REPO/scripts_local/emulator-stale.sh" "$REPO" >/dev/null 2>&1; then
     echo
     echo "browser artifact is STALE"
     echo "  site/emulator/ was built at $(git log -1 --format=%h\ %s -- site/emulator | cut -c1-58)"
-    echo "  but $(git log -1 --format=%h\ %s -- src lib assets_local tools_local/wasm | cut -c1-58) came after it"
+    # shellcheck disable=SC2086
+    echo "  but $(git log -1 --format=%h\ %s -- $EMU_SOURCES | cut -c1-58) came after it"
     echo "  the live page would ship code older than this branch. Rebuild:"
     echo "    pio run -e simulator_x4_pro -t compiledb"
     echo "    source ../.emsdk/emsdk_env.sh && python3 tools_local/wasm/build.py"

--- a/scripts_local/emulator-stale.sh
+++ b/scripts_local/emulator-stale.sh
@@ -8,11 +8,19 @@
 # otherwise. The source list is the guard's, in one place.
 #
 #   scripts_local/emulator-stale.sh [repo-dir]
+#   scripts_local/emulator-stale.sh --paths      # the source list itself
 set -uo pipefail
-cd "${1:-$(dirname "$0")/..}" || exit 2
 
 SOURCES=(src lib assets_local tools_local/wasm platformio.sim.ini freeink-sdk)
 ARTEFACT=site/emulator
+
+# --paths: print the source list, one per line, for callers that want to name
+# what moved (check.sh's message) without spelling the list a second time.
+if [ "${1:-}" = "--paths" ]; then
+  printf '%s\n' "${SOURCES[@]}"
+  exit 0
+fi
+cd "${1:-$(dirname "$0")/..}" || exit 2
 
 src_ts="$(git log -1 --format=%ct -- "${SOURCES[@]}" 2>/dev/null || echo 0)"
 art_ts="$(git log -1 --format=%ct -- "$ARTEFACT" 2>/dev/null || echo 0)"


### PR DESCRIPTION
## What

check.sh's browser-artifact staleness guard now calls `scripts_local/emulator-stale.sh`, the test the emulator CI job uses, with a `--paths` mode so the guard's message names the same list. host-tests/checksh's fixture carries the script. docs/workflow/README.md documents the guard's fail-open policy.

What is new: nothing user-facing; check.sh and the emulator CI job agree by construction on what counts as a source.

## Proof

host-tests/bugflow 66 checks and host-tests/checksh 66 checks green locally.

## Not verified

The device builds are CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)