### PR TITLE
Trivia: the parts of the difficulty work that outlived the ratings

### DIFF
--- a/docs/apps/trivia-pack-format.md
+++ b/docs/apps/trivia-pack-format.md
@@ -9,11 +9,24 @@ with an offset index and a trailing sentinel, mutable state in a separate
 fixed-width file. `tools_local/trivia/pack_format.py` is both the writer and a
 reference reader, so the format is executable rather than only described.
 
+It reads a pack back out too, which matters because the season TSVs
+`build_pack.py --src` wants are not in this repo and not on this machine, so a
+published `pack.dat` is the only surviving copy of its corpus:
+
+```bash
+python3 tools_local/trivia/pack_format.py pack.dat > corpus.jsonl
+```
+
+The `id` that comes back is RE-DERIVED from clue text, which is not a safe join
+key for ratings; the module's own comment says why, at length.
+
 ## Why there is a pack at all
 
-50,000 questions is 5.37 MB. The app partition is 7.94 MB total and the image
-already uses most of it, so the questions cannot ride in flash. They live on the
-card, like study decks and the xkcd archive.
+The shipped 50,000 questions are 5.37 MB. The app partition is 7.94 MB total and
+the image already uses most of it, so the questions cannot ride in flash. They
+live on the card, like study decks and the xkcd archive. The argument holds at
+any pack size and the megabyte figure is not current: a pack assembled from the
+local rating run was 3.39 MB at 25,866 questions.
 
 ## Two files
 
@@ -66,19 +79,53 @@ bit 1 `FLAGGED`. Marking a question is one seek and one byte, never a rewrite,
 so a power loss mid-write can lose at most one question's state and can never
 touch the question text — the same durability rule study follows.
 
-49 KB for a 50,000-question pack.
+One byte per question: 49 KB for the shipped 50,000.
+
+**Its length and the pack's count are the same fact written twice, so any
+disagreement means the pack was replaced and the file is rewritten from zero.**
+Not "shorter than the pack" -- a LONGER file is stale in exactly the same way,
+and it is the case that actually happens, because a rated pack is smaller than
+the 50,000 it replaces. A stale `FLAGGED` byte landing on an arbitrary question
+hides it from every draw with nothing on screen and no way to clear it.
+`PackState::open` and `TriviaActivity::ensureState` both compare with `!=`.
+
+**The device's own download replaces `pack.dat` and nothing else.** It never
+fetches a state file, so crossing a pack rebuild is entirely that comparison's
+job. Copying a pack to a card by hand is the other case, and there both files
+are copied together; see ../trivia-curation.md.
+
+**The residual: length is a proxy, not an identity.** A pack replaced by one
+with the SAME question count keeps its state file, and every byte then describes
+whichever question now sits at that index. The header carries no content hash to
+compare, so nothing on the device can see it. It is not worth a format bump
+today because a rebuild changes the count, but it is the case this check cannot
+cover.
 
 `FLAGGED` is the in-play "this question is bad" button. Those indices are read
 back off the card and merged into `tools_local/trivia/verdicts.tsv`, which the
 next build applies. That is the loop that improves the pack through play rather
 than through a curation project.
 
-## Difficulty is derived, not stored upstream
+## Difficulty comes from the builder, and the two builders disagree
 
-Jeopardy doubled its clue values on 2001-11-26, so raw `clue_value` is not
-comparable across the 42 seasons. The builder doubles pre-2001 values, halves
-Double Jeopardy to the round-one scale, and calls Final Jeopardy tier 5. The
-result is an even spread; raw values would not be.
+`d` is one byte, 1 to 5, and the record says nothing about where it came from.
+Two tools write it and they mean different things by it:
+
+- **`build_pack.py`** derives it from Jeopardy's clue value. Jeopardy doubled
+  its values on 2001-11-26, so raw `clue_value` is not comparable across the 42
+  seasons; the builder doubles pre-2001 values, halves Double Jeopardy to the
+  round-one scale, and calls Final Jeopardy tier 5. The result is an even
+  spread, which raw values would not be. This is what the shipped pack carries.
+- **`assemble_pack.py`** cuts it from a stored 0-10 rating by fixed absolute
+  thresholds, so level 3 means the same thing in a pack built from 18,000 rated
+  rows and one built from 40,000. See ../trivia-curation.md.
+
+A clue's value is its ROW ON A BOARD, picked relative to the other five clues in
+its category that night -- a category the pack throws away. Whether that is a
+usable proxy for how hard a question is, and whether the rating run's number is
+better, is the open question ../trivia-curation.md tracks. **The format cannot
+tell you which builder made a pack**, which is why the level a player picks
+means whatever the last build meant by it.
 
 ## The clue cap is measured in pixels, not characters
 
@@ -120,8 +167,16 @@ complete, so a torn download leaves the card exactly as it was.
 
 ## Solo multiple choice
 
-18,485 of the 50,000 carry precomputed distractors. The rest are quizmaster-only,
-which is why both modes exist rather than one.
+Not every question carries precomputed distractors; the rest are
+quizmaster-only, which is why both modes exist rather than one. **18,485 of the
+shipped 50,000**, against 76.6% of a pack assembled from the local rating run.
+
+**How MANY are stored differs too, and the device is at its boundary.**
+`build_pack.py` stores up to 6 and the draw picks 3 of them; `assemble_pack.py`
+stores exactly 3 or exactly 0, because a set of three is the set the gate
+checked. `playableAsChoice()` is `wrongCount_ >= kOptions - 1`, so 3 is correct
+with zero margin and 1 or 2 would be undefined -- unreachable twice over, and
+pinned by `testChoicesAtThreeOptions()` in host-tests/trivia.
 
 **The type comes from the clue itself.** A Jeopardy clue names what its answer
 is -- "this **country**", "this **writer**", "this **metal**" -- so distractors

