### PR TITLE
heartbeat: the device makes no request of its own for reporting

### DIFF
--- a/src/network/Heartbeat.cpp
+++ b/src/network/Heartbeat.cpp
@@ -453,6 +453,11 @@ void begin(const bool rebootedFromPanic, const bool panicReasonRecorded) {
 
 void update() {
   if (!loaded) return;
+  // Nothing is posted from here. A device must never spend its radio on
+  // reporting (Mario, 2026-09-04): device info rides on the requests the
+  // device already makes to CrossPlay's own services, and those services post
+  // the events. This module only records until that rework replaces it.
+  return;
   const bool on = SETTINGS.heartbeat != 0;
   if (on != lastEnabled) {
     lastEnabled = on;


### PR DESCRIPTION
Stopgap so no release carries the daily heartbeat request. Mario decided a device must never spend its radio on reporting; the rework (device id, board and pending crash or update report as headers on requests the device already makes to CrossPlay's own services) follows in its own PR. Until then `heartbeat::update()` returns before posting anything; the module still records locally.

Verified: builds through CI here; the host suite for HeartbeatCore is untouched. Not verified: hardware, as always.

🤖 Generated with [Claude Code](https://claude.com/claude-code)