### PR TITLE
feat(site): the inbox opens with a passphrase

### DIFF
--- a/host-tests/site/inbox_fn.js
+++ b/host-tests/site/inbox_fn.js
@@ -1,0 +1,168 @@
+// The inbox function, run under plain node with the board stubbed out.
+//
+// api/inbox.js is the gate between a passphrase and the board's write key,
+// so the gate is what is asserted: a wrong passphrase reads nothing, a
+// right one reads, an answer writes exactly one blocker closed.
+//
+//   node host-tests/site/inbox_fn.js <repo-root>
+
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+const root = process.argv[2] || path.join(__dirname, "..", "..");
+process.env.SUPABASE_URL = "https://board.test";
+process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key-for-tests";
+process.env.INBOX_PASSPHRASE_HASH = crypto
+  .createHash("sha256")
+  .update("open sesame")
+  .digest("hex");
+const handler = require(path.join(root, "site", "api", "inbox.js"));
+
+let calls = [];
+global.fetch = async function (url, opts) {
+  opts = opts || {};
+  calls.push({
+    url: String(url),
+    method: opts.method || "GET",
+    body: opts.body,
+  });
+  const u = String(url);
+  if (u.includes("/rest/v1/inbox"))
+    return new Response(
+      JSON.stringify([
+        {
+          blocker_id: 5,
+          n: 1,
+          card_id: 3,
+          title: "Use Instapaper once",
+          app: "instapaper",
+          body: "since: proven",
+          ask: "did it work?",
+          default: "unverified",
+        },
+      ]),
+      { status: 200 },
+    );
+  if (u.includes("/rest/v1/cards"))
+    return new Response(
+      JSON.stringify([
+        {
+          id: 3,
+          title: "Use Instapaper once",
+          app: "instapaper",
+          state: "reported",
+          parent: null,
+        },
+      ]),
+      { status: 200 },
+    );
+  if (u.includes("/rest/v1/blockers") && opts.method === "PATCH")
+    return new Response(null, { status: 204 });
+  if (u.includes("/rest/v1/history"))
+    return new Response(null, { status: 201 });
+  return new Response("[]", { status: 200 });
+};
+
+function fakeReq(body) {
+  return { method: "POST", url: "/api/inbox", headers: {}, body, socket: {} };
+}
+function fakeRes() {
+  const res = { statusCode: 200, headers: {}, body: "" };
+  res.setHeader = (k, v) => {
+    res.headers[k.toLowerCase()] = v;
+  };
+  res.end = (b) => {
+    res.body = b || "";
+    res.done();
+  };
+  res.finished = new Promise((r) => {
+    res.done = r;
+  });
+  return res;
+}
+async function call(body) {
+  const res = fakeRes();
+  await handler(fakeReq(body), res);
+  await res.finished;
+  let j = null;
+  try {
+    j = JSON.parse(res.body);
+  } catch (e) {}
+  return { status: res.statusCode, json: j };
+}
+
+let pass = 0,
+  fail = 0;
+const ok = (m) => {
+  pass++;
+  console.log("  ok   " + m);
+};
+const bad = (m) => {
+  fail++;
+  console.log("  FAIL " + m);
+};
+const expect = (label, got, want) =>
+  got === want
+    ? ok(label)
+    : bad(
+        `${label} (got ${JSON.stringify(got)}, wanted ${JSON.stringify(want)})`,
+      );
+
+(async () => {
+  calls = [];
+  let r = await call({ pass: "wrong", op: "list" });
+  expect("a wrong passphrase is refused", r.status, 401);
+  expect("and reads nothing from the board", calls.length, 0);
+  r = await call({ op: "list" });
+  expect("no passphrase is refused", r.status, 401);
+
+  calls = [];
+  r = await call({ pass: "open sesame", op: "list" });
+  expect("the right passphrase reads the inbox", r.status, 200);
+  expect(
+    "with the open blockers",
+    r.json && r.json.inbox && r.json.inbox.length,
+    1,
+  );
+  expect("and every card", r.json && r.json.cards && r.json.cards.length, 1);
+
+  calls = [];
+  r = await call({
+    pass: "open sesame",
+    op: "answer",
+    card_id: 3,
+    n: 1,
+    choice: "it worked",
+    note: "",
+  });
+  expect("an answer succeeds", r.status, 200);
+  const patch = calls.find(
+    (c) => c.method === "PATCH" && c.url.includes("/rest/v1/blockers"),
+  );
+  expect(
+    "closes exactly the named blocker",
+    patch ? patch.url.includes("card_id=eq.3&n=eq.1&open=is.true") : false,
+    true,
+  );
+  expect(
+    "with the choice on it",
+    patch ? JSON.parse(patch.body).answer_choice : null,
+    "it worked",
+  );
+  expect(
+    "and writes one history line",
+    calls.filter((c) => c.url.includes("/rest/v1/history")).length,
+    1,
+  );
+
+  r = await call({ pass: "open sesame", op: "answer", card_id: 3 });
+  expect("an answer without a choice is refused", r.status, 502);
+  r = await call({ pass: "open sesame", op: "nonsense" });
+  expect("an unknown operation is refused", r.status, 400);
+
+  console.log(`${pass + fail} checks, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})().catch((e) => {
+  console.log("  FAIL harness crashed: " + e.stack);
+  process.exit(1);
+});

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -258,7 +258,21 @@ fi
 
 # The inbox page and serve.py must agree on the config endpoint's shape, or
 # local work passes against a key production never sends.
-grep -q 'anonKey' "$ROOT/site/api/board-config.js" && grep -q '"anonKey"' "$SERVE" && grep -q 'anonKey' "$ROOT/site/inbox/index.html" && ok || bad "board-config: api, serve.py and the inbox page do not agree on anonKey"
+grep -q 'anonKey' "$ROOT/site/api/board-config.js" && grep -q '"anonKey"' "$SERVE" && ok || bad "board-config: api and serve.py do not agree on anonKey"
+
+# The inbox gate: a passphrase, checked by api/inbox.js against a hash. Run
+# under node with the board stubbed; the wrong passphrase must read nothing.
+if inbox_out="$(node "$HERE/inbox_fn.js" "$ROOT" 2>&1)"; then
+  ok
+  n_fail="$(printf '%s\n' "$inbox_out" | grep -c '^  FAIL' || true)"
+  [ "$n_fail" -eq 0 ] && ok || { while IFS= read -r line; do bad "inbox_fn: $line"; done < <(printf '%s\n' "$inbox_out" | grep '^  FAIL'); }
+else
+  bad "inbox_fn.js could not run, so api/inbox.js went unchecked:"
+  while IFS= read -r line; do echo "      $line"; done <<< "$inbox_out"
+fi
+# and the page talks only to that gate, never to the board directly
+grep -q '"/api/inbox"' "$ROOT/site/inbox/index.html" && ok || bad "the inbox page does not call /api/inbox"
+grep -q 'supabase.co\|/rest/v1/\|/auth/v1/' "$ROOT/site/inbox/index.html" && bad "the inbox page still talks to the board directly" || ok
 
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/site/api/inbox.js
+++ b/site/api/inbox.js
@@ -1,0 +1,154 @@
+// POST /api/inbox   {pass, op, ...}
+//
+// The inbox page's one door to the board. A passphrase instead of an email
+// link: the page sends it with every call, this checks its hash against the
+// INBOX_PASSPHRASE_HASH environment variable (sha256, hex), and only then
+// reads or writes the board with the service key. The passphrase never
+// reaches the board and is never stored anywhere but the reader's browser.
+//
+// Change the passphrase: printf '%s' 'new one' | shasum -a 256, then set
+// INBOX_PASSPHRASE_HASH on Vercel to the hex and redeploy.
+//
+// Operations:
+//   list     -> {inbox: [open blockers that need Mario, with their card], cards: [every card]}
+//   numbers  -> {byVersion, daily, services, errors}
+//   answer   -> closes one blocker: {card_id, n, choice, note}
+
+const crypto = require("node:crypto");
+
+const SUPABASE_URL = process.env.SUPABASE_URL || "";
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+const PASS_HASH = (process.env.INBOX_PASSPHRASE_HASH || "")
+  .trim()
+  .toLowerCase();
+
+function json(res, status, body) {
+  res.statusCode = status;
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Cache-Control", "no-store");
+  res.end(JSON.stringify(body));
+}
+
+async function readBody(req) {
+  if (req.body !== undefined && req.body !== null) {
+    if (Buffer.isBuffer(req.body)) return req.body.toString("utf8");
+    if (typeof req.body === "string") return req.body;
+    return JSON.stringify(req.body);
+  }
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > 64 * 1024) return null;
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function passOk(pass) {
+  if (!PASS_HASH || typeof pass !== "string" || !pass.length) return false;
+  const got = crypto.createHash("sha256").update(pass).digest("hex");
+  if (got.length !== PASS_HASH.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(got), Buffer.from(PASS_HASH));
+}
+
+async function rest(path, init) {
+  const headers = Object.assign(
+    {
+      apikey: SERVICE_KEY,
+      Authorization: `Bearer ${SERVICE_KEY}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    (init && init.headers) || {},
+  );
+  const r = await fetch(
+    `${SUPABASE_URL}/rest/v1/${path}`,
+    Object.assign({}, init, { headers }),
+  );
+  if (!r.ok) throw new Error(`board ${r.status} on ${path.split("?")[0]}`);
+  const text = await r.text();
+  return text ? JSON.parse(text) : null;
+}
+
+async function opList() {
+  const [inbox, cards] = await Promise.all([
+    rest("inbox?select=*"),
+    rest("cards?select=id,title,app,state,parent,updated_at&order=id.desc"),
+  ]);
+  return { inbox: inbox || [], cards: cards || [] };
+}
+
+async function opNumbers() {
+  const q = (p) => rest(p).catch(() => []);
+  const [byVersion, daily, services, errors] = await Promise.all([
+    q("devices_by_version?select=*"),
+    q("daily_active_devices?select=*"),
+    q("service_users?select=*"),
+    q(
+      "error_fingerprints?select=service,message,count,last_seen,card_id&order=last_seen.desc&limit=20",
+    ),
+  ]);
+  return { byVersion, daily, services, errors };
+}
+
+async function opAnswer(body) {
+  const cardId = parseInt(body.card_id, 10);
+  const n = parseInt(body.n, 10);
+  const choice = String(body.choice || "")
+    .trim()
+    .slice(0, 500);
+  const note = String(body.note || "")
+    .trim()
+    .slice(0, 2000);
+  if (!Number.isInteger(cardId) || !Number.isInteger(n) || !choice)
+    throw new Error("card, blocker and a choice are needed");
+  await rest(`blockers?card_id=eq.${cardId}&n=eq.${n}&open=is.true`, {
+    method: "PATCH",
+    headers: { Prefer: "return=minimal" },
+    body: JSON.stringify({
+      open: false,
+      answer_choice: choice,
+      answer_note: note,
+      answered_at: new Date().toISOString(),
+    }),
+  });
+  await rest("history", {
+    method: "POST",
+    headers: { Prefer: "return=minimal" },
+    body: JSON.stringify({
+      card_id: cardId,
+      what: `answered from the inbox: ${choice}`,
+    }),
+  });
+  return { ok: true };
+}
+
+module.exports = async function handler(req, res) {
+  if (req.method !== "POST") return json(res, 405, { error: "POST only." });
+  if (!SUPABASE_URL || !SERVICE_KEY || !PASS_HASH)
+    return json(res, 503, {
+      error: "The inbox is not set up on this deployment.",
+    });
+  const raw = await readBody(req);
+  let body;
+  try {
+    body = JSON.parse(raw || "{}");
+  } catch (err) {
+    return json(res, 400, { error: "Unreadable request." });
+  }
+  if (!passOk(body.pass)) {
+    await new Promise((r) => setTimeout(r, 400));
+    return json(res, 401, { error: "That is not the passphrase." });
+  }
+  try {
+    if (body.op === "list") return json(res, 200, await opList());
+    if (body.op === "numbers") return json(res, 200, await opNumbers());
+    if (body.op === "answer") return json(res, 200, await opAnswer(body));
+    return json(res, 400, { error: "Unknown operation." });
+  } catch (err) {
+    return json(res, 502, {
+      error: err.message || "The board did not answer.",
+    });
+  }
+};

--- a/site/inbox/index.html
+++ b/site/inbox/index.html
@@ -12,7 +12,8 @@
 <style>
   [hidden] { display: none !important; } /* styles.css styles buttons; the attribute must still win */
   /* One message at a time. What needs Mario, in three lines, with buttons.
-     Signed in by magic link; the board's row security decides who reads. */
+     A passphrase, typed once and remembered by this browser; every call to
+     the board goes through /api/inbox, which checks it. */
   .inbox { max-width: 34rem; margin: 0 auto; padding: 2rem var(--gutter) 5rem; }
   .top { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; border-bottom: 2px solid var(--ink); padding-bottom: 0.6rem; margin-bottom: 1.2rem; }
   .top h1 { font-family: var(--display); font-weight: 400; font-size: 2.6rem; margin: 0; line-height: 1; }
@@ -45,10 +46,10 @@
   summary small { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); margin-left: 0.5rem; font-weight: 400; }
   .all { list-style: none; padding: 0; margin: 0.6rem 0 0; }
   .all li { display: flex; gap: 0.8rem; align-items: baseline; padding: 0.45rem 0; border-bottom: 1px solid var(--edge); font-size: 0.95rem; }