--- a/docs/apps/trivia.md
+++ b/docs/apps/trivia.md
@@ -1,8 +1,15 @@
 # TRIVIA
 
-50,000 questions on the card, two ways to play them. The questions and how they
-were chosen are in [../trivia-curation.md](../trivia-curation.md); the on-card
-format is [trivia-pack-format.md](trivia-pack-format.md). This is the app.
+A pack of questions on the card, two ways to play them. The questions and how
+they were chosen are in [../trivia-curation.md](../trivia-curation.md); the
+on-card format is [trivia-pack-format.md](trivia-pack-format.md). This is the
+app.
+
+**No question count is written down here on purpose.** The shipped pack is
+50,000 clues whose difficulty is Jeopardy's dollar value; the pack
+`assemble_pack.py` builds holds exactly the questions a rating run has reached,
+so it is a different and SMALLER number on every build. The front door reads the
+count off the card.
 
 ## Two modes, because the pack is not uniform
 
@@ -13,9 +20,13 @@ works alone too, the way a flashcard does.
 **SOLO** adds four options and keeps score, because with nobody else in the room
 something has to judge you.
 
-They are not two skins on one mode. Only **18,485 of the 50,000** carry
-distractors, so solo draws from under a third of the pack. The chooser is told
-`requireChoice` and skips the rest.
+They are not two skins on one mode. Not every question carries distractors, so
+solo draws from part of the pack and the chooser is told `requireChoice` and
+skips the rest. How large that part is depends on which builder made the pack:
+**18,485 of the shipped 50,000** (under a third), against **76.6%** of a pack
+assembled from the local rating run, which generates its own candidate options
+rather than drawing them from questions of the same type. That share is flat
+across the five levels (72.7% to 82.5%), so no level is short of solo material.
 
 ## The question screen
 

--- a/docs/open-items.md
+++ b/docs/open-items.md
@@ -21,7 +21,10 @@ fact.
 **Closed, and counted on every stored option rather than sampled:** two options
 that are one thing 5.3% -> 0.0%, options not capitalised alike 9.9% -> 0.0%.
 **Improved, sampled:** a region named with only one option in it 15.5% -> 5.5%.
-Playable questions went 14,388 -> 18,485.
+Playable questions went 14,388 -> 18,485 **on the shipped 50,000**, whose
+options come from questions of the same type. A pack assembled from the local
+rating run uses that run's own candidate options and lands at 76.6% playable,
+flat across the five levels (72.7% to 82.5%).
 
 **What is still open, in the order it will be noticed:**
 

--- a/docs/trivia-curation.md
+++ b/docs/trivia-curation.md
@@ -293,7 +293,12 @@ python3 tools_local/trivia/test_pack.py .rate/out/pack.jsonl
 # 4. What a cold player could exploit without knowing anything.
 python3 tools_local/trivia/audit_options.py .rate/out/pack.jsonl
 
