### PR TITLE
feat: the Anki and Instapaper bridges post sync and error events (cards 20, 21)

### DIFF
--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -422,7 +422,7 @@ fi
 # which is exactly when nobody is looking.
 for entry in \
   "server/study-bridge:bridge:12:tests/test_engine.py tests/test_api.py tests/test_window.py tests/test_events.py" \
-  "server/read-bridge:readbridge:8:tests/test_oauth.py tests/test_article.py tests/test_window.py tests/test_lockout.py tests/test_engine.py tests/test_api.py"
+  "server/read-bridge:readbridge:8:tests/test_oauth.py tests/test_article.py tests/test_window.py tests/test_lockout.py tests/test_engine.py tests/test_api.py tests/test_events.py"
 do
   BRIDGE_DIR="$REPO/${entry%%:*}"
   rest="${entry#*:}"

--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -421,7 +421,7 @@ fi
 # takes 12. Sharing an offset would only bite when two trees gate at once,
 # which is exactly when nobody is looking.
 for entry in \
-  "server/study-bridge:bridge:12:tests/test_engine.py tests/test_api.py tests/test_window.py" \
+  "server/study-bridge:bridge:12:tests/test_engine.py tests/test_api.py tests/test_window.py tests/test_events.py" \
   "server/read-bridge:readbridge:8:tests/test_oauth.py tests/test_article.py tests/test_window.py tests/test_lockout.py tests/test_engine.py tests/test_api.py"
 do
   BRIDGE_DIR="$REPO/${entry%%:*}"

--- a/server/read-bridge/README.md
+++ b/server/read-bridge/README.md
@@ -46,6 +46,7 @@ uv venv .venv && uv pip install --python .venv/bin/python -r requirements.txt
 .venv/bin/python tests/test_article.py   # HTML -> flat text, rule by rule
 .venv/bin/python tests/test_engine.py    # the three silent-failure rules
 .venv/bin/python tests/test_api.py       # the whole surface, end to end
+.venv/bin/python tests/test_events.py    # the board poster, HTTP stubbed
 ```
 
 `tests/fake_instapaper.py` stands in for the real API and **verifies OAuth
@@ -99,12 +100,40 @@ ssh orange 'cd /srv/readbridge && docker compose logs -f'       # sync activity
 ssh orange 'cd /srv/readbridge && docker compose stop cloudflared'  # kill switch
 ```
 
+## Events
+
+Every finished sync posts one event to the board (`docs/workflow/events.md`):
+`instapaper`/`sync` with `{articles, seconds}` under a salted hash of the
+account id, or the same event at level `error` with `{message}` when the job
+was refused or died. `bridge/events.py` sends from its own thread with a 3 s
+timeout and drops the event after one log line if the board does not take
+it, so a board outage cannot slow or fail a sync (`tests/test_api.py` proves
+both). The module is a byte-identical twin of `study-bridge/bridge/events.py`;
+`tests/test_events.py` fails if the two drift.
+
+Where to post comes from two more `.env` keys, both optional:
+
+```sh
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_ANON_KEY=<the public anon key, the one that can only insert>
+```
+
+They are the URL and ANON key from `<workspace>/.board/supabase.env` (never
+the service role key). With either missing the service runs exactly as
+before and logs `events are off` once at startup. To turn them on: append
+the two lines to `/srv/readbridge/.env` on the pi, ship this code with
+`./scripts/deploy.sh` (once it is running there, a bare `ssh orange 'cd
+/srv/readbridge && docker compose up -d'` is enough, because an `.env`
+change is a recreate and not a rebuild), then check for `events on` in
+`docker compose logs readbridge`.
+
 ## Secrets
 
 `.env` lives on the pi only, at `/srv/readbridge/.env`, mode 600, never in
 git, never rsync'd in either direction (`deploy.sh` excludes it). Keys:
 `READ_FERNET_KEY`, `READ_ALLOWLIST`, `READ_CONSUMER_KEY`,
-`READ_CONSUMER_SECRET`, `CLOUDFLARE_TUNNEL_TOKEN`.
+`READ_CONSUMER_SECRET`, `CLOUDFLARE_TUNNEL_TOKEN`, and the optional
+`SUPABASE_URL` / `SUPABASE_ANON_KEY` pair above.
 
 Generate the Fernet key **on the pi** so it never lands in a transcript:
 

--- a/server/read-bridge/bridge/app.py
+++ b/server/read-bridge/bridge/app.py
@@ -23,7 +23,7 @@ import time
 from fastapi import Depends, FastAPI, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 
-from . import accounts, engine, jobs, pairing, store
+from . import accounts, engine, events, jobs, pairing, store
 from .ratelimit import Lockout, Window
 
 log = logging.getLogger("bridge.app")
@@ -394,7 +394,16 @@ async def start_sync(request: Request, dev=Depends(require_device)):
         st.save_state(fresh)
         return summary
 
-    job = jobs.JOBS.start(uid, work)
+    job = jobs.JOBS.start(
+        uid,
+        work,
+        service="instapaper",
+        # The account id (itself a hash of the address), salted once more: the
+        # board counts accounts and can name none of them.
+        device=events.device_id(uid),
+        # articles: what came down this sync, new or changed.
+        props=lambda s: {"articles": len(s["articles"])},
+    )
     jobs.JOBS.gc()
     return {"job": job.id}
 