+  .all li.child { padding-left: 1.4rem; font-size: 0.9rem; }
   .all .st { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); min-width: 5.5rem; }
   .all .st.released, .all .st.done { color: var(--ink); }
   .all .app { color: var(--muted); font-size: 0.82rem; margin-left: auto; white-space: nowrap; }
-  .foot { margin-top: 2rem; font-size: 0.85rem; color: var(--muted); display: flex; justify-content: space-between; gap: 1rem; }
   .num-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr)); gap: 0.6rem; margin: 0.8rem 0; }
   .tile { border: 1px solid var(--edge); border-radius: 6px; padding: 0.6rem 0.8rem; }
   .tile b { display: block; font-family: var(--display); font-weight: 400; font-size: 2rem; line-height: 1; }
@@ -57,7 +58,7 @@
   table.nums th, table.nums td { text-align: left; padding: 0.3rem 0.4rem; border-bottom: 1px solid var(--edge); }
   table.nums td.n, table.nums th.n { text-align: right; }
   .nums-h { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin: 0.9rem 0 0.2rem; }
-  .photo { max-width: 100%; border: 1px solid var(--edge); border-radius: 4px; margin-top: 0.6rem; }
+  .foot { margin-top: 2rem; font-size: 0.85rem; color: var(--muted); display: flex; justify-content: space-between; gap: 1rem; }
 </style>
 </head>
 <body>