-# 5. On the card, beside the .state file the build wrote next to it.
+# 5. The one difficulty check the ratings cannot satisfy by construction.
+#    Reads the run's own output; see "The levels against a blind panel" below
+#    before treating a low number as a blocker.
+python3 tools_local/trivia/panel_score.py .rate/enriched.jsonl
+
+# 6. On the card, beside the .state file the build wrote next to it.
 cp .rate/out/pack.dat  <sd>/trivia/pack.dat
 cp .rate/out/pack.state <sd>/trivia/pack.state
 ```
@@ -302,6 +307,60 @@ cp .rate/out/pack.state <sd>/trivia/pack.state
 and addressed by index, so a state file left over from a different pack marks
 the wrong questions seen. `assemble_pack.py --dat` writes a fresh zeroed one
 beside the pack every time; copy both or neither.
+
+**A device crossing this rebuild over the air cannot do that**, because the
+download replaces `pack.dat` and never fetches a state file. It relies on the
+firmware noticing that the state file's length no longer matches the pack's
+count, and until 2026-09-04 that check only caught a state file that was too
+SHORT. An assembled pack is SMALLER than the 50,000 it replaces, so the state
+file left behind is too LONG, which was the case the check could not see.
+
+**And the finished pack will miss by a handful, not by thousands**, which is the
+worst version of it. The run's worklist is `rest40383.ids` plus the 9,617
+already rated, i.e. the whole 50,000 corpus, so at completion the only questions
+missing are the ones `assemble_pack.py` rejects as unanswerable -- 9 of the
+first 25,875. A pack of roughly 49,98x against a 50,000-byte state file is a
+misalignment nothing on screen can show and nobody would think to look for.
+(Mid-run it is blunter: 25,866 questions at 25,875 ratings.)
+
+Fixed at `PackState::open` and `TriviaActivity::ensureState`; a device on
+firmware older than that will reuse stale `FLAGGED` bytes against the new record
+order and hide arbitrary questions from every draw.
+
+### The levels against a blind panel
+
+`difficulty_panel.tsv` is 50 pairs that three blind judges unanimously called
+(easier, harder), frozen. It is the only difficulty check here that a wrong
+rating can fail: everything else -- a stocked tier, monotone means, a wide 1-to-5
+gap -- is computed from `r`, and `d` is CUT from `r`, so those are arithmetic.
+Shuffle the ratings across questions and they all still pass; the panel drops to
+34%.
+
+| ratings | panel agreement |
+| --- | --- |
+| the cloud judge's, which the pairs were sampled from | 50/50 = 100% |
+| the LOCAL run, which builds the shipping pack | 36/50 = 72% |
+| the local run, raw `r`, thresholds removed | 38/50 = 76% |
+| the local run, shuffled across questions | 17/50 = 34% |
+
+**Do not read that first row as quality, and do not read the second as a
+verdict on the local rater.** Candidates were sampled as level 1 against level 5
+*as the cloud file cut them*, so that file is being scored on its own extremes
+and every other rater on somebody else's. No threshold here transfers.
+
+The cloud file is also the noisy one, which is the finding that put PR #19 on
+hold: **9,597 of its 9,617 rows are single-judge** (only the 20 anchors carry
+more), a fresh judge agrees with it at +0.58 / +0.64, and two fresh judges agree
+with **each other** at +0.92 / +0.895. The two files agree with each other at
+Spearman +0.34 on the 9,597 questions both cover, and their scales differ --
+`local/local_difficulty_intl.tsv` says so in its own header -- so their means are
+not comparable either.
+
+What survives is 50 blind pairwise verdicts, re-scorable against any future
+rater, and the shape of a check that a wrong rating can fail. **To use it as a
+bar, draw a fresh panel from the shipping rater's own extremes.** Until then
+`panel_score.py` prints numbers and no verdict, exits 0, and is not in
+`check.sh`.
 
 ### Three rules in that tool, each of which fails silently when undone
 

--- a/host-tests/trivia/test_trivia.cpp
+++ b/host-tests/trivia/test_trivia.cpp
@@ -223,6 +223,21 @@ void testState() {
   MemorySource small(std::vector<uint8_t>(10, 0));
   PackState mismatched;
   CHECK(!mismatched.open(small, 50));
+
+  // And so does a LONGER one, which is the half that had no coverage. The pack
+  // is addressed by index and the state file is one byte per index, so the two
+  // lengths are the same fact written twice; any disagreement means the pack
+  // under the state file changed. A SHORTER file was rejected and a longer one
+  // was accepted, on the reasoning that every index still had a byte -- but the
+  // bytes describe questions that are no longer at those indices. A FLAGGED bit
+  // landing on an arbitrary question hides it from every draw with nothing on
+  // screen and no way for a player to clear it.
+  //
+  // Reachable as soon as a pack SHRINKS, which is what a rated pack does to the
+  // 50,000 it replaces.
+  MemorySource oversized(std::vector<uint8_t>(90, 0));
+  PackState stale;
+  CHECK(!stale.open(oversized, 50));
 }
 
 // --- chooser --------------------------------------------------------------

--- a/src/apps_local/trivia/TriviaActivity.cpp
+++ b/src/apps_local/trivia/TriviaActivity.cpp
@@ -78,10 +78,19 @@ std::unique_ptr<Activity> TriviaActivity::create(GfxRenderer& renderer, MappedIn
 
 bool TriviaActivity::ensureState(const uint32_t count) {
   g_stateFile = Storage.open(kStatePath, O_RDWR);
-  if (!g_stateFile.isOpen() || static_cast<uint32_t>(g_stateFile.size()) < count) {
-    // Missing, or shorter than the pack because the pack was replaced under it.
-    // Rewriting loses which questions have been seen, which is the right trade:
-    // reading a stale byte for a question it does not describe is worse.
+  if (!g_stateFile.isOpen() || static_cast<uint32_t>(g_stateFile.size()) != count) {
+    // Missing, or a DIFFERENT length from the pack because the pack was
+    // replaced under it. Rewriting loses which questions have been seen, which
+    // is the right trade: reading a stale byte for a question it does not
+    // describe is worse.
+    //
+    // `!=`, not `<`. A pack that SHRANK left a longer state file, size() >= count
+    // held, and every byte was reused against a pack whose record order had
+    // changed -- so SEEN bits deprioritised arbitrary questions and, worse,
+    // FLAGGED bits made arbitrary questions permanently unservable with no way
+    // for the player to clear them. Both this call site and PackState::open
+    // check the length; the guard is at the boundary as well as at the caller
+    // because this is the only caller today and will not be the last.
     HalFile fresh;
     if (!Storage.openFileForWrite("TRIVIA", kStatePath, fresh)) {
       LOG_ERR("TRIVIA", "Cannot create %s", kStatePath);

--- a/src/apps_local/trivia/TriviaActivity.h
+++ b/src/apps_local/trivia/TriviaActivity.h
@@ -1,6 +1,11 @@
 #pragma once
 
-// TRIVIA: 50,000 questions on the card, two ways to play them.
+// TRIVIA: a pack of questions on the card, two ways to play them.
+//
+// No count here on purpose. The shipped pack is 50,000 clues levelled by
+// Jeopardy's dollar value; assemble_pack.py builds one holding whatever a
+// rating run has reached, so the figure changes on every build and the front
+// door reads it off the card. See docs/apps/trivia.md.
 //
 // The activity is the thin layer: it owns the pack files, the round and the
 // input. The format and the round logic are in TriviaCore.h (freestanding) and

--- a/src/apps_local/trivia/TriviaCore.cpp
+++ b/src/apps_local/trivia/TriviaCore.cpp
@@ -123,9 +123,17 @@ bool PackState::open(WritableByteSource& source, const uint32_t count) {
   source_ = nullptr;
   count_ = 0;
   if (count == 0) return false;
-  // A state file shorter than the pack means a pack was replaced under it. The
-  // caller rewrites rather than reading garbage for the tail.
-  if (source.size() < count) return false;
+  // The state file is one byte per pack index, so its length and the pack's
+  // count are the same fact written twice. ANY disagreement means a pack was
+  // replaced under it; the caller rewrites rather than reading bytes that
+  // describe questions no longer at those indices.
+  //
+  // `!=`, not `<`. A LONGER file used to be accepted, on the reasoning that
+  // every index still had a byte -- but a stale FLAGGED byte landing on an
+  // arbitrary question hides it from every draw, with nothing on screen and no
+  // way for a player to clear it. That is what a pack SHRINKING does, which is
+  // what a rated pack does to the 50,000 it replaces.
+  if (source.size() != count) return false;
   source_ = &source;
   count_ = count;
   // Counted here, not lazily: without this the totals start at zero every boot

--- a/src/apps_local/trivia/TriviaCore.cpp
+++ b/src/apps_local/trivia/TriviaCore.cpp
@@ -101,8 +101,10 @@ bool Pack::read(const uint32_t index, Question& out) const {
 }
 
 // One chunked pass when the state file is opened, answering both counts. A byte
-// at a time would be 50,000 reads through the storage mutex; a 256-byte window
-// is 196 of them and the buffer is small enough for the stack.
+// at a time would be one read per question through the storage mutex; a
+// 256-byte window is a 256th of that, and the buffer is small enough for the
+// stack. No question count written down here: the pack is as big as the rating
+// run that built it.
 void PackState::scanCounts() {
   seenCount_ = 0;
   flaggedCount_ = 0;

--- a/src/apps_local/trivia/TriviaCore.h
+++ b/src/apps_local/trivia/TriviaCore.h
@@ -81,8 +81,9 @@ class Question {
   char bytes_[kMaxRecordBytes] = {};
 };
 
-// The pack file. Holds NO index in RAM: 195KB of offsets for a 50k pack is
-// memory the device does not have, so an index entry is itself a read.
+// The pack file. Holds NO index in RAM: four bytes per question plus a sentinel
+// is memory the device does not have to spare at any pack size, so an index
+// entry is itself a read.
 class Pack {
  public:
   bool open(ByteSource& source);
@@ -199,7 +200,8 @@ enum class Room : uint8_t { Ok, Unknown, TooSmall };
 // the server's Content-Length -- after the point where refusing is still free.
 // So this is a deliberate over-estimate with room for a larger pack and for the
 // FAT to record it. Raise it if the pack approaches it; never pin it to the
-// current byte count.
+// current byte count -- and do NOT lower it when a pack shrinks. The number
+// sizes by who else needs the card, not by what this download writes.
 constexpr uint64_t kPackFreeFloorBytes = 12ull * 1024 * 1024;
 
 // queryOk mirrors HalStorage::freeBytes()'s return exactly: false means the card

--- a/tools_local/trivia/difficulty_panel.tsv
+++ b/tools_local/trivia/difficulty_panel.tsv
@@ -1,0 +1,98 @@
+# A blind head-to-head, frozen so the levels can be checked against something
+# that is NOT the ratings they were cut from.
+#
+# Three judges were each shown the same 60 pairs, one question against another,
+# with the level hidden and the slot randomised, and asked which one more
+# groups of four ordinary adults in a bar would get. They never saw a rating.
+# Kept here: the pairs they all decided the same way, as (easier, harder).
+#
+# The check is then simply that the pack agrees: the question the panel called
+# easier must sit at a lower-numbered level. Shuffle the ratings across
+# questions and this collapses towards chance (measured: 34%), which is the one
+# thing every other difficulty assertion in this repo cannot see, because they
+# are all computed from the cut itself. Score it with panel_score.py.
+#
+# What it does NOT cover: the pairs are level 1 against level 5, so it proves
+# the extremes are ordered and says nothing about levels 2, 3 and 4 against each
+# other. Judges 2 and 3 differ from judge 1 only in being separate runs of the
+# same model on the same prompt -- they are a consistency check on the ratings,
+# not human testers, and no human has scored this pack.
+#
+# Regenerate with a fresh panel whenever the rating scale changes; do not edit
+# by hand to make a check pass.
+#
+# HOW THE PAIRS WERE SAMPLED, which decides what a score means. Candidates were
+# drawn as level 1 against level 5 AS THE CLOUD RATING FILE CUT THEM, and the
+# pairs kept are those the judges then decided unanimously. So the score is not
+# comparable across raters: that file is being asked about its own extremes and
+# any other rater is being asked about somebody else's.
+#
+#   the cloud ratings the pairs came from   50/50 = 100%   (0 pairs same level)
+#   the LOCAL run that builds the pack      36/50 =  72%   (5 pairs same level)
+#   the local run, raw r, cut removed       38/50 =  76%
+#   the local run, shuffled                 17/50 =  34%
+#
+# READ THAT 100% AS SAMPLING, NOT QUALITY. The cloud file is 9,597 single-judge
+# rows out of 9,617 -- only the 20 anchors carry more -- and the owner's HOLD on
+# PR #19 records a fresh judge agreeing with it at only +0.58 / +0.64 while two
+# fresh judges agree with EACH OTHER at +0.92 / +0.895. It is the noisy party.
+# The two files agree with each other at Spearman +0.34 on the 9,597 questions
+# both cover.
+#
+# So this file does not say the local rater is worse. There is no threshold here
+# that transfers to it. What survives is 50 blind pairwise verdicts that cost
+# something to make and can be re-scored against any future rater, and the shape
+# of the one difficulty check that is not computed from the ratings themselves.
+# Draw a fresh panel from the shipping rater's own extremes before using a bar.
+#
+# easier_id	harder_id	judges_agreeing	judges_voting
+0102225d5a20	44ca0bd7de5e	3	3
+02c7eded25a2	aa8229dcb157	3	3
+083bb3076234	75ee51573fa9	3	3
+1f14a3fe5fe7	7d550c2770dd	3	3
+29e0e74a1cac	60fe234097ef	3	3
+2b66d44cd845	0782bfb41b4f	3	3
+2df475e93556	05e3fd12ac82	3	3
+31028b1ebbe8	29fca0fb269e	3	3
+3804fa363ac5	2784502b7382	3	3
+3d0600982689	062165d74702	3	3
+3d878f6ac0c9	2d93c291345f	3	3
+3da38b24b1ae	42607c76f574	3	3
+434ce4be7762	4dfa6bbb00bd	3	3
+46b45c3d5af4	b70a414aa600	3	3
+4ee79d272d68	0ec5f5eda23f	3	3
+56edb9b92743	f0979a48423e	3	3
+5a2428304dbe	a3f45a515137	3	3
+6ac57a28113e	2a34ff6e8c2c	3	3
+6b38f3a2d32f	9327df622e52	3	3
+6b571a39f821	b29d1d37a529	3	3
+72e7981bd7f7	bb80186aa060	3	3
+760834aab9dc	6b6136aa17e0	3	3
+78063e5e3791	5ca77b5bfb73	3	3
+7903dd42b24f	a6905a541410	3	3
+7f6f1adee588	21642a418edf	3	3
+869acf4869c7	7e4ef6c4eaea	3	3
+904e95413669	683cd6da07a5	3	3
+9215856e5948	e0ad6eb138d4	3	3
+97e1571923b2	723a796b3612	2	3
+97f240045bf3	5f1a6da91ca5	3	3
+989fe7acfc5e	2149e596534f	3	3
+a089f0fa0111	b2c071836e58	3	3
+a0eaf27a3a42	346d29f248c0	3	3
+a2958c52d332	282a9003cea8	3	3
+a45e26730348	3da04842e1f9	1	3
+a52e8ddf3b6b	f73f467bff35	3	3
+a6a5140061ff	2e63b4f4c199	3	3
+b1aa525d55a0	fe267f816b7f	3	3
+c408f76c5bbd	7ec22fa04762	3	3
+c430e4ba70e3	348e03089b68	3	3
+c7c1ec6e0d0a	0492f816687f	3	3
+c8b2996eb658	1b9d5f160a4b	3	3
+cdc88c08a22f	7f78a8a9ec9b	3	3
+d3be24344b50	05ef347df277	3	3
+d54fa2978bff	098bfc34cb6f	3	3
+d6b5b76f7d96	7d8036486e4a	3	3
+ee2535f3925d	1935ca72c841	3	3
+f06e61a7cadf	0d81b95cbb6f	3	3
+fabef47f3426	eaaf00206b83	3	3
+fffef0a4a9f7	758dc6919e57	3	3

--- a/tools_local/trivia/pack_format.py
+++ b/tools_local/trivia/pack_format.py
@@ -5,7 +5,7 @@ Shape follows docs/apps/study-deck-format.md -- immutable content with an
 offset index and a trailing sentinel, mutable state in a separate fixed-width
 file. The C++ reader mirrors this; this module is the spec that proves it.
 """
-import struct
+import struct, sys
 
 MAGIC = b'XTRIVIA\0'
 VERSION = 1
@@ -96,3 +96,40 @@ def get_flag(path, i):
         f.seek(i)
         b = f.read(1)
     return b[0] if b else 0
+
+
+# --- reading a pack back out --------------------------------------------------
+# A pack.dat is the only copy of a corpus once the season TSVs are gone, and
+# they are gone: build_pack.py --src wants a 544k-row Jeopardy TSV that is not
+# in this repo and not on this machine. Without this the published
+# 50,000-question release asset is a dead end -- readable by the device and by
+# nothing else.
+#
+#     python3 tools_local/trivia/pack_format.py pack.dat > corpus.jsonl
+#
+# WHAT COMES BACK IS NOT A JOIN KEY. The .dat format carries no id field, so the
+# id here is RE-DERIVED from the clue text, and re-deriving is the one thing
+# assemble_pack.py's rule 1 forbids: 349 rows of corpus_repaired.jsonl carry
+# pre-repair ids beside post-repair clue text, and a re-derived id misses their
+# ratings silently -- no error, a slightly smaller pack. So use .rate's
+# corpus_repaired.jsonl as --corpus whenever it exists, and treat this output as
+# the fallback for when it does not.
+#
+# Also absent, because the .dat never carried them: the generality score `g` and
+# the event tag `ev`.
+def dump(path, out):
+    import hashlib, json, re
+    pack = open_pack(path)
+    for i in range(pack['count']):
+        item = read_one(pack, i)
+        key = re.sub(r'[^a-z0-9]', '', item['q'].lower())
+        item['id'] = hashlib.sha1(key.encode()).hexdigest()[:12]
+        out.write(json.dumps(item, ensure_ascii=False, separators=(',', ':')) + '\n')
+    return pack['count']
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        sys.exit("usage: pack_format.py <pack.dat>   (writes jsonl to stdout)")
+    n = dump(sys.argv[1], sys.stdout)
+    print(f"{n:,} questions; ids are RE-DERIVED, see the note above", file=sys.stderr)

--- a/tools_local/trivia/panel_score.py
+++ b/tools_local/trivia/panel_score.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Score a rating file against the frozen blind panel.
+
+    python3 tools_local/trivia/panel_score.py <ratings>
+
+<ratings> is either enriched.jsonl (objects carrying `id` and `r`) or a
+two-column TSV of `id<TAB>rating`, so it reads the rating run's own output and
+the committed snapshot in local/ without a conversion step.
+
+WHY THIS EXISTS. Every other difficulty assertion in this repo is computed from
+`r`, and `d` is CUT from `r` by assemble_pack.level -- so monotone means, a wide
+1-to-5 gap and a stocked tier are arithmetic, not evidence. Shuffle the ratings
+across questions and all of them still pass, byte for byte. difficulty_panel.tsv
+is 50 pairs decided by judges who never saw a rating, as (easier, harder), and
+re-scoring them against the current levels is the only thing here that a wrong
+rating can fail.
+
+THE SCORE IS NOT COMPARABLE ACROSS RATERS, and this is the trap. The pairs in
+difficulty_panel.tsv were SELECTED from the extremes of one rating file -- level
+1 against level 5 as that file cut them -- and only pairs three blind judges
+then decided unanimously were kept. So the file the pairs were drawn from scores
+50/50 = 100% partly by construction, and any other rater is being asked about
+somebody else's extremes. There is no threshold here that transfers. Draw a
+fresh panel from the extremes of the rater you are shipping before treating any
+number as a bar.
+
+WHAT IT STILL MEASURES. The judges never saw a rating, so their verdicts are
+independent of the cut even though the sampling was not. Against a ratings file
+shuffled across questions the score collapses (measured: 34%), which no other
+difficulty assertion in this repo does -- they are all computed from `r`.
+
+NO PASS AND NO FAIL, and it exits 0. A verdict here would be a verdict against a
+bar that does not transfer, and a gate that says FAIL for a structural reason
+teaches people to ignore it. It prints numbers; the reading is the runbook's
+(docs/trivia-curation.md) and it is not in check.sh.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import assemble_pack
+
+# What a ratings file shuffled across these questions scores, measured. It is
+# the only reference point here that does not depend on which rater the pairs
+# were sampled from, so it is printed rather than a bar.
+SHUFFLED_BASELINE = 34.0
+
+
+def load_ratings(path):
+    """id -> r, from enriched jsonl or a two-column tsv."""
+    out = {}
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line[0] == "{":
+            try:
+                o = json.loads(line)
+            except ValueError:
+                continue
+            if "id" in o and "r" in o:
+                out[o["id"]] = float(o["r"])
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        try:
+            out[parts[0].strip()] = float(parts[1])
+        except ValueError:
+            continue
+    return out
+
+
+def load_pairs(path):
+    pairs = []
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            pairs.append((parts[0], parts[1]))
+    return pairs
+
+
+def main(argv):
+    if len(argv) != 2:
+        sys.exit(__doc__.strip().splitlines()[2].strip())
+    here = os.path.dirname(os.path.abspath(__file__))
+    pairs = load_pairs(os.path.join(here, "difficulty_panel.tsv"))
+    ratings = load_ratings(argv[1])
+    print(f"{len(pairs)} panel pairs; {len(ratings):,} ratings in {argv[1]}")
+
+    known = [(a, b) for a, b in pairs if a in ratings and b in ratings]
+    missing = len(pairs) - len(known)
+    if missing:
+        # Not a soft warning: a pair whose questions have lost their ratings is
+        # silently dropped from the denominator, which raises the score.
+        print(f"  !! {missing} of {len(pairs)} pairs have lost a rating and were "
+              f"NOT scored -- regenerate the panel rather than reading the rest")
+    if not known:
+        print("  !! nothing to score")
+        return 1
+
+    lv = {q: assemble_pack.level(r) for q, r in ratings.items()}
+    agree = sum(1 for a, b in known if lv[a] < lv[b])
+    same = sum(1 for a, b in known if lv[a] == lv[b])
+    rate = 100.0 * agree / len(known)
+
+    # The same question asked without the cut in the way, so a bad score can be
+    # read as "the thresholds are wrong" or "the ratings are wrong" rather than
+    # leaving the two confounded. r is 0-10 with HIGH meaning EASY.
+    raw = sum(1 for a, b in known if ratings[a] > ratings[b])
+    ties = sum(1 for a, b in known if ratings[a] == ratings[b])
+
+    print(f"  levels agree with the panel : {agree}/{len(known)} = {rate:.1f}%"
+          f"   ({same} pairs landed on the SAME level and decide nothing)")
+    print(f"  raw ratings, cut removed    : {raw}/{len(known)} = "
+          f"{100.0 * raw / len(known):.1f}%   ({ties} ties)")
+    print(f"\n  for reference, these ratings shuffled across questions: "
+          f"~{SHUFFLED_BASELINE:.0f}%")
+    print("\nNO VERDICT, on purpose. The pairs were sampled from the extremes of ONE\n"
+          "rating file, so that file scores near 100% partly by construction and no\n"
+          "threshold here carries over to a different rater. Draw a fresh panel from\n"
+          "the rater you are shipping before treating any number as a bar. See\n"
+          "docs/trivia-curation.md, 'The levels against a blind panel'.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
**Rebased down.** This PR opened as five commits and 10,718 lines; #58 and #64
landed under it during the day and made most of that dead. What is left is five
commits and about 450 lines. Old tip, still reachable on GitHub by sha:
`50c4bd810fdcec45867633e21416b840e0e86c6b`.

Your HOLD stands: this no longer contains a pack, ratings or a rating tool, so
there is nothing left in it for the ratings to block.

## The reason it is not just closed

`pack.state` is one byte per pack index, and `TriviaActivity::ensureState` /
`PackState::open` rewrote it only when it was **shorter** than the pack. A
longer one was accepted, so its bytes were reapplied to questions no longer at
those indices. A stale `FLAGGED` byte hides a question from every draw with
nothing on screen and no way for a player to clear it.

**That is reachable the moment `assemble_pack.py`'s pack ships**, and it is not
theoretical: assembling one here from the live run's own output gives **25,866
questions against the shipped 50,000**. The device's OTA replaces `pack.dat` and
never fetches a state file, so this comparison is the only thing carrying a
device across the rebuild.

**The finished pack will miss by a handful, not by thousands**, which is the
worse version. The run's worklist is `rest40383.ids` plus the 9,617 already
rated — the whole 50,000 corpus — so at completion the only absentees are the
questions `assemble_pack.py` rejects as unanswerable, 9 of the first 25,875. A
~49,98x pack against a 50,000-byte state file is a misalignment nothing on
screen can show. (I had this as "roughly 40,000" first, from the filename
instead of the worklist.)

Fixed at both ends, because they do different jobs, and the boundary fix alone
would be worse than nothing (a shrinking pack would refuse to open rather than
serve stale flags). `testState()` had built a 10-byte state over a 50-question
pack and asserted rejection, and never built a 90-byte one; the longer case had
no coverage at all. Added and **watched failing** against the unfixed reader
(`FAIL test_trivia.cpp:240`, 1 of 117,896), then the `!=` reverted to `<` alone
with `git diff --stat` non-empty so a no-op could not read as a pass, red on the
same line, restored green.

## What was dropped, and why

| dropped | superseded by |
| --- | --- |
| `difficulty.tsv`, 9,617 cloud ratings | the local run; the committed local file says in its own header it is **not the same scale** |
| `difficulty.py`, thresholds 6.5/4.5/3.0/1.5 | `assemble_pack.level`, 9/7/5/3, on the rater whose numbers actually build the pack |
| `rate_pack.py`, sheets and anchors | `rate_local.py` and the local run |
| `build_pack.py --ratings` / `--from-pack` | `assemble_pack.py`. It also made `--src` hard-fail without ratings, which would break the TSV path #58 deliberately kept |
| its three `build_pack.py` bug fixes (idempotent verdict pins, `--out` overwriting `--from-pack`, `--limit` with no score) | not live on `xteink`: all three are reachable only through `--from-pack`, which is this PR's own feature |
| most of `test_difficulty.py` (the cut, the ratings file, the build wiring) | `test_assemble.py::test_levels` |
| the rebuilt pack and every count derived from it | Mario's hold: the pack ships from the finished run |

Two more were checked rather than assumed, and **both went the other way from
what the PR argued**:

- **`test_pack.py`'s `hi <= lo * 2.5` spread check.** This PR replaced it as "the
  wrong invariant for absolute tiers". On a pack assembled from the live run it
  **passes**, along with all 21 checks: the local rater's levels come out roughly
  even (3,767 / 6,852 / 5,149 / 4,205 / 5,893) where the cloud rater's did not.
  The motivating failure no longer exists. Not carried over.
- **The level-skewed solo share** this PR filed in `open-items.md` as new and
  open (18% at level 1 against 42% at level 5). Measured on the assembled pack:
  **73.7 / 82.5 / 74.0 / 72.7 / 76.8 %** — flat. It was a property of the
  rule-based option picker on a cloud-rated slice, not of the levels. Retired,
  and the surrounding figure qualified rather than left reading as current.

## What was kept

- **The state-file fix**, above.
- **`difficulty_panel.tsv` + `panel_score.py`.** 50 pairs three blind judges
  unanimously called (easier, harder). Every difficulty assertion on `xteink`
  today is computed from `r` and `d` is cut from `r`, so a stocked tier and a
  monotone mean are arithmetic — shuffle the ratings and they all still pass.
  This drops to 34%. Kept for the verdicts and the shape, **not as a bar**; see
  below.
- **`pack_format.py` read-back.** The season TSVs `--src` wants are not in this
  repo and not on this machine, so a published `pack.dat` is the only surviving
  copy of its corpus. Its id is RE-DERIVED, which is exactly what #58's rule 1
  forbids as a join key, and the comment says so at length.
- **The comment de-numbering.** Three source comments still said 50,000 or
  sized themselves by it. Correcting the docs and leaving those is how a file
  ends up describing a pack that no longer exists, which is what this branch is
  about. `kPackFreeFloorBytes` gains the missing half of its rule: it is not
  LOWERED when a pack shrinks either. **Not** carried: #19's `kMaxRecordBytes`
  re-measurement (348 bytes, 1 alternate) — measured on a pack that will not
  ship, so it would be a fresher wrong number rather than a right one. **Not**
  carried: its clang-format churn, which is the clang-format-22-vs-21 split.
- **The doc corrections**, below.

## Merging `origin/xteink` — one conflict, and a worse thing git did not flag

`docs/trivia-curation.md`, one hunk: an alternate-answer count, 1,080 (this
PR's rebuilt pack) against 5,507 (the shipped one). Not resolved, because the
commit it came from is dropped.

`check.sh` **auto-merged correctly** — this PR's loop and #58's separate
`test_assemble` block both survive; grepped rather than assumed.

The thing worth reporting is what merged **cleanly and should not have**: the
result carried this PR's `## Layer 1b` (cloud sheets, `/tmp/rate/raw`) *and*
#58's `## Building the pack from a local rating run`, with a `build_pack.py
--ratings difficulty.tsv` recipe sitting directly above a runbook telling you to
use `assemble_pack.py`. Two pipelines, no conflict marker. That is the reason
this is rebuilt on `xteink` rather than merged.

## The docs, which had a real gap nobody had filled

#58 and #64 rewrote `docs/trivia-curation.md` and left the two app docs alone,
so `docs/apps/trivia-pack-format.md` still opened a section **"Difficulty is
derived, not stored upstream"** — the wrong claim, not a stale one — and
`docs/apps/trivia.md` still said **"50,000 questions on the card"**. Both now
say which of the two builders wrote a pack's `d` and that the format byte cannot
tell them apart. `pack.state`'s length rule is written down for the first time.

## Your HOLD, and what it does to the panel

Your comment on this PR says the ratings behind it do not reproduce and that
`difficulty.tsv` is single-judge, not three-judge. **Verified here rather than
relayed** — `awk` over its judges column: **9,597 of 9,617 rows are
single-judge**, only the 20 anchors carry more. This PR's description was wrong
about that, and the file is gone either way.

It also changes how the panel's numbers read, and I had them framed wrong in a
first draft of this branch:

| ratings | panel agreement |
| --- | --- |
| the cloud judge's, **which the pairs were sampled from** | 50/50 = 100% |
| the LOCAL run, which builds the shipping pack | 36/50 = 72% |
| the local run, raw `r`, thresholds removed | 38/50 = 76% |
| the local run, shuffled across questions | 17/50 = 34% |

Candidates were sampled as level 1 against level 5 **as the cloud file cut
them**, so that file is scored on its own extremes and every other rater on
somebody else's. The 100% is sampling, not quality — and given your +0.58/+0.64
reproduction figure it cannot be quality. **The 72% is therefore not a verdict
on the local rater and I am not presenting it as one.** No threshold on this
panel transfers.

The two files agree with each other at **Spearman +0.34** on the 9,597 questions
both cover, and their scales differ (`local_difficulty_intl.tsv` says so in its
own header), so their means are not comparable either — the "2.2 points soft"
finding does not carry over to the local run in either direction.

So `panel_score.py` prints **no verdict and exits 0**, and is not in `check.sh`.
**To use the panel as a bar, a fresh one has to be drawn from the shipping
rater's own extremes** — that is the actionable item this leaves, and it is
cheap: the scorer already takes the run's `enriched.jsonl` directly.

## Verification

- `./scripts_local/check.sh --committed --tests` on this exact HEAD:
  `verifying HEAD (936fd124) in a throwaway worktree` … **`all green`**, exit 0,
  no `FAILED`, no `SKIPPED`, no withheld verdict. (`--tests --committed` in that
  order is silently a working-tree run — the flag is only read as `$1`.)
- `host-tests/trivia/run.sh`: 117,896 + 4,804 checks, 0 failed.
- A pack really assembled from the live run's output into a scratch directory:
  25,866 questions, 3.39 MB `pack.dat`, `test_pack.py` **21 of 21**, `pack.state`
  25,866 bytes.
- `panel_score.py` exercised on four inputs (live run, cloud ratings, a shuffled
  copy, and a ratings file missing the panel's questions — the last reports the
  missing pairs rather than dropping them from the denominator, which would have
  raised the score).
- **The rating job was untouched:** nothing written in `wt/localrate`, the local
  model never called, PID 7404 alive and advancing throughout.

## Not verified

- **No device build and no hardware.** The state-file fix is host-tested at
  `PackState::open`; `TriviaActivity::ensureState` is not host-compiled, so its
  half is read, not exercised. It is the same comparison at the same width
  against the same two values.
- **The shrink has not been played through on a device**: no unit was given the
  50,000 pack, played, then handed a smaller one.
- The assembled pack uses 25,875 of the 50,000 the run will cover, since it is
  mid-flight. The completed pack has not been built or gated by anyone yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
