### PR TITLE
feat: wt.sh prune drops every merged, clean, idle tree at once

### DIFF
--- a/docs/workflow/orchestrator.md
+++ b/docs/workflow/orchestrator.md
@@ -44,7 +44,9 @@ integrator --session <your id>`) only while you resolve a conflict or
    Mac; the guard once stayed a version behind for a whole evening that way.
 6. **Close.** For each `released` card: worktree dropped, session archived,
    leftovers filed as new cards, `board state <id> done`. A session never
-   outlives its card.
+   outlives its card. Once a tick, `./scripts/wt.sh prune`: it drops every
+   tree that is merged, clean and idle, and nothing else; a tree it keeps
+   has work in it, and that work has a card or needs one.
 7. **Cards that arrive by themselves.** Three kinds need no dispatcher:
    `source: error` (an error event opened it; the count on the card's
    fingerprint says how often; treat it as a bug owned by the service it

--- a/host-tests/wtbase/run.sh
+++ b/host-tests/wtbase/run.sh
@@ -113,5 +113,29 @@ is "--from still overrides the default" \
    "$(git rev-parse app/stacked 2>/dev/null || echo missing)" \
    "$(git rev-parse app/probe)"
 
+echo "wt.sh prune"
+
+# Four trees: probe and stacked carry a commit not in origin (kept), merged1 is
+# level and clean (goes), dirtyone is level with an edit (kept). prune must
+# never remove anything it cannot recreate.
+./scripts_local/wt.sh new merged1 >/dev/null 2>&1
+./scripts_local/wt.sh new dirtyone >/dev/null 2>&1
+echo edit >> "$WORK/wt/dirtyone/file.txt"
+DRY="$(./scripts_local/wt.sh prune --dry-run 2>&1)"
+case "$DRY" in
+  *"would drop merged1"*) ok "dry run names the merged, clean tree" ;;
+  *) bad "dry run did not name merged1: $DRY" ;;
+esac
+[ -d "$WORK/wt/merged1" ] && ok "dry run removes nothing" || bad "dry run removed merged1"
+OUT="$(./scripts_local/wt.sh prune 2>&1)"
+[ ! -d "$WORK/wt/merged1" ] && ok "prune drops the merged, clean tree" || bad "prune kept merged1: $OUT"
+git rev-parse -q --verify app/merged1 >/dev/null 2>&1 && bad "prune left the merged branch behind" || ok "and its branch"
+[ -d "$WORK/wt/probe" ] && [ -d "$WORK/wt/stacked" ] && ok "prune keeps trees with unmerged commits" || bad "prune dropped an unmerged tree: $OUT"
+[ -d "$WORK/wt/dirtyone" ] && ok "prune keeps a dirty tree" || bad "prune dropped a dirty tree: $OUT"
+case "$OUT" in
+  *"1 dropped, 3 kept"*) ok "and says what it did" ;;
+  *) bad "summary line wrong: $OUT" ;;
+esac
+
 echo "$((PASS+FAIL)) checks, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/scripts_local/wt.sh
+++ b/scripts_local/wt.sh
@@ -4,6 +4,7 @@
 #   ./scripts/wt.sh new <name> [--from <branch>]   # make one
 #   ./scripts/wt.sh list                           # what exists, and what state
 #   ./scripts/wt.sh drop <name>                    # remove it once merged
+#   ./scripts/wt.sh prune [--dry-run]              # drop every tree that is merged and clean
 #
 # Why this exists: everything used to happen in firmware-next/. Several apps
 # were built at once, so that one tree held four efforts' uncommitted work at
@@ -155,6 +156,39 @@ cmd_drop() {
   echo "dropped $name"
 }
 
+# Closing is the part nobody does. A tree whose branch is entirely in
+# origin/xteink and whose working copy is clean holds nothing: no commits, no
+# edits, and its build output and screenshots can be made again. Ninety-odd
+# such trees once sat under wt/ because dropping them was a decision per tree.
+# prune makes it one decision for all of them and never touches a tree that
+# has anything in it, is detached (wt/_land), or has a simulator running.
+cmd_prune() {
+  local dry=0
+  [ "${1:-}" = "--dry-run" ] && dry=1
+  git -C "$INTEGRATION" fetch -q origin 2>/dev/null
+  local d name branch dirty unmerged kept=0 dropped=0
+  for d in "$WT_ROOT"/*/; do
+    [ -d "$d" ] || continue
+    d="${d%/}"; name="$(basename "$d")"
+    branch="$(git -C "$d" branch --show-current 2>/dev/null)"
+    [ -n "$branch" ] || { kept=$((kept + 1)); continue; }
+    dirty="$(git -C "$d" status --porcelain --ignore-submodules=untracked 2>/dev/null | grep -c '' | tr -d ' ')"
+    unmerged="$(git -C "$INTEGRATION" rev-list --count origin/xteink.."$branch" 2>/dev/null || echo 1)"
+    if [ "$dirty" != "0" ] || [ "$unmerged" != "0" ] || pgrep -f "^$d/.pio/build/simulator_x4_pro/program" >/dev/null 2>&1; then
+      kept=$((kept + 1)); continue
+    fi
+    if [ "$dry" = 1 ]; then
+      echo "would drop $name ($branch: merged, clean)"
+    else
+      git -C "$INTEGRATION" worktree remove --force "$d" >/dev/null 2>&1 || { echo "could not remove $name" >&2; kept=$((kept + 1)); continue; }
+      git -C "$INTEGRATION" branch -D "$branch" >/dev/null 2>&1
+      echo "dropped $name ($branch: merged, clean)"
+    fi
+    dropped=$((dropped + 1))
+  done
+  [ "$dry" = 1 ] && echo "prune: $dropped would go, $kept kept" || echo "prune: $dropped dropped, $kept kept"
+}
+
 case "${1:-}" in
   new)
     shift
@@ -167,8 +201,12 @@ case "${1:-}" in
     shift
     cmd_drop "$@"
     ;;
+  prune)
+    shift
+    cmd_prune "$@"
+    ;;
   *)
-    echo "usage: wt.sh {new <name> [--from <branch>] | list | drop <name>}" >&2
+    echo "usage: wt.sh {new <name> [--from <branch>] | list | drop <name> | prune [--dry-run]}" >&2
     exit 2
     ;;
 esac


### PR DESCRIPTION
Closing was a decision per tree, so nobody made it: ninety-odd trees whose branches were entirely in xteink sat under wt/. `wt.sh prune` drops a tree only when its branch has no commit outside origin/xteink, its working copy is clean, it is on a branch, and no simulator runs from it. `--dry-run` lists what would go. The orchestrator's Close step now uses it.

Verified: host-tests/wtbase (11 checks: merged goes, unmerged and dirty stay, dry run removes nothing). Not verified: nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)