@@ -68,10 +69,10 @@
   </div>
 
   <section class="login" id="inbox-login" hidden>
-    <label for="inbox-email">Sign in with a link to your email</label>
+    <label for="inbox-pass">Passphrase</label>
     <div class="answer">
-      <input type="email" id="inbox-email" autocomplete="email" placeholder="you@example.com">
-      <button class="btn primary" id="inbox-link">Send link</button>
+      <input type="password" id="inbox-pass" autocomplete="current-password" placeholder="the one from the workflow session">
+      <button class="btn primary" id="inbox-enter">Open</button>
     </div>
     <p class="status" id="inbox-login-status"></p>
   </section>
@@ -89,81 +90,46 @@
     <div id="inbox-numbers-body"></div>
   </details>
 
-  <p class="foot"><span>One message at a time. A tap is the whole answer.</span><button class="btn quiet" id="inbox-signout" hidden>Sign out</button></p>
+  <p class="foot"><span>One message at a time. A tap is the whole answer.</span><button class="btn quiet" id="inbox-signout" hidden>Forget passphrase</button></p>
 </main>
 
 <script>
 (function () {
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
-  var KEY = "crossplay-inbox-session";
-  var cfg = null, session = null, later = {}, items = [], all = [];
+  var KEY = "crossplay-inbox-pass";
+  var pass = null, later = {}, items = [], all = [];
 
   function say(text, err) { var s = $("inbox-status"); s.textContent = text || ""; s.className = "status" + (err ? " err" : ""); }
   function esc(s) { return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) { return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]; }); }