@@ -436,6 +445,9 @@ async def article_file(bookmark_id: int, bookmark_hash: str, dev=Depends(require
 @app.on_event("startup")
 async def startup():
     logging.basicConfig(level=logging.INFO)
+    # Says "events are off" once when the two variables are not both set.
+    if events.enabled():
+        log.info("events on: syncs and failures post to the board")
     try:
         import bridge.instapaper as ip
 

--- a/server/read-bridge/bridge/events.py
+++ b/server/read-bridge/bridge/events.py
@@ -1,0 +1,119 @@
+"""Post one event to the board, and never get in the way of a sync.
+
+The contract is docs/workflow/events.md: one POST to
+<SUPABASE_URL>/rest/v1/events with the public key. Where to post arrives as
+SUPABASE_URL and SUPABASE_ANON_KEY in the environment (the pi's .env, passed
+through by compose.yaml). With either missing every post is a no-op and the
+service says so once in its log, at startup or at the first post, whichever
+comes first.
+
+Three rules, because the board is where numbers go and never something a
+sync waits on:
+
+- post() never raises. A prop that is not JSON, a dead network, a 4xx from
+  the board: one log line, the event is dropped, the caller never knows.
+- post() never blocks the caller. The request runs on its own daemon thread
+  with a short timeout, so the worst case costs the process one idle thread
+  for TIMEOUT_S and the sync nothing at all.
+- The device field is a hash, never an identifier. device_id() folds the
+  caller's id (a token hash, an account id) through sha256 with a fixed salt,
+  so the board can count devices and nothing on it names one.
+
+Byte-identical twin of the other bridge's bridge/events.py (study-bridge and
+read-bridge). Neither Dockerfile can COPY a file from outside its own
+directory without a build change, so the module is duplicated rather than
+shared; each service's tests/test_events.py checks the twin still matches.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+log = logging.getLogger("bridge.events")
+
+TIMEOUT_S = 3.0
+
+# Fixed and public on purpose. The salt is not a secret: it only keeps a
+# device hash from being the plain sha256 of its input, so a value that leaks
+# from elsewhere (a token hash in a state file, an account id in a log) cannot
+# be matched to a row on the board by hashing it once more.
+SALT = "crossplay-events"
+
+# The whole HTTP layer, as one name the tests replace.
+_urlopen = urllib.request.urlopen
+_off_logged = False
+
+
+def device_id(raw: str) -> str:
+    """The stable, non-reversible id the board counts a device or account by."""
+    return hashlib.sha256(f"{SALT}:{raw}".encode()).hexdigest()
+
+
+def enabled() -> bool:
+    """True when both variables are set. Logs once, the first time they are not."""
+    global _off_logged
+    url = os.environ.get("SUPABASE_URL", "").strip()
+    key = os.environ.get("SUPABASE_ANON_KEY", "").strip()
+    if url and key:
+        return True
+    if not _off_logged:
+        _off_logged = True
+        log.info("events are off: SUPABASE_URL and SUPABASE_ANON_KEY are not both set")
+    return False
+
+
+def post(
+    service: str,
+    event: str,
+    *,
+    device: str = "",
+    level: str = "info",
+    props: dict | None = None,
+) -> threading.Thread | None:
+    """Queue one event for the board. Never raises, never blocks.
+
+    Returns the thread carrying the request, or None when nothing was sent;
+    only the tests have a reason to join it."""
+    try:
+        if not enabled():
+            return None
+        record = {"service": service, "event": event, "level": level}
+        if device:
+            record["device"] = device
+        record["props"] = props or {}
+        body = json.dumps(record).encode()
+        url = os.environ["SUPABASE_URL"].strip().rstrip("/") + "/rest/v1/events"
+        key = os.environ["SUPABASE_ANON_KEY"].strip()
+        t = threading.Thread(
+            target=_deliver, args=(url, key, body), name="events-post", daemon=True
+        )
+        t.start()
+        return t
+    except Exception as e:  # a prop that is not JSON, a thread that cannot start
+        log.warning("event %s/%s dropped before sending: %s", service, event, e)
+        return None
+
+
+def _deliver(url: str, key: str, body: bytes) -> None:
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "apikey": key,
+            "Authorization": "Bearer " + key,
+            "Content-Type": "application/json",
+            "Prefer": "return=minimal",
+        },
+    )
+    try:
+        resp = _urlopen(req, timeout=TIMEOUT_S)
+        try:
+            resp.read()
+        finally:
+            resp.close()
+    except Exception as e:
+        log.warning("event dropped, the board did not take it: %s", e)

--- a/server/read-bridge/bridge/jobs.py
+++ b/server/read-bridge/bridge/jobs.py
@@ -13,9 +13,35 @@ import logging
 import secrets
 import time
 
-from . import store
+from . import events, store
 
 log = logging.getLogger("bridge.jobs")
+
+# The job clock, as a name the tests replace to pin the seconds an event
+# reports. time.monotonic itself stays alone: asyncio's loop reads it too.
+_clock = time.monotonic
+
+
+def _report(service, device, failure, summary, props, elapsed):
+    """One event per finished job: what it moved, or what it died of. Never
+    raises -- the job is already done or failed on its own terms, and the
+    board is not allowed to change that."""
+    try:
+        if failure is None:
+            p = dict(props(summary) if props else {})
+            p["seconds"] = round(elapsed, 1)
+            events.post(service, "sync", device=device, props=p)
+        else:
+            message = f"{type(failure).__name__}: {failure}"[:200]
+            events.post(
+                service,
+                "sync",
+                device=device,
+                level="error",
+                props={"message": message},
+            )
+    except Exception:
+        log.exception("event for a %s job not posted", service)
 
 
 class Refused(Exception):
@@ -49,7 +75,16 @@ class Jobs:
             return job
         return None
 
-    def start(self, uid: str, work) -> Job:
+    def start(
+        self, uid: str, work, *, service: str = "", device: str = "", props=None
+    ) -> Job:
+        """work: a blocking callable run in a thread under the user lock.
+        Returns the existing job instead when one is already in flight.
+
+        service names the board's row for this job (events.py): when set,
+        the job's end posts one event -- `sync` with props(summary) plus the
+        seconds it took, or `sync` at level error with what it died of.
+        device is the hashed id the event is counted under."""
         existing = self.active_for(uid)
         if existing:
             return existing
@@ -60,6 +95,8 @@ class Jobs:
         async def run():
             async with store.LOCKS.for_user(uid):
                 job.status = "running"
+                started = _clock()
+                failure = None
                 try:
                     job.summary = await asyncio.to_thread(work)
                     job.status = "done"
@@ -67,13 +104,19 @@ class Jobs:
                     job.status = "error"
                     job.message = str(e)
                     log.info("job %s refused: %s", job.id, e)
-                except Exception:
+                    failure = e
+                except Exception as e:
                     job.status = "error"
                     job.message = (
                         "Syncing hit a problem on the bridge. Nothing on your"
                         " reader was lost; try again in a while."
                     )
                     log.exception("job %s failed", job.id)
+                    failure = e
+                if service:
+                    _report(
+                        service, device, failure, job.summary, props, _clock() - started
+                    )
 
         asyncio.get_running_loop().create_task(run())
         return job

--- a/server/read-bridge/compose.yaml
+++ b/server/read-bridge/compose.yaml
@@ -41,6 +41,11 @@ services:
       READ_ALLOWLIST: ${READ_ALLOWLIST}
       READ_CONSUMER_KEY: ${READ_CONSUMER_KEY}
       READ_CONSUMER_SECRET: ${READ_CONSUMER_SECRET}
+      # Where sync and error events go (docs/workflow/events.md). Both
+      # optional: with either unset the service posts nothing and logs so
+      # once at startup. The anon key can only insert.
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-}
     volumes:
       - ./data:/data
     user: "10003:10003"

--- a/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
+++ b/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
@@ -58,6 +58,13 @@ so it is never copied up and never overwritten.
     ENV
     ssh orange 'chmod 600 /srv/readbridge/.env && ls -l /srv/readbridge/.env'
 
+Optional, for the board's numbers (`docs/workflow/events.md`; the values are
+the URL and ANON key in `<workspace>/.board/supabase.env`, never the service
+role key). Without both, the service posts nothing and logs so once:
+
+    SUPABASE_URL=https://<project>.supabase.co
+    SUPABASE_ANON_KEY=<the public anon key>
+
 `READ_FERNET_KEY` is generated ON the pi and never leaves it:
 
     ssh orange "docker run --rm python:3.13-slim sh -c \

--- a/server/read-bridge/tests/test_api.py
+++ b/server/read-bridge/tests/test_api.py
@@ -269,6 +269,160 @@ async def run(tmp, state_file):
         r = await client.get("/api/sync/status?job=nope", headers=headers)
         ok(r.status_code == 200 and "restarted" in r.json()["message"], "a forgotten job is explained")
 
+        # --- events: what a finished sync tells the board, and what a board
+        # that is down costs it (nothing). The HTTP layer is stubbed at the one
+        # name events.py sends through, so these assert the exact body.
+        import urllib.error
+        import urllib.request
+
+        import bridge.app as app_mod
+        from bridge import engine as engine_mod
+        from bridge import events
+        from bridge import jobs as jobs_mod
+        from bridge import store as store_mod
+        from bridge.ratelimit import Window
+
+        os.environ["SUPABASE_URL"] = "https://board.test"
+        os.environ["SUPABASE_ANON_KEY"] = "anon-test-key"
+        posted = []
+
+        class Taken:
+            def read(self):
+                return b""
+
+            def close(self):
+                pass
+
+        def take(req, timeout):
+            posted.append(req)
+            return Taken()
+
+        def refuse(req, timeout):
+            posted.append(req)
+            raise urllib.error.URLError("connection refused")
+
+        async def settle(n):
+            # The post rides its own thread; give it a moment to land.
+            for _ in range(50):
+                if len(posted) >= n:
+                    return
+                await asyncio.sleep(0.1)
+
+        events._urlopen = take
+        # Each job reads the clock twice; pinned so `seconds` is asserted
+        # exactly rather than as "some number".
+        ticks = iter([100.0, 102.5, 200.0, 200.4, 300.0, 300.1, 400.0, 400.2])
+        jobs_mod._clock = lambda: next(ticks, time.monotonic())
+        # The syncs above spent this user's window; this block gets a fresh
+        # one with the same limits.
+        app_mod.SYNC_USER = Window(6, 300)
+        expected_device = events.device_id(store_mod.uid_for(USER))
+
+        r = await client.post(
+            "/api/sync", json={"have": [], "archive": []}, headers=headers
+        )
+        result = await poll_job(client, headers, r.json()["job"])
+        ok(
+            result["status"] == "done",
+            f"the events sync finishes ({result.get('message', '')})",
+        )
+        came_down = len(result["summary"]["articles"])
+        ok(came_down > 0, "and delivered something, so the count below is not a zero")
+        await settle(1)
+        ok(len(posted) == 1, f"a finished sync posts one event, got {len(posted)}")
+        wire_body = json.loads(posted[0].data)
+        ok(
+            wire_body
+            == {
+                "service": "instapaper",
+                "event": "sync",
+                "level": "info",
+                "device": expected_device,
+                "props": {"articles": came_down, "seconds": 2.5},
+            },
+            f"a sync posts the contract's body, got {wire_body}",
+        )
+        ok(
+            posted[0].full_url == "https://board.test/rest/v1/events",
+            "to the events table",
+        )
+        ok(posted[0].get_header("Apikey") == "anon-test-key", "with the public key")
+        ok(
+            USER not in posted[0].data.decode()
+            and store_mod.uid_for(USER) not in posted[0].data.decode(),
+            "neither the address nor the account id is in the event",
+        )
+
+        # A board that refuses the event cannot fail the sync.
+        events._urlopen = refuse
+        r = await client.post(
+            "/api/sync", json={"have": [], "archive": []}, headers=headers
+        )
+        result = await poll_job(client, headers, r.json()["job"])
+        ok(
+            result["status"] == "done" and "articles" in result["summary"],
+            f"a board that is down does not fail the sync, got {result['status']}",
+        )
+        await settle(2)
+        ok(len(posted) == 2, "and the event was attempted, not skipped")
+
+        # A sync that dies posts what it died of: an Instapaper refusal ...
+        events._urlopen = take
+        real_cycle = engine_mod.sync_cycle
+
+        def refused(*a, **kw):
+            raise jobs_mod.Refused("Instapaper refused: 1041 for bookmark 77")
+
+        engine_mod.sync_cycle = refused
+        try:
+            r = await client.post(
+                "/api/sync", json={"have": [], "archive": []}, headers=headers
+            )
+            result = await poll_job(client, headers, r.json()["job"])
+        finally:
+            engine_mod.sync_cycle = real_cycle
+        ok(result["status"] == "error", f"the refused sync fails, got {result}")
+        await settle(3)
+        wire_body = json.loads(posted[2].data)
+        ok(
+            wire_body
+            == {
+                "service": "instapaper",
+                "event": "sync",
+                "level": "error",
+                "device": expected_device,
+                "props": {
+                    "message": "Refused: Instapaper refused: 1041 for bookmark 77"
+                },
+            },
+            f"a refusal posts its sentence at level error, got {wire_body}",
+        )
+
+        # ... and a bridge fault.
+        def dead(*a, **kw):
+            raise RuntimeError("disk full")
+
+        engine_mod.sync_cycle = dead
+        try:
+            r = await client.post(
+                "/api/sync", json={"have": [], "archive": []}, headers=headers
+            )
+            result = await poll_job(client, headers, r.json()["job"])
+        finally:
+            engine_mod.sync_cycle = real_cycle
+        ok(result["status"] == "error", f"the broken sync fails, got {result}")
+        await settle(4)
+        wire_body = json.loads(posted[3].data)
+        ok(
+            wire_body["level"] == "error"
+            and wire_body["props"] == {"message": "RuntimeError: disk full"},
+            f"a bridge fault posts its cause at level error, got {wire_body}",
+        )
+
+        events._urlopen = urllib.request.urlopen
+        jobs_mod._clock = time.monotonic
+        del os.environ["SUPABASE_URL"], os.environ["SUPABASE_ANON_KEY"]
+
         # --- revocation
         page = await client.get("/devices")
         token_hash = page.text.split("name=token_hash value='")[1].split("'")[0]

--- a/server/read-bridge/tests/test_events.py
+++ b/server/read-bridge/tests/test_events.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""The event poster's promises, with the HTTP layer stubbed.
+
+  * off means off: without both variables nothing is sent and the log says
+    so exactly once;
+  * a post is the body docs/workflow/events.md describes, with the key in
+    both headers, and it returns before the request does;
+  * a board that is down, or a prop that cannot be JSON, costs one log line
+    and nothing else.
+
+And one that is about the repo rather than the module: bridge/events.py is
+duplicated into both bridges because neither image can COPY a file from
+outside its own directory. The two copies must stay byte-identical, or a fix
+lands on one and not its twin.
+
+Run: .venv/bin/python tests/test_events.py
+"""
+
+import hashlib
+import json
+import logging
+import os
+import pathlib
+import sys
+import threading
+import time
+import urllib.error
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from bridge import events  # noqa: E402
+
+checks = 0
+failures = 0
+
+
+def ok(cond, label):
+    global checks, failures
+    checks += 1
+    if not cond:
+        failures += 1
+        print(f"  FAIL: {label}")
+
+
+class Capture(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class FakeResponse:
+    def read(self):
+        return b""
+
+    def close(self):
+        pass
+
+
+def main():
+    log = logging.getLogger("bridge.events")
+    cap = Capture()
+    log.addHandler(cap)
+    log.setLevel(logging.INFO)
+    sent = []
+
+    def record(req, timeout):
+        sent.append((req, timeout))
+        return FakeResponse()
+
+    def off_lines():
+        return sum("events are off" in r.getMessage() for r in cap.records)
+
+    # --- off means off
+    os.environ.pop("SUPABASE_URL", None)
+    os.environ.pop("SUPABASE_ANON_KEY", None)
+    events._off_logged = False
+    events._urlopen = record
+    ok(
+        events.post("anki", "sync", props={"cards": 1}) is None,
+        "nothing is queued without the variables",
+    )
+    events.post("anki", "sync", props={"cards": 2})
+    ok(sent == [], "and nothing reaches the HTTP layer")
+    ok(
+        off_lines() == 1,
+        f"the log says events are off exactly once, said it {off_lines()} times",
+    )
+    os.environ["SUPABASE_URL"] = "https://x.supabase.co/"
+    ok(events.post("anki", "sync") is None and sent == [], "one variable is not enough")
+    ok(off_lines() == 1, "and a later post does not repeat the line")
+
+    # --- the body
+    os.environ["SUPABASE_ANON_KEY"] = "anon-test-key"
+    cap.records.clear()
+    dev = events.device_id("tok")
+    t = events.post("anki", "sync", device=dev, props={"cards": 3, "seconds": 1.5})
+    ok(t is not None, "with both variables a post is queued")
+    t.join(5)
+    ok(len(sent) == 1, f"one request, got {len(sent)}")
+    req, timeout = sent[0]
+    ok(
+        req.full_url == "https://x.supabase.co/rest/v1/events",
+        f"the trailing slash is folded, got {req.full_url}",
+    )
+    ok(req.get_method() == "POST", "it is a POST")
+    ok(timeout == events.TIMEOUT_S, f"the request carries the timeout, got {timeout}")
+    ok(
+        req.get_header("Apikey") == "anon-test-key"
+        and req.get_header("Authorization") == "Bearer anon-test-key",
+        "the key rides in both headers",
+    )
+    ok(
+        req.get_header("Content-type") == "application/json"
+        and req.get_header("Prefer") == "return=minimal",
+        "JSON in, nothing back",
+    )
+    body = json.loads(req.data)
+    ok(
+        body
+        == {
+            "service": "anki",
+            "event": "sync",
+            "level": "info",
+            "device": dev,
+            "props": {"cards": 3, "seconds": 1.5},
+        },
+        f"the body is the contract's, got {body}",
+    )
+    ok(cap.records == [], "a delivered event logs nothing")
+
+    # --- device_id
+    ok(dev != hashlib.sha256(b"tok").hexdigest(), "the device hash is salted")
+    ok(len(dev) == 64 and dev == events.device_id("tok"), "and stable")
+    ok("tok" not in req.data.decode(), "the raw id is not in the body")
+    t = events.post("anki", "heartbeat")
+    t.join(5)
+    ok(
+        "device" not in json.loads(sent[-1][0].data),
+        "no device means no device field, not an empty one",
+    )
+
+    # --- it returns before the request does
+    gate = threading.Event()
+
+    def slow(req, timeout):
+        gate.wait(5)
+        return FakeResponse()
+
+    events._urlopen = slow
+    t0 = time.monotonic()
+    t = events.post("anki", "sync")
+    elapsed = time.monotonic() - t0
+    gate.set()
+    t.join(5)
+    ok(
+        elapsed < 0.5,
+        f"post returned in {elapsed:.3f}s while the request was still open",
+    )
+
+    # --- a board that is down
+    cap.records.clear()
+
+    def down(req, timeout):
+        raise urllib.error.URLError("connection refused")
+
+    events._urlopen = down
+    t = events.post("anki", "sync", level="error", props={"message": "x"})
+    t.join(5)
+    ok(not t.is_alive(), "the request thread finishes")
+    ok(
+        len(cap.records) == 1 and cap.records[0].levelno == logging.WARNING,
+        f"one warning line, got {[r.getMessage() for r in cap.records]}",
+    )
+    ok("dropped" in cap.records[0].getMessage(), "and it says the event was dropped")
+
+    # --- a prop that cannot be JSON
+    cap.records.clear()
+    events._urlopen = record
+    before = len(sent)
+    ok(
+        events.post("anki", "sync", props={"bad": object()}) is None,
+        "an unserialisable prop is dropped, not raised",
+    )
+    ok(len(sent) == before and len(cap.records) == 1, "one warning, no request")
+
+    # --- the twin
+    other = [s for s in ("study-bridge", "read-bridge") if s != ROOT.name]
+    twin = ROOT.parent / other[0] / "bridge" / "events.py"
+    mine = ROOT / "bridge" / "events.py"
+    if twin.exists():
+        ok(
+            mine.read_bytes() == twin.read_bytes(),
+            f"bridge/events.py is byte-identical to its twin in {other[0]}",
+        )
+    else:
+        print(f"  (no twin at {twin}; the byte-identity check needs the whole repo)")
+
+    print(f"{checks} checks, {failures} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/study-bridge/README.md
+++ b/server/study-bridge/README.md
@@ -53,10 +53,38 @@ Backup: nightly snapshot of the authoritative state only (the credential store
 and per-user sync state under `/srv/ankibridge/data`, not the rebuildable
 converted output) to `/mnt/hdd/backups/ankibridge`. **TODO: wiring not done.**
 
+## Events
+
+Every finished sync posts one event to the board (`docs/workflow/events.md`):
+`anki`/`sync` with `{cards, reviews, seconds}` under a salted hash of the
+device's token hash, or the same event at level `error` with `{message}` when
+the job died or froze. `bridge/events.py` sends from its own thread with a
+3 s timeout and drops the event after one log line if the board does not take
+it, so a board outage cannot slow or fail a sync (`tests/test_api.py` proves
+both). The module is a byte-identical twin of `read-bridge/bridge/events.py`;
+`tests/test_events.py` fails if the two drift.
+
+Where to post comes from two more `.env` keys, both optional:
+
+```sh
+SUPABASE_URL=https://<project>.supabase.co
+SUPABASE_ANON_KEY=<the public anon key, the one that can only insert>
+```
+
+They are the URL and ANON key from `<workspace>/.board/supabase.env` (never
+the service role key). With either missing the service runs exactly as
+before and logs `events are off` once at startup. To turn them on: append
+the two lines to `/srv/ankibridge/.env` on the pi, ship this code with
+`./scripts/deploy.sh` (once it is running there, a bare `ssh orange 'cd
+/srv/ankibridge && docker compose up -d'` is enough, because an `.env`
+change is a recreate and not a rebuild), then check for `events on` in
+`docker compose logs ankibridge`.
+
 ## Secrets
 
 `.env` lives on the pi only, at `/srv/ankibridge/.env`, mode 600, never in
-git. Keys: `BRIDGE_FERNET_KEY`, `CLOUDFLARE_TUNNEL_TOKEN`, `BRIDGE_ALLOWLIST`.
+git. Keys: `BRIDGE_FERNET_KEY`, `CLOUDFLARE_TUNNEL_TOKEN`, `BRIDGE_ALLOWLIST`,
+and the optional `SUPABASE_URL` / `SUPABASE_ANON_KEY` pair above.
 It is never rsync'd in either direction (`deploy.sh` excludes it, and that
 exclude is load-bearing) and never pasted into commands, where it would land
 in shell history and `ps` output. Edit it in place on the pi.

--- a/server/study-bridge/bridge/app.py
+++ b/server/study-bridge/bridge/app.py
@@ -27,7 +27,7 @@ import time
 from fastapi import Depends, FastAPI, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 
-from . import accounts, decks, engine, jobs, pairing, store, wire
+from . import accounts, decks, engine, events, jobs, pairing, store, wire
 from .ratelimit import Window
 from .journal import Journal
 
@@ -488,7 +488,17 @@ async def start_sync(request: Request, dev=Depends(require_device)):
         summary["failedDecks"] = failed
         return summary
 
-    job = jobs.JOBS.start(uid, work)
+    job = jobs.JOBS.start(
+        uid,
+        work,
+        service="anki",
+        # The token hash, salted once more: the board counts readers and can
+        # name none of them, and the raw token never reaches this line at all.
+        device=events.device_id(th),
+        # cards: what the reader posted, its whole hand across the chosen
+        # decks; reviews: what this sync carried up into the collection.
+        props=lambda s: {"cards": len(device_cards), "reviews": s["applied"]},
+    )
     return {"job": job.id, "ackOffsets": acks}
 
 
@@ -542,4 +552,7 @@ async def startup():
     logging.basicConfig(level=logging.INFO)
     if decks.TOOLS is None:
         log.error("tools_local/study not found; deck builds will fail loudly")
+    # Says "events are off" once when the two variables are not both set.
+    if events.enabled():
+        log.info("events on: syncs and failures post to the board")
     log.info("bridge up; tools at %s", decks.TOOLS)

--- a/server/study-bridge/bridge/events.py
+++ b/server/study-bridge/bridge/events.py
@@ -1,0 +1,119 @@
+"""Post one event to the board, and never get in the way of a sync.
+
+The contract is docs/workflow/events.md: one POST to
+<SUPABASE_URL>/rest/v1/events with the public key. Where to post arrives as
+SUPABASE_URL and SUPABASE_ANON_KEY in the environment (the pi's .env, passed
+through by compose.yaml). With either missing every post is a no-op and the
+service says so once in its log, at startup or at the first post, whichever
+comes first.
+
+Three rules, because the board is where numbers go and never something a
+sync waits on:
+
+- post() never raises. A prop that is not JSON, a dead network, a 4xx from
+  the board: one log line, the event is dropped, the caller never knows.
+- post() never blocks the caller. The request runs on its own daemon thread
+  with a short timeout, so the worst case costs the process one idle thread
+  for TIMEOUT_S and the sync nothing at all.
+- The device field is a hash, never an identifier. device_id() folds the
+  caller's id (a token hash, an account id) through sha256 with a fixed salt,
+  so the board can count devices and nothing on it names one.
+
+Byte-identical twin of the other bridge's bridge/events.py (study-bridge and
+read-bridge). Neither Dockerfile can COPY a file from outside its own
+directory without a build change, so the module is duplicated rather than
+shared; each service's tests/test_events.py checks the twin still matches.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import threading
+import urllib.request
+
+log = logging.getLogger("bridge.events")
+
+TIMEOUT_S = 3.0
+
+# Fixed and public on purpose. The salt is not a secret: it only keeps a
+# device hash from being the plain sha256 of its input, so a value that leaks
+# from elsewhere (a token hash in a state file, an account id in a log) cannot
+# be matched to a row on the board by hashing it once more.
+SALT = "crossplay-events"
+
+# The whole HTTP layer, as one name the tests replace.
+_urlopen = urllib.request.urlopen
+_off_logged = False
+
+
+def device_id(raw: str) -> str:
+    """The stable, non-reversible id the board counts a device or account by."""
+    return hashlib.sha256(f"{SALT}:{raw}".encode()).hexdigest()
+
+
+def enabled() -> bool:
+    """True when both variables are set. Logs once, the first time they are not."""
+    global _off_logged
+    url = os.environ.get("SUPABASE_URL", "").strip()
+    key = os.environ.get("SUPABASE_ANON_KEY", "").strip()
+    if url and key:
+        return True
+    if not _off_logged:
+        _off_logged = True
+        log.info("events are off: SUPABASE_URL and SUPABASE_ANON_KEY are not both set")
+    return False
+
+
+def post(
+    service: str,
+    event: str,
+    *,
+    device: str = "",
+    level: str = "info",
+    props: dict | None = None,
+) -> threading.Thread | None:
+    """Queue one event for the board. Never raises, never blocks.
+
+    Returns the thread carrying the request, or None when nothing was sent;
+    only the tests have a reason to join it."""
+    try:
+        if not enabled():
+            return None
+        record = {"service": service, "event": event, "level": level}
+        if device:
+            record["device"] = device
+        record["props"] = props or {}
+        body = json.dumps(record).encode()
+        url = os.environ["SUPABASE_URL"].strip().rstrip("/") + "/rest/v1/events"
+        key = os.environ["SUPABASE_ANON_KEY"].strip()
+        t = threading.Thread(
+            target=_deliver, args=(url, key, body), name="events-post", daemon=True
+        )
+        t.start()
+        return t
+    except Exception as e:  # a prop that is not JSON, a thread that cannot start
+        log.warning("event %s/%s dropped before sending: %s", service, event, e)
+        return None
+
+
+def _deliver(url: str, key: str, body: bytes) -> None:
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "apikey": key,
+            "Authorization": "Bearer " + key,
+            "Content-Type": "application/json",
+            "Prefer": "return=minimal",
+        },
+    )
+    try:
+        resp = _urlopen(req, timeout=TIMEOUT_S)
+        try:
+            resp.read()
+        finally:
+            resp.close()
+    except Exception as e:
+        log.warning("event dropped, the board did not take it: %s", e)

--- a/server/study-bridge/bridge/jobs.py
+++ b/server/study-bridge/bridge/jobs.py
@@ -12,10 +12,36 @@ import logging
 import secrets
 import time
 
-from . import store
+from . import events, store
 from .engine import Frozen
 
 log = logging.getLogger("bridge.jobs")
+
+# The job clock, as a name the tests replace to pin the seconds an event
+# reports. time.monotonic itself stays alone: asyncio's loop reads it too.
+_clock = time.monotonic
+
+
+def _report(service, device, failure, summary, props, elapsed):
+    """One event per finished job: what it moved, or what it died of. Never
+    raises -- the job is already done or failed on its own terms, and the
+    board is not allowed to change that."""
+    try:
+        if failure is None:
+            p = dict(props(summary) if props else {})
+            p["seconds"] = round(elapsed, 1)
+            events.post(service, "sync", device=device, props=p)
+        else:
+            message = f"{type(failure).__name__}: {failure}"[:200]
+            events.post(
+                service,
+                "sync",
+                device=device,
+                level="error",
+                props={"message": message},
+            )
+    except Exception:
+        log.exception("event for a %s job not posted", service)
 
 
 class Job:
@@ -43,9 +69,16 @@ class Jobs:
             return job
         return None
 
-    def start(self, uid: str, work) -> Job:
+    def start(
+        self, uid: str, work, *, service: str = "", device: str = "", props=None
+    ) -> Job:
         """work: a blocking callable run in a thread under the user lock.
-        Returns the existing job instead when one is already in flight."""
+        Returns the existing job instead when one is already in flight.
+
+        service names the board's row for this job (events.py): when set,
+        the job's end posts one event -- `sync` with props(summary) plus the
+        seconds it took, or `sync` at level error with what it died of.
+        device is the hashed id the event is counted under."""
         existing = self.active_for(uid)
         if existing:
             return existing
@@ -56,6 +89,8 @@ class Jobs:
         async def run():
             async with store.LOCKS.for_user(uid):
                 job.status = "running"
+                started = _clock()
+                failure = None
                 try:
                     job.summary = await asyncio.to_thread(work)
                     job.status = "done"
@@ -63,13 +98,19 @@ class Jobs:
                     job.status = "frozen"
                     job.message = str(e)
                     log.warning("job %s frozen: %s", job.id, e)
-                except Exception:
+                    failure = e
+                except Exception as e:
                     job.status = "error"
                     job.message = (
                         "Syncing hit a problem on the bridge. Your reviews are"
                         " safe; try again in a while."
                     )
                     log.exception("job %s failed", job.id)
+                    failure = e
+                if service:
+                    _report(
+                        service, device, failure, job.summary, props, _clock() - started
+                    )
 
         asyncio.get_running_loop().create_task(run())
         return job

--- a/server/study-bridge/compose.yaml
+++ b/server/study-bridge/compose.yaml
@@ -38,6 +38,11 @@ services:
       BRIDGE_DATA: /data
       BRIDGE_FERNET_KEY: ${BRIDGE_FERNET_KEY}
       BRIDGE_ALLOWLIST: ${BRIDGE_ALLOWLIST}
+      # Where sync and error events go (docs/workflow/events.md). Both
+      # optional: with either unset the service posts nothing and logs so
+      # once at startup. The anon key can only insert.
+      SUPABASE_URL: ${SUPABASE_URL:-}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-}
     volumes:
       - ./data:/data
     # uid 10002: 10001 is getbooks on the same box, and shared uids would let

--- a/server/study-bridge/tests/test_api.py
+++ b/server/study-bridge/tests/test_api.py
@@ -353,6 +353,171 @@ async def run(tmp):
             "the buildable deck should still be built",
         )
 
+        # --- Events: what a finished sync tells the board, and what a board
+        # that is down costs it (nothing). The HTTP layer is stubbed at the one
+        # name events.py sends through, so these assert the exact body.
+        import urllib.error
+        import urllib.request
+
+        import bridge.app as app_mod
+        from bridge import engine as engine_mod
+        from bridge import events
+        from bridge import jobs as jobs_mod
+        from bridge import pairing as pairing_mod
+        from bridge.ratelimit import Window
+
+        os.environ["SUPABASE_URL"] = "https://board.test"
+        os.environ["SUPABASE_ANON_KEY"] = "anon-test-key"
+        posted = []
+
+        class Taken:
+            def read(self):
+                return b""
+
+            def close(self):
+                pass
+
+        def take(req, timeout):
+            posted.append(req)
+            return Taken()
+
+        def refuse(req, timeout):
+            posted.append(req)
+            raise urllib.error.URLError("connection refused")
+
+        async def settle(n):
+            # The post rides its own thread; give it a moment to land.
+            for _ in range(50):
+                if len(posted) >= n:
+                    return
+                await asyncio.sleep(0.1)
+
+        async def finish(job_id):
+            for _ in range(600):
+                await asyncio.sleep(0.1)
+                r = await web.get(
+                    "/api/sync/status", headers=dev, params={"job": job_id}
+                )
+                if r.json()["status"] in ("done", "error", "frozen"):
+                    break
+            return r.json()
+
+        events._urlopen = take
+        # Each job reads the clock twice; pinned so `seconds` is asserted
+        # exactly rather than as "some number".
+        ticks = iter([100.0, 102.5, 200.0, 200.4, 300.0, 300.1, 400.0, 400.2])
+        jobs_mod._clock = lambda: next(ticks, time.monotonic())
+        # The syncs above spent this user's window; this block gets a fresh
+        # one with the same limits.
+        app_mod.SYNC_USER = Window(6, 300)
+        expected_device = events.device_id(pairing_mod.token_hash(token))
+
+        r = await web.post(
+            "/api/sync",
+            headers=dev,
+            content=struct.pack("<I", len(empty_header)) + empty_header,
+        )
+        status = await finish(r.json()["job"])
+        ok(status["status"] == "done", f"the events sync should finish, got {status}")
+        await settle(1)
+        ok(len(posted) == 1, f"a finished sync posts one event, got {len(posted)}")
+        wire_body = json.loads(posted[0].data)
+        ok(
+            wire_body
+            == {
+                "service": "anki",
+                "event": "sync",
+                "level": "info",
+                "device": expected_device,
+                "props": {"cards": 0, "reviews": 0, "seconds": 2.5},
+            },
+            f"a sync posts the contract's body, got {wire_body}",
+        )
+        ok(
+            posted[0].full_url == "https://board.test/rest/v1/events",
+            "to the events table",
+        )
+        ok(posted[0].get_header("Apikey") == "anon-test-key", "with the public key")
+        ok(
+            token not in posted[0].data.decode()
+            and pairing_mod.token_hash(token) not in posted[0].data.decode(),
+            "neither the token nor its hash is in the event",
+        )
+
+        # A board that refuses the event cannot fail the sync.
+        events._urlopen = refuse
+        r = await web.post(
+            "/api/sync",
+            headers=dev,
+            content=struct.pack("<I", len(empty_header)) + empty_header,
+        )
+        status = await finish(r.json()["job"])
+        ok(
+            status["status"] == "done" and status["summary"]["manifests"],
+            f"a board that is down does not fail the sync, got {status['status']}",
+        )
+        await settle(2)
+        ok(len(posted) == 2, "and the event was attempted, not skipped")
+
+        # A sync that dies posts what it died of: the generic branch ...
+        events._urlopen = take
+        real_cycle = engine_mod.sync_cycle
+
+        def dead(*a, **kw):
+            raise RuntimeError("AnkiWeb answered 503 for user 42")
+
+        engine_mod.sync_cycle = dead
+        try:
+            r = await web.post(
+                "/api/sync",
+                headers=dev,
+                content=struct.pack("<I", len(empty_header)) + empty_header,
+            )
+            status = await finish(r.json()["job"])
+        finally:
+            engine_mod.sync_cycle = real_cycle
+        ok(status["status"] == "error", f"the broken sync should fail, got {status}")
+        await settle(3)
+        wire_body = json.loads(posted[2].data)
+        ok(
+            wire_body
+            == {
+                "service": "anki",
+                "event": "sync",
+                "level": "error",
+                "device": expected_device,
+                "props": {"message": "RuntimeError: AnkiWeb answered 503 for user 42"},
+            },
+            f"a failure posts its message at level error, got {wire_body}",
+        )
+
+        # ... and the frozen one, whose message is the sentence the reader shows.
+        def frozen(*a, **kw):
+            raise engine_mod.Frozen("AnkiWeb wants an upload.")
+
+        engine_mod.sync_cycle = frozen
+        try:
+            r = await web.post(
+                "/api/sync",
+                headers=dev,
+                content=struct.pack("<I", len(empty_header)) + empty_header,
+            )
+            status = await finish(r.json()["job"])
+        finally:
+            engine_mod.sync_cycle = real_cycle
+        ok(status["status"] == "frozen", f"the frozen sync should freeze, got {status}")
+        await settle(4)
+        wire_body = json.loads(posted[3].data)
+        ok(
+            wire_body["level"] == "error"
+            and wire_body["props"] == {"message": "Frozen: AnkiWeb wants an upload."},
+            f"a frozen sync posts its sentence at level error, got {wire_body}",
+        )
+
+        events._urlopen = urllib.request.urlopen
+        jobs_mod._clock = time.monotonic
+        del os.environ["SUPABASE_URL"], os.environ["SUPABASE_ANON_KEY"]
+
         # --- Revocation kills the token.
         th = __import__("bridge.pairing", fromlist=["token_hash"]).token_hash(token)
         store_mod.revoke_device(st.uid, th)

--- a/server/study-bridge/tests/test_events.py
+++ b/server/study-bridge/tests/test_events.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""The event poster's promises, with the HTTP layer stubbed.
+
+  * off means off: without both variables nothing is sent and the log says
+    so exactly once;
+  * a post is the body docs/workflow/events.md describes, with the key in
+    both headers, and it returns before the request does;
+  * a board that is down, or a prop that cannot be JSON, costs one log line
+    and nothing else.
+
+And one that is about the repo rather than the module: bridge/events.py is
+duplicated into both bridges because neither image can COPY a file from
+outside its own directory. The two copies must stay byte-identical, or a fix
+lands on one and not its twin.
+
+Run: .venv/bin/python tests/test_events.py
+"""
+
+import hashlib
+import json
+import logging
+import os
+import pathlib
+import sys
+import threading
+import time
+import urllib.error
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+
+from bridge import events  # noqa: E402
+
+checks = 0
+failures = 0
+
+
+def ok(cond, label):
+    global checks, failures
+    checks += 1
+    if not cond:
+        failures += 1
+        print(f"  FAIL: {label}")
+
+
+class Capture(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+class FakeResponse:
+    def read(self):
+        return b""
+
+    def close(self):
+        pass
+
+
+def main():
+    log = logging.getLogger("bridge.events")
+    cap = Capture()
+    log.addHandler(cap)
+    log.setLevel(logging.INFO)
+    sent = []
+
+    def record(req, timeout):
+        sent.append((req, timeout))
+        return FakeResponse()
+
+    def off_lines():
+        return sum("events are off" in r.getMessage() for r in cap.records)
+
+    # --- off means off
+    os.environ.pop("SUPABASE_URL", None)
+    os.environ.pop("SUPABASE_ANON_KEY", None)
+    events._off_logged = False
+    events._urlopen = record
+    ok(
+        events.post("anki", "sync", props={"cards": 1}) is None,
+        "nothing is queued without the variables",
+    )
+    events.post("anki", "sync", props={"cards": 2})
+    ok(sent == [], "and nothing reaches the HTTP layer")
+    ok(
+        off_lines() == 1,
+        f"the log says events are off exactly once, said it {off_lines()} times",
+    )
+    os.environ["SUPABASE_URL"] = "https://x.supabase.co/"
+    ok(events.post("anki", "sync") is None and sent == [], "one variable is not enough")
+    ok(off_lines() == 1, "and a later post does not repeat the line")
+
+    # --- the body
+    os.environ["SUPABASE_ANON_KEY"] = "anon-test-key"
+    cap.records.clear()
+    dev = events.device_id("tok")
+    t = events.post("anki", "sync", device=dev, props={"cards": 3, "seconds": 1.5})
+    ok(t is not None, "with both variables a post is queued")
+    t.join(5)
+    ok(len(sent) == 1, f"one request, got {len(sent)}")
+    req, timeout = sent[0]
+    ok(
+        req.full_url == "https://x.supabase.co/rest/v1/events",
+        f"the trailing slash is folded, got {req.full_url}",
+    )
+    ok(req.get_method() == "POST", "it is a POST")
+    ok(timeout == events.TIMEOUT_S, f"the request carries the timeout, got {timeout}")
+    ok(
+        req.get_header("Apikey") == "anon-test-key"
+        and req.get_header("Authorization") == "Bearer anon-test-key",
+        "the key rides in both headers",
+    )
+    ok(
+        req.get_header("Content-type") == "application/json"
+        and req.get_header("Prefer") == "return=minimal",
+        "JSON in, nothing back",
+    )
+    body = json.loads(req.data)
+    ok(
+        body
+        == {
+            "service": "anki",
+            "event": "sync",
+            "level": "info",
+            "device": dev,
+            "props": {"cards": 3, "seconds": 1.5},
+        },
+        f"the body is the contract's, got {body}",
+    )
+    ok(cap.records == [], "a delivered event logs nothing")
+
+    # --- device_id
+    ok(dev != hashlib.sha256(b"tok").hexdigest(), "the device hash is salted")
+    ok(len(dev) == 64 and dev == events.device_id("tok"), "and stable")
+    ok("tok" not in req.data.decode(), "the raw id is not in the body")
+    t = events.post("anki", "heartbeat")
+    t.join(5)
+    ok(
+        "device" not in json.loads(sent[-1][0].data),
+        "no device means no device field, not an empty one",
+    )
+
+    # --- it returns before the request does
+    gate = threading.Event()
+
+    def slow(req, timeout):
+        gate.wait(5)
+        return FakeResponse()
+
+    events._urlopen = slow
+    t0 = time.monotonic()
+    t = events.post("anki", "sync")
+    elapsed = time.monotonic() - t0
+    gate.set()
+    t.join(5)
+    ok(
+        elapsed < 0.5,
+        f"post returned in {elapsed:.3f}s while the request was still open",
+    )
+
+    # --- a board that is down
+    cap.records.clear()
+
+    def down(req, timeout):
+        raise urllib.error.URLError("connection refused")
+
+    events._urlopen = down
+    t = events.post("anki", "sync", level="error", props={"message": "x"})
+    t.join(5)
+    ok(not t.is_alive(), "the request thread finishes")
+    ok(
+        len(cap.records) == 1 and cap.records[0].levelno == logging.WARNING,
+        f"one warning line, got {[r.getMessage() for r in cap.records]}",
+    )
+    ok("dropped" in cap.records[0].getMessage(), "and it says the event was dropped")
+
+    # --- a prop that cannot be JSON
+    cap.records.clear()
+    events._urlopen = record
+    before = len(sent)
+    ok(
+        events.post("anki", "sync", props={"bad": object()}) is None,
+        "an unserialisable prop is dropped, not raised",
+    )
+    ok(len(sent) == before and len(cap.records) == 1, "one warning, no request")
+
+    # --- the twin
+    other = [s for s in ("study-bridge", "read-bridge") if s != ROOT.name]
+    twin = ROOT.parent / other[0] / "bridge" / "events.py"
+    mine = ROOT / "bridge" / "events.py"
+    if twin.exists():
+        ok(
+            mine.read_bytes() == twin.read_bytes(),
+            f"bridge/events.py is byte-identical to its twin in {other[0]}",
+        )
+    else:
+        print(f"  (no twin at {twin}; the byte-identity check needs the whole repo)")
+
+    print(f"{checks} checks, {failures} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Cards #20 and #21: the two pi bridges post their syncs and their failures to the board (`docs/workflow/events.md`). One commit per service.

## What each service posts

| service      | done                               | failed                              |
| ------------ | ---------------------------------- | ----------------------------------- |
| `anki`       | `sync` `{cards, reviews, seconds}` | `sync` at level `error` `{message}` |
| `instapaper` | `sync` `{articles, seconds}`       | `sync` at level `error` `{message}` |

`device` is `sha256("crossplay-events:" + id)`: the token hash for the study bridge, the account id for the Instapaper bridge. Neither a token, a token hash, an address nor an account id appears in any event, and the tests assert that by searching the posted bytes.

`bridge/events.py` (byte-identical in both services; each `tests/test_events.py` fails if they drift) posts from a daemon thread with a 3 s timeout, drops the event after one log line when the board does not take it, and is a no-op that logs `events are off` once when `SUPABASE_URL` and `SUPABASE_ANON_KEY` are not both set. The two variables come in through `compose.yaml` as optional passthroughs.

Why duplicated rather than shared: neither Dockerfile can `COPY` from outside its own directory (study-bridge stages a build context from the repo, read-bridge rsyncs its own dir), so one shared module would be a build change in both. Forty lines twice, with a test that keeps them equal.

## Verified (host, this tree)

- study-bridge: `test_events` 25, `test_api` 46 (was 34), `test_engine` 13, `test_window` 9; `host-tests/study` green.
- read-bridge: `test_events` 25, `test_api` 64 (was 51), `test_engine` 13, `test_lockout` 18, `test_article` 40, `test_oauth` 11, `test_window` 9; `host-tests/instapaper` 92.
- `scripts_local/check.sh`'s bridge stage now runs `test_events` for both.

The API suites stub the HTTP layer at the one name `events.py` sends through and assert the exact bodies:

```json
{"service":"anki","event":"sync","level":"info","device":"<sha256>","props":{"cards":0,"reviews":0,"seconds":2.5}}
{"service":"anki","event":"sync","level":"error","device":"<sha256>","props":{"message":"RuntimeError: AnkiWeb answered 503 for user 42"}}
{"service":"instapaper","event":"sync","level":"info","device":"<sha256>","props":{"articles":2,"seconds":2.5}}
{"service":"instapaper","event":"sync","level":"error","device":"<sha256>","props":{"message":"Refused: Instapaper refused: 1041 for bookmark 77"}}
```

and, per service, that a board answering `URLError` leaves the sync `done` with its summary intact while the event was attempted (not skipped).

## NOT verified: deploy

**Nothing is deployed. The pi is off (power cut).** Neither the real Supabase endpoint nor the containers have seen this code. When the pi is back, per service:

study-bridge:

```sh
ssh orange 'umask 077 && cat >> /srv/ankibridge/.env' <<'ENV'
SUPABASE_URL=https://<project>.supabase.co
SUPABASE_ANON_KEY=<anon key from <workspace>/.board/supabase.env>
ENV
bash server/study-bridge/scripts/deploy.sh
ssh orange 'cd /srv/ankibridge && docker compose logs ankibridge | grep "events on"'
ssh orange 'bash -s' < server/study-bridge/scripts/isolation_test.sh
```

read-bridge:

```sh
ssh orange 'umask 077 && cat >> /srv/readbridge/.env' <<'ENV'
SUPABASE_URL=https://<project>.supabase.co
SUPABASE_ANON_KEY=<anon key from <workspace>/.board/supabase.env>
ENV
bash server/read-bridge/scripts/deploy.sh
ssh orange 'cd /srv/readbridge && docker compose logs readbridge | grep "events on"'
```

(read-bridge's `deploy.sh` runs its own isolation test and refuses to report success without it.) Then one sync from a reader and a row in `events` with `service = 'anki'` / `'instapaper'` is the end-to-end proof; the anon key can only insert, so it is read from the inbox page's numbers, not from the pi.

Hardware always counts as not verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
