### PR TITLE
fix: guard allows own subagents; pulse cards land on owners and close on recovery

### DIFF
--- a/docs/workflow/events.md
+++ b/docs/workflow/events.md
@@ -45,6 +45,13 @@ like any other card. Every later occurrence adds one to the count in
 `error_fingerprints` and attaches to the same card. A fingerprint whose card
 was closed and that comes back opens a new card: that is a regression.
 
+An `info` event that carries a `fingerprint` says that problem is gone:
+the open card for it closes by itself with a "recovered" line. The pulse
+does this on every host that answers; a service that can tell its own
+error is over may do the same.
+
+Send `props.app` when the card belongs to another app's owner than the
+poster (the pulse posts as `pulse`; a dead books host is Get Books').
 Send a `fingerprint` yourself when you know better than the message what
 makes two errors the same (for example the book id is what matters, not the
 timeout).
@@ -85,7 +92,8 @@ daily upstream sync: upstream commits xteink lacks, older than 30 hours,
 with no `sync/upstream-*` pull request open, is an error.
 
 **When your service goes live, add its line to `hosts.txt`** with the
-method, the path, and the status it really answers there (a 401 from a
+method, the path, the status it really answers there, and your app's name
+(the card for an outage lands on that app's owner) (a 401 from a
 Basic-auth root is fine, and is what proves the service is up). A host
 listed before it exists opens a card every half hour.
 

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -77,6 +77,7 @@ expect "worker to orchestrator allowed"         0 pretool "{\"session_id\":\"$WO
 expect "worker to orchestrator with ref allowed" 0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"SendMessage\",\"tool_input\":{\"to\":\"Main [1a2b3c]\",\"message\":\"blocked\"}}"
 expect "worker to a peer refused"               2 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"SendMessage\",\"tool_input\":{\"to\":\"xteink-ff\",\"message\":\"who owns 1.12.5\"}}"
 expect "worker to a peer via the app refused"   2 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"mcp__ccd_session_mgmt__send_message\",\"tool_input\":{\"session_id\":\"local_dddd-peer\",\"message\":\"hi\"}}"
+expect "worker to its own subagent allowed"        0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"SendMessage\",\"tool_input\":{\"to\":\"aaab5d61709dbe8a4\",\"message\":\"apply the review\"}}"
 expect "worker to the orchestrator's app id, unregistered, refused" 2 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"mcp__ccd_session_mgmt__send_message\",\"tool_input\":{\"session_id\":\"local_bbbb-app\",\"message\":\"hi\"}}"
 board orchestrator --name Main --session "$ORCH" --app-id local_bbbb-app >/dev/null
 expect "worker to the orchestrator's app id, registered, allowed" 0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"mcp__ccd_session_mgmt__send_message\",\"tool_input\":{\"session_id\":\"local_bbbb-app\",\"message\":\"hi\"}}"

--- a/host-tests/pulse/run.sh
+++ b/host-tests/pulse/run.sh
@@ -47,10 +47,10 @@ for _ in $(seq 50); do curl -s -o /dev/null "http://127.0.0.1:$PORT/ok" && break
 export SUPABASE_URL="http://127.0.0.1:$PORT" SUPABASE_ANON_KEY=test PULSE_TIMEOUT=1
 cat > "$WORK/hosts.txt" <<H
 # name method url alive
-site   GET  http://127.0.0.1:$PORT/ok     200
-inbox  POST http://127.0.0.1:$PORT/login  401
-books  GET  http://127.0.0.1:$PORT/auth   2xx,401
-bad    GET  http://127.0.0.1:$PORT/bad    200
+site   GET  http://127.0.0.1:$PORT/ok     200      site
+inbox  POST http://127.0.0.1:$PORT/login  401      site
+books  GET  http://127.0.0.1:$PORT/auth   2xx,401  getbooks
+bad    GET  http://127.0.0.1:$PORT/bad    200      getbooks
 gone   GET  http://127.0.0.1:$PORT/slow   200
 H
 : > "$WORK/events.log"
@@ -61,7 +61,7 @@ grep -q "ok   inbox 401" "$WORK/out" && ok "a POST answered 401 where 401 is exp
 grep -q "ok   books 401" "$WORK/out" && ok "a class list (2xx,401) accepts 401" || bad "books not up"
 grep -q "DOWN bad answered 500" "$WORK/out" && ok "a 500 is down, and says the status" || bad "bad not down"
 grep -q "DOWN gone no answer in 1s" "$WORK/out" && ok "a timeout is down, and says so" || bad "gone not down"
-python3 - "$WORK/events.log" <<'PY' && ok "posted three info and two error events with fixed fingerprints" || bad "the posted events are not what the board expects"
+python3 - "$WORK/events.log" <<'PY' && ok "posted three info and two error events with fixed fingerprints and the owning app" || bad "the posted events are not what the board expects"
 import json, sys
 ev = [json.loads(l) for l in open(sys.argv[1]) if l.strip()]
 info = [e for e in ev if e.get("level", "info") == "info"]
@@ -70,10 +70,14 @@ assert len(ev) == 5, ev
 assert all(e["service"] == "pulse" and e["event"] == "probe" for e in ev)
 assert sorted(e["props"]["host"] for e in info) == ["books", "inbox", "site"], info
 assert all(isinstance(e["props"]["ms"], int) and e["props"]["status"] for e in info)
+assert all(e.get("fingerprint") == "pulse|" + e["props"]["host"] for e in info), info  # an ok carries the fingerprint so the board can close the card
 assert sorted(e["fingerprint"] for e in err) == ["pulse|bad", "pulse|gone"], err
 msgs = {e["props"]["host"]: e["props"]["message"] for e in err}
 assert "answered 500" in msgs["bad"] and "/bad" in msgs["bad"], msgs
 assert "no answer in 1s" in msgs["gone"], msgs
+apps = {e["props"]["host"]: e["props"].get("app") for e in ev}
+assert apps["bad"] == "getbooks" and apps["site"] == "site", apps
+assert apps["gone"] == "tooling", apps  # no app column: tooling owns it
 PY
 
 # Without a board address it still probes, and posts nothing.

--- a/scripts_local/hooks/guard.py
+++ b/scripts_local/hooks/guard.py
@@ -270,6 +270,11 @@ def pretool(board, data):
         if not orch:
             return
         to = str(inp.get("to") or inp.get("session_id") or "")
+        # A session's own subagents (Agent tool) are addressed by a bare agent
+        # id, not a session name or a local_ id; they are this session, not a
+        # peer, and the review cycle runs through them.
+        if re.fullmatch(r"a[0-9a-f]{16}", to):
+            return
         name = str(orch.get("name") or "")
         target = to.split(" [")[0].strip().lower()
         allowed = {name.lower(), "main"} if name else {"main"}

--- a/server/board/supabase/migrations/20260903000800_card_app.sql
+++ b/server/board/supabase/migrations/20260903000800_card_app.sql
@@ -1,0 +1,62 @@
+-- Two additions to the 000200 trigger. An error event may name the app whose
+-- owner gets the card (props.app): the pulse posts as "pulse" but a dead
+-- books host is Get Books' problem. And an info event carrying a fingerprint
+-- closes that fingerprint's open error card: the outage was a card exactly
+-- as long as it lasted.
+create or replace function events_before_insert() returns trigger
+language plpgsql security definer set search_path = public as $$
+declare
+  fp text;
+  msg text;
+  open_card bigint;
+  new_card bigint;
+  app text;
+begin
+  -- An info event that carries a fingerprint says that problem is gone: the
+  -- open card for it closes by itself, with a line saying what answered.
+  if new.level <> 'error' then
+    if new.fingerprint is not null then
+      select card_id into open_card from error_fingerprints where fingerprint = new.fingerprint;
+      if open_card is not null and exists (
+        select 1 from cards where id = open_card and source = 'error' and state not in ('done', 'released', 'parked')
+      ) then
+        update cards set state = 'done', updated_at = now() where id = open_card;
+        insert into history (card_id, what)
+          values (open_card, 'recovered: ' || coalesce(new.props ->> 'host', new.service) || ' answers again');
+        new.card_id := open_card;
+      end if;
+    end if;
+    return new;
+  end if;
+  msg := coalesce(new.props ->> 'message', '');
+  fp := coalesce(new.fingerprint, event_fingerprint(new.service, new.event, msg));
+  new.fingerprint := fp;
+  app := coalesce(nullif(new.props ->> 'app', ''), new.service);
+
+  insert into error_fingerprints (fingerprint, service, message, count, last_seen)
+    values (fp, new.service, left(msg, 400), 1, now())
+    on conflict (fingerprint) do update
+      set count = error_fingerprints.count + 1, last_seen = now()
+    returning card_id into open_card;
+
+  if open_card is not null then
+    if exists (select 1 from cards where id = open_card and state not in ('done', 'released', 'parked')) then
+      new.card_id := open_card;
+      return new;
+    end if;
+  end if;
+
+  insert into cards (title, app, kind, body, state, source, fingerprint)
+    values (
+      left(new.service || ': ' || coalesce(nullif(msg, ''), new.event), 120),
+      app, 'bug',
+      'Seen by the ' || new.service || ' service. First message: ' || left(msg, 1000) ||
+        E'\nEvent: ' || new.event || E'\nProps: ' || left(new.props::text, 1500),
+      'triaged', 'error', fp)
+    returning id into new_card;
+  insert into history (card_id, what) values (new_card, 'opened from an error event (' || new.service || ')');
+  update error_fingerprints set card_id = new_card where fingerprint = fp;
+  new.card_id := new_card;
+  return new;
+end
+$$;

--- a/server/pulse/hosts.txt
+++ b/server/pulse/hosts.txt
@@ -1,14 +1,14 @@
-# What the pulse probes every 30 minutes: name, method, URL, and the HTTP
-# statuses that mean "alive", comma-separated (2xx, 3xx, 4xx stand for a
-# class). Anything else, a timeout, or a refused connection posts an error
+# What the pulse probes every 30 minutes: name, method, URL, the HTTP
+# statuses that mean "alive" (comma-separated; 2xx, 3xx, 4xx stand for a
+# class), and the app whose owner gets the card when it is down. Anything else, a timeout, or a refused connection posts an error
 # event to the board, which opens a card, so an outage becomes work within
 # half an hour with nobody watching.
 #
 # Owners add their host here the day it goes live, with the status the
 # service really answers on that path. A host listed before it exists opens a
 # card every half hour.
-site     GET   https://crossplay.ma-r-s.com/            200
-report   GET   https://crossplay.ma-r-s.com/report/     200
-inbox    POST  https://crossplay.ma-r-s.com/api/inbox   401
-books    GET   https://books.ma-r-s.com/                2xx,401
-anki     GET   https://sync.ma-r-s.com/                 2xx,3xx,4xx
+site     GET   https://crossplay.ma-r-s.com/            200            site
+report   GET   https://crossplay.ma-r-s.com/report/     200            site
+inbox    POST  https://crossplay.ma-r-s.com/api/inbox   401            site
+books    GET   https://books.ma-r-s.com/                2xx,401        getbooks
+anki     GET   https://sync.ma-r-s.com/                 2xx,3xx,4xx    anki

--- a/server/pulse/hosts.txt
+++ b/server/pulse/hosts.txt
@@ -12,3 +12,4 @@ report   GET   https://crossplay.ma-r-s.com/report/     200            site
 inbox    POST  https://crossplay.ma-r-s.com/api/inbox   401            site
 books    GET   https://books.ma-r-s.com/                2xx,401        getbooks
 anki     GET   https://sync.ma-r-s.com/                 2xx,3xx,4xx    anki
+read     GET   https://read.ma-r-s.com/                 2xx,3xx,4xx    instapaper

--- a/server/pulse/pulse.sh
+++ b/server/pulse/pulse.sh
@@ -7,7 +7,8 @@
 # posts to the board with the public key: an info event when a host answers
 # as expected, an error event otherwise. The error opens a card by the board's
 # own rule (docs/workflow/events.md), one per host thanks to a fixed
-# fingerprint, and a new one when an outage comes back after the card closed.
+# fingerprint; the next info event with the same fingerprint closes it, so an
+# outage is a card exactly as long as it lasts, and a new one if it returns.
 #
 #   server/pulse/pulse.sh [hosts.txt]
 #
@@ -46,8 +47,8 @@ alive() {  # alive <status> <expected>
   return 1
 }
 
-probe() {  # probe <name> <method> <url> <expected>
-  local name="$1" method="$2" url="$3" expect="$4" out st secs ms why
+probe() {  # probe <name> <method> <url> <expected> <app>
+  local name="$1" method="$2" url="$3" expect="$4" app="${5:-tooling}" out st secs ms why
   if [ "$method" = POST ]; then
     out=$(curl -s -o /dev/null -m "$TIMEOUT" -w '%{http_code} %{time_total}' -X POST \
       -H 'Content-Type: application/json' --data '{}' "$url" 2>/dev/null) || out="000 $TIMEOUT"
@@ -58,12 +59,12 @@ probe() {  # probe <name> <method> <url> <expected>
   ms=$(python3 -c "print(int(float('$secs') * 1000))" 2>/dev/null || echo 0)
   if alive "$st" "$expect"; then
     echo "  ok   $name $st ${ms}ms"
-    post "{\"service\":\"pulse\",\"event\":\"probe\",\"props\":{\"host\":$(jstr "$name"),\"status\":\"$st\",\"ms\":$ms}}"
+    post "{\"service\":\"pulse\",\"event\":\"probe\",\"fingerprint\":\"pulse|$name\",\"props\":{\"host\":$(jstr "$name"),\"app\":$(jstr "$app"),\"status\":\"$st\",\"ms\":$ms}}"
   else
     why="answered $st"; [ "$st" = 000 ] && why="no answer in ${TIMEOUT}s"
     echo "  DOWN $name $why"
     down=$((down + 1))
-    post "{\"service\":\"pulse\",\"event\":\"probe\",\"level\":\"error\",\"fingerprint\":\"pulse|$name\",\"props\":{\"message\":$(jstr "$name is down: $why from $url"),\"host\":$(jstr "$name"),\"url\":$(jstr "$url"),\"status\":\"$st\",\"ms\":$ms}}"
+    post "{\"service\":\"pulse\",\"event\":\"probe\",\"level\":\"error\",\"fingerprint\":\"pulse|$name\",\"props\":{\"message\":$(jstr "$name is down: $why from $url"),\"host\":$(jstr "$name"),\"app\":$(jstr "$app"),\"url\":$(jstr "$url"),\"status\":\"$st\",\"ms\":$ms}}"
   fi
 }
 
@@ -89,7 +90,7 @@ upstream() {
   n=$(git -C "$repo" rev-list --count "$base..FETCH_HEAD")
   if [ "$n" = 0 ]; then
     echo "  ok   upstream in sync"
-    post '{"service":"pulse","event":"probe","props":{"host":"upstream-sync","behind":0}}'
+    post '{"service":"pulse","event":"probe","fingerprint":"pulse|upstream-sync","props":{"host":"upstream-sync","app":"tooling","behind":0}}'
     return
   fi
   oldest=$(git -C "$repo" log --format=%ct "$base..FETCH_HEAD" | sort -n | head -1)
@@ -102,17 +103,17 @@ upstream() {
   else
     echo "  DOWN upstream sync late: $n commits behind, oldest ${oldest_h}h, no sync pull request"
     down=$((down + 1))
-    post "{\"service\":\"pulse\",\"event\":\"probe\",\"level\":\"error\",\"fingerprint\":\"pulse|upstream-sync\",\"props\":{\"message\":$(jstr "upstream sync late: $n commits not merged, oldest ${oldest_h}h, no sync pull request open"),\"host\":\"upstream-sync\",\"behind\":$n,\"oldest_h\":$oldest_h}}"
+    post "{\"service\":\"pulse\",\"event\":\"probe\",\"level\":\"error\",\"fingerprint\":\"pulse|upstream-sync\",\"props\":{\"message\":$(jstr "upstream sync late: $n commits not merged, oldest ${oldest_h}h, no sync pull request open"),\"host\":\"upstream-sync\",\"app\":\"tooling\",\"behind\":$n,\"oldest_h\":$oldest_h}}"
     return
   fi
-  post "{\"service\":\"pulse\",\"event\":\"probe\",\"props\":{\"host\":\"upstream-sync\",\"behind\":$n,\"oldest_h\":$oldest_h,\"open_prs\":$open}}"
+  post "{\"service\":\"pulse\",\"event\":\"probe\",\"fingerprint\":\"pulse|upstream-sync\",\"props\":{\"host\":\"upstream-sync\",\"app\":\"tooling\",\"behind\":$n,\"oldest_h\":$oldest_h,\"open_prs\":$open}}"
 }
 
 [ -f "$HOSTS" ] || { echo "pulse: no hosts file at $HOSTS"; exit 1; }
-while read -r name method url expect _; do
+while read -r name method url expect app _; do
   case "$name" in "" | \#*) continue ;; esac
   [ -n "$expect" ] || { echo "  ?    $name: no expected status on its line, skipped"; continue; }
-  probe "$name" "$method" "$url" "$expect"
+  probe "$name" "$method" "$url" "$expect" "$app"
 done < "$HOSTS"
 [ "${PULSE_UPSTREAM:-0}" = 1 ] && upstream
 echo "pulse: $down down"


### PR DESCRIPTION
Two small pipeline fixes found by using it tonight.

- **Guard**: SendMessage to a bare Agent-tool id (`a` + 16 hex) is this session's own subagent, not a peer; it was refused, so a review could reach the builder only by spawning a second builder. Card #113.
- **Pulse cards**: the first real run opened three cards on app `pulse`, which nobody owns. `hosts.txt` names the owning app per host; the trigger uses `props.app` for the card. An `info` event carrying a fingerprint now closes that fingerprint's open error card ("recovered"), and every ok probe carries its host's fingerprint, so an outage is a card exactly as long as it lasts.

Verified: bugflow 81, pulse 13; the trigger is applied live and proven in a rolled-back transaction. Not verified: a real recovery (the pi is off with the power right now; when it returns, cards #114 and #115 should close by themselves within 30 minutes, which is the field proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)