-  function loadSession() { try { session = JSON.parse(localStorage.getItem(KEY) || "null"); } catch (e) { session = null; } }
-  function saveSession(s) { session = s; try { if (s) localStorage.setItem(KEY, JSON.stringify(s)); else localStorage.removeItem(KEY); } catch (e) {} }
+  function loadPass() { try { pass = localStorage.getItem(KEY) || null; } catch (e) { pass = null; } }
+  function savePass(p) { pass = p; try { if (p) localStorage.setItem(KEY, p); else localStorage.removeItem(KEY); } catch (e) {} }
 
-  // A magic link lands here with the tokens in the fragment. Keep them, then
-  // drop them from the address bar.
-  function takeTokensFromHash() {
-    if (!location.hash || location.hash.indexOf("access_token=") < 0) return;
-    var h = new URLSearchParams(location.hash.slice(1));
-    saveSession({ access_token: h.get("access_token"), refresh_token: h.get("refresh_token"), expires_at: Date.now() + (parseInt(h.get("expires_in") || "3600", 10) * 1000) });
-    history.replaceState(null, "", location.pathname);
+  function api(op, extra) {
+    var body = Object.assign({ pass: pass, op: op }, extra || {});
+    return fetch("/api/inbox", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) })
+      .then(function (r) { return r.json().then(function (j) { if (!r.ok) { var e = new Error(j && j.error || ("HTTP " + r.status)); e.status = r.status; throw e; } return j; }); });
   }
 
-  function authHeaders(json) {
-    var h = { apikey: cfg.anonKey, Authorization: "Bearer " + session.access_token };
-    if (json) h["Content-Type"] = "application/json";
-    return h;
-  }
-
-  function refresh() {
-    if (!session || !session.refresh_token) return Promise.reject(new Error("no session"));
-    return fetch(cfg.url + "/auth/v1/token?grant_type=refresh_token", {
-      method: "POST", headers: { apikey: cfg.anonKey, "Content-Type": "application/json" },
-      body: JSON.stringify({ refresh_token: session.refresh_token })
-    }).then(function (r) { if (!r.ok) throw new Error("refresh failed"); return r.json(); })
-      .then(function (j) { saveSession({ access_token: j.access_token, refresh_token: j.refresh_token, expires_at: Date.now() + j.expires_in * 1000 }); });
-  }
-
-  function api(path, init, retried) {
-    init = init || {};
-    init.headers = Object.assign(authHeaders(!!init.body), init.headers || {});
-    return fetch(cfg.url + "/rest/v1/" + path, init).then(function (r) {
-      if (r.status === 401 && !retried) return refresh().then(function () { return api(path, init, true); });
-      if (!r.ok) return r.text().then(function (t) { throw new Error(t || ("HTTP " + r.status)); });
-      return r.status === 204 ? null : r.json();
-    });
-  }
-
-  function sendLink() {
-    var email = $("inbox-email").value.trim();
-    var st = $("inbox-login-status");
-    if (!email) { st.textContent = "Your email first."; return; }
-    $("inbox-link").disabled = true;
-    fetch(cfg.url + "/auth/v1/otp?redirect_to=" + encodeURIComponent(location.origin + location.pathname), {
-      method: "POST", headers: { apikey: cfg.anonKey, "Content-Type": "application/json" },
-      body: JSON.stringify({ email: email, create_user: true })
-    }).then(function (r) {
-      st.textContent = r.ok ? "Sent. Open the link on this device." : "Could not send the link. Try again in a minute.";
-    }).catch(function () { st.textContent = "Could not reach the board."; })
-      .finally(function () { $("inbox-link").disabled = false; });
+  function enter() {
+    var p = $("inbox-pass").value;
+    if (!p) { $("inbox-pass").focus(); return; }
+    $("inbox-enter").disabled = true;
+    savePass(p);
+    load().finally(function () { $("inbox-enter").disabled = false; });
   }
 
   function load() {
     say("Loading...");
-    return Promise.all([
-      api("inbox?select=*"),
-      api("cards?select=id,title,app,state,updated_at&order=id.desc")
-    ]).then(function (res) {
-      items = res[0] || []; all = res[1] || [];
+    return api("list").then(function (res) {
+      items = res.inbox || []; all = res.cards || [];
+      $("inbox-login").hidden = true;
       say("");
       render();
       loadNumbers();
     }).catch(function (err) {
-      if (/JWT|401|refresh|no session/i.test(err.message)) { saveSession(null); showLogin("Your link expired. Send a new one."); return; }
+      if (err.status === 401) { savePass(null); showLogin("That is not the passphrase."); return; }
+      if (err.status === 503) { showLogin("The inbox is not set up on this deployment."); return; }
       say("Could not read the board: " + err.message, true);
     });
   }
@@ -181,9 +147,7 @@
 
   function answer(m, choice, note) {
     say("Saving...");
-    var body = { open: false, answer_choice: choice, answer_note: note || "", answered_at: new Date().toISOString() };
-    api("blockers?card_id=eq." + m.card_id + "&n=eq." + m.n, { method: "PATCH", headers: { Prefer: "return=minimal" }, body: JSON.stringify(body) })
-      .then(function () { return api("history", { method: "POST", headers: { Prefer: "return=minimal" }, body: JSON.stringify({ card_id: m.card_id, what: "answered from the inbox: " + choice }) }); })
+    api("answer", { card_id: m.card_id, n: m.n, choice: choice, note: note || "" })
       .then(function () { items = items.filter(function (x) { return x.blocker_id !== m.blocker_id; }); say("Answered."); render(); })
       .catch(function (err) { say("Could not save that: " + err.message, true); });
   }
@@ -213,12 +177,17 @@
       $("inbox-default").addEventListener("click", function () { answer(m, m["default"] || "default", "took the default"); });
       $("inbox-later").addEventListener("click", function () { later[m.blocker_id] = true; render(); });
     }
+    // Everything: parents first, their children indented, in state order.
     var ul = $("inbox-all");
     var order = ["reported", "triaged", "working", "review", "merged", "released", "done", "parked"];
-    all.sort(function (a, b) { return order.indexOf(a.state) - order.indexOf(b.state) || b.id - a.id; });
-    ul.innerHTML = all.map(function (c) {
-      return '<li><span class="st ' + esc(c.state) + '">' + esc(c.state) + '</span><span>#' + c.id + ' ' + esc(c.title) + '</span><span class="app">' + esc(c.app) + '</span></li>';
-    }).join("");
+    var byId = {}; all.forEach(function (c) { byId[c.id] = c; });
+    var kids = {}; all.forEach(function (c) { if (c.parent && byId[c.parent]) (kids[c.parent] = kids[c.parent] || []).push(c); });
+    var tops = all.filter(function (c) { return !(c.parent && byId[c.parent]); });
+    tops.sort(function (a, b) { return order.indexOf(a.state) - order.indexOf(b.state) || b.id - a.id; });
+    var row = function (c, child) {
+      return '<li' + (child ? ' class="child"' : '') + '><span class="st ' + esc(c.state) + '">' + esc(c.state) + '</span><span>#' + c.id + ' ' + esc(c.title) + '</span><span class="app">' + esc(c.app) + '</span></li>';
+    };
+    ul.innerHTML = tops.map(function (c) { return row(c, false) + (kids[c.id] || []).map(function (k) { return row(k, true); }).join(""); }).join("");
     $("inbox-all-count").textContent = all.length + " cards";
     $("inbox-everything").hidden = false;
     $("inbox-signout").hidden = false;
@@ -226,7 +195,7 @@
 
   // Numbers: the four views over events, and GitHub's own download counts.
   // Every figure names its window, because a count without one reads as
-  // "always" (see the memory about denominators).
+  // "always".
   function loadNumbers() {
     var body = $("inbox-numbers-body");
     $("inbox-numbers").hidden = false;
@@ -237,28 +206,25 @@
         rows.map(function (r) { return '<tr>' + r.map(function (v, i) { return '<td' + (i ? ' class="n"' : '') + '>' + esc(v) + '</td>'; }).join('') + '</tr>'; }).join('') + '</table>';
     }
     Promise.all([
-      api("devices_by_version?select=*").catch(function () { return []; }),
-      api("daily_active_devices?select=*").catch(function () { return []; }),
-      api("service_users?select=*").catch(function () { return []; }),
-      api("error_fingerprints?select=service,message,count,last_seen,card_id&order=last_seen.desc&limit=20").catch(function () { return []; }),
+      api("numbers").catch(function () { return { byVersion: [], daily: [], services: [], errors: [] }; }),
       fetch("https://api.github.com/repos/ma-r-s/crossplay/releases?per_page=10").then(function (r) { return r.ok ? r.json() : []; }).catch(function () { return []; })
     ]).then(function (res) {
-      var byVersion = res[0], daily = res[1], services = res[2], errors = res[3], releases = res[4];
-      var devices7 = byVersion.reduce(function (a, r) { return a + (r.devices || 0); }, 0);
-      var today = daily.length ? daily[0].devices : 0;
+      var n = res[0], releases = res[1];
+      var devices7 = (n.byVersion || []).reduce(function (a, r) { return a + (r.devices || 0); }, 0);
+      var today = (n.daily || []).length ? n.daily[0].devices : 0;
       var h = '<div class="num-grid">' +
         '<div class="tile"><b>' + devices7 + '</b><span>devices heard from, 7 days</span></div>' +
         '<div class="tile"><b>' + today + '</b><span>devices today</span></div>' +
-        '<div class="tile"><b>' + errors.filter(function (e) { return e.card_id; }).length + '</b><span>distinct errors with a card</span></div>' +
+        '<div class="tile"><b>' + (n.errors || []).filter(function (e) { return e.card_id; }).length + '</b><span>distinct errors with a card</span></div>' +
         '</div>';
-      h += '<p class="nums-h">Devices by version, 7 days</p>' + tbl(["board", "version", "devices"], byVersion.map(function (r) { return [r.board, r.version, r.devices]; }));
-      h += '<p class="nums-h">Who uses each service, 7 days</p>' + tbl(["service", "devices", "events"], services.map(function (r) { return [r.service, r.devices_7d, r.events_7d]; }));
+      h += '<p class="nums-h">Devices by version, 7 days</p>' + tbl(["board", "version", "devices"], (n.byVersion || []).map(function (r) { return [r.board, r.version, r.devices]; }));
+      h += '<p class="nums-h">Who uses each service, 7 days</p>' + tbl(["service", "devices", "events"], (n.services || []).map(function (r) { return [r.service, r.devices_7d, r.events_7d]; }));
       h += '<p class="nums-h">Downloads per release, from GitHub, all time</p>' + tbl(["release", "published", "downloads"], releases.map(function (r) {
-        var n = (r.assets || []).filter(function (a) { return /firmware(-sticky)?\.bin$|-full\.bin$/.test(a.name); }).reduce(function (a, x) { return a + (x.download_count || 0); }, 0);
-        return [r.tag_name, (r.published_at || "").slice(0, 10), n];
+        var d = (r.assets || []).filter(function (a) { return /firmware(-sticky)?\.bin$|-full\.bin$/.test(a.name); }).reduce(function (a, x) { return a + (x.download_count || 0); }, 0);
+        return [r.tag_name, (r.published_at || "").slice(0, 10), d];
       }));
-      h += '<p class="nums-h">Errors seen, latest first</p>' + tbl(["service", "message", "times", "card"], errors.map(function (e) { return [e.service, (e.message || "").slice(0, 60), e.count, e.card_id ? "#" + e.card_id : ""]; }));
-      if (!byVersion.length && !services.length) h += '<p class="status">No events yet. Devices and services start posting once their owners wire the heartbeat and the events in docs/workflow/events.md.</p>';
+      h += '<p class="nums-h">Errors seen, latest first</p>' + tbl(["service", "message", "times", "card"], (n.errors || []).map(function (e) { return [e.service, (e.message || "").slice(0, 60), e.count, e.card_id ? "#" + e.card_id : ""]; }));
+      if (!(n.byVersion || []).length && !(n.services || []).length) h += '<p class="status">No events yet. Devices and services start posting once their owners wire the heartbeat and the events in docs/workflow/events.md.</p>';
       body.innerHTML = h;
     });
   }
@@ -270,21 +236,16 @@
     $("inbox-numbers").hidden = true;
     $("inbox-signout").hidden = true;
     $("inbox-count").textContent = "";
-    if (text) $("inbox-login-status").textContent = text;
+    $("inbox-login-status").textContent = text || "";
+    $("inbox-pass").focus();
   }
 
-  $("inbox-link").addEventListener("click", sendLink);
-  $("inbox-email").addEventListener("keydown", function (e) { if (e.key === "Enter") sendLink(); });
-  $("inbox-signout").addEventListener("click", function () { saveSession(null); showLogin(""); });
+  $("inbox-enter").addEventListener("click", enter);
+  $("inbox-pass").addEventListener("keydown", function (e) { if (e.key === "Enter") enter(); });
+  $("inbox-signout").addEventListener("click", function () { savePass(null); showLogin(""); });
 
-  fetch("/api/board-config").then(function (r) { if (!r.ok) throw new Error("no config"); return r.json(); })
-    .then(function (c) {
-      cfg = c;
-      takeTokensFromHash();
-      loadSession();
-      if (session && session.access_token) { $("inbox-login").hidden = true; load(); } else { showLogin(""); }
-    })
-    .catch(function () { say("The board is not set up on this deployment.", true); });
+  loadPass();
+  if (pass) load(); else showLogin("");
 })();
 </script>
 </body>


### PR DESCRIPTION
The inbox page asks for one passphrase and sends it to api/inbox.js, which checks a hash and proxies the board. No email link, no direct Supabase calls from the page. Site-only; host suites green locally (site 101 checks).

What is new: the inbox opens with a passphrase instead of an email link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)