### PR TITLE
site: the report box is a dialog behind a corner button, not a page

### DIFF
--- a/host-tests/site/aria_roles.py
+++ b/host-tests/site/aria_roles.py
@@ -25,9 +25,14 @@ is what gets counted here -- per container and by real nesting, because a
 file-level count would pass a page holding one honest tablist and one leftover.
 
 The table is deliberately short. Both rows are exercised by markup on this site
-(study had the tablist, report has two radiogroups), so neither is a rule
+(study had the tablist, the report form has a radiogroup), so neither is a rule
 nobody has ever seen run. Add a row when a page grows a new composite, not
 before.
+
+The report form is not in any .html file: assets/report.js draws it from a
+template literal into the front page's dialog and into /report/. A sweep of
+.html alone would have quietly stopped checking the one form this site has, so
+the backtick literals in that script are parsed as markup too.
 
 Children are counted by their EFFECTIVE role, implicit included: an
 <input type="radio"> is a radio to every screen reader without saying so, and a
@@ -42,6 +47,7 @@ lines and checks the exit status.
 
 import html.parser
 import pathlib
+import re
 import sys
 
 # A role that promises siblings -> the role those siblings carry, and how many
@@ -153,11 +159,27 @@ class Roles(html.parser.HTMLParser):
             )
 
 
+# Scripts that carry markup in template literals. Listed, not discovered: the
+# vendored bundles under site/assets hold backticks that are not HTML, and a
+# parse of those would be noise passing as coverage.
+TEMPLATED = ["site/assets/report.js"]
+
+
 def pages(root):
     for page in sorted(root.glob("site/**/*.html")):
         if any(part in SKIP for part in page.relative_to(root).parts):
             continue
-        yield page
+        yield page, page.read_text()
+    for name in TEMPLATED:
+        script = root / name
+        if not script.exists():
+            print(f"{name} is listed as carrying markup and does not exist")
+            continue
+        literals = re.findall(r"`([^`]*)`", script.read_text())
+        if not literals:
+            print(f"{name} is listed as carrying markup and has no template literal")
+            continue
+        yield script, "\n".join(literals)
 
 
 def main():
@@ -166,10 +188,10 @@ def main():
     root = pathlib.Path(sys.argv[1])
 
     seen = 0
-    for page in pages(root):
+    for page, text in pages(root):
         seen += 1
         parser = Roles()
-        parser.feed(page.read_text())
+        parser.feed(text)
         parser.finish()
         rel = page.relative_to(root)
         for finding in parser.findings:

--- a/host-tests/site/report_fn.js
+++ b/host-tests/site/report_fn.js
@@ -178,20 +178,80 @@ const expect = (label, got, want) =>
   expect("a version that is not three numbers is refused", r.status, 400);
   r = await call("POST", Object.assign({}, good, { email: "not an email" }));
   expect("a bad email is refused", r.status, 400);
-  r = await call(
-    "POST",
-    Object.assign({}, good, { kind: "idea", device: "toaster" }),
-  );
+
   calls = [];
-  r = await call(
-    "POST",
-    Object.assign({}, good, { kind: "idea", device: "toaster" }),
-  );
+  r = await call("POST", Object.assign({}, good, { kind: "idea" }));
   const row2 = JSON.parse(
     calls.find((c) => c.url.endsWith("/rest/v1/cards?select=id")).body,
   );
   expect("an idea is a feature card", row2.kind, "feature");
-  expect("an unknown device is 'unknown'", row2.device, "unknown");
+  const ev1 = calls.find(
+    (c) => c.url.endsWith("/rest/v1/events") && c.method === "POST",
+  );
+  expect(
+    "one device is the event's board",
+    ev1 ? JSON.parse(ev1.body).board : null,
+    "x4pro",
+  );
+
+  // The device: one or both of the two boards, nothing else, never none.
+  calls = [];
+  r = await call(
+    "POST",
+    Object.assign({}, good, { device: " Sticky , x4pro " }),
+  );
+  expect("both devices are accepted", r.status, 201);
+  const row3 = JSON.parse(
+    calls.find((c) => c.url.endsWith("/rest/v1/cards?select=id")).body,
+  );
+  expect(
+    "and stored comma-joined in a fixed order, whatever order they came in",
+    row3.device,
+    "x4pro,sticky",
+  );
+  const hist = calls.find(
+    (c) => c.url.endsWith("/rest/v1/history") && c.method === "POST",
+  );
+  expect(
+    "the history line names both",
+    hist ? JSON.parse(hist.body).what : null,
+    "reported from the site (bug, x4pro and sticky)",
+  );
+  const ev2 = calls.find(
+    (c) => c.url.endsWith("/rest/v1/events") && c.method === "POST",
+  );
+  expect(
+    "the event leaves board empty for two boards",
+    ev2 ? JSON.parse(ev2.body).board : "missing",
+    null,
+  );
+  expect(
+    "and lists them in props instead",
+    ev2 ? JSON.parse(ev2.body).props.devices.join(",") : null,
+    "x4pro,sticky",
+  );
+
+  calls = [];
+  r = await call("POST", Object.assign({}, good, { device: "sticky" }));
+  expect("the Sticky alone is accepted", r.status, 201);
+  expect(
+    "and stored as itself",
+    JSON.parse(
+      calls.find((c) => c.url.endsWith("/rest/v1/cards?select=id")).body,
+    ).device,
+    "sticky",
+  );
+
+  for (const wrong of ["", ",", "unknown", "toaster", "x4pro,toaster"]) {
+    calls = [];
+    r = await call("POST", Object.assign({}, good, { device: wrong }));
+    expect(`device ${JSON.stringify(wrong)} is refused`, r.status, 400);
+    expect("and stores nothing", calls.length, 0);
+  }
+  calls = [];
+  r = await call("POST", { kind: "bug", what: good.what });
+  expect("a report with no device at all is refused", r.status, 400);
+  expect("and stores nothing", calls.length, 0);
 
   recent = 10;
   r = await call("POST", good);

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -201,18 +201,76 @@ else
   while IFS= read -r line; do echo "      $line"; done <<< "$report_out"
 fi
 
-# Each of the two new pages looks its controls up by id inside its own file.
-# Same failure as install.js: a renamed id renders fine and does nothing.
-for page in report inbox; do
-  P="$ROOT/site/$page/index.html"
-  [ -f "$P" ] || { bad "site/$page/index.html is missing"; continue; }
+# The inbox page looks its controls up by id inside its own file. Same failure
+# as install.js: a renamed id renders fine and does nothing.
+P="$ROOT/site/inbox/index.html"
+if [ -f "$P" ]; then
   page_ids="$(sed -nE 's/.*\$\(["'"'"']([A-Za-z-]+)["'"'"']\).*/\1/p' "$P" | sort -u)"
-  [ -n "$page_ids" ] || { bad "site/$page/index.html looks up no element ids"; continue; }
+  [ -n "$page_ids" ] || bad "site/inbox/index.html looks up no element ids"
   for id in $page_ids; do
     case "$id" in inbox-answer|inbox-send|inbox-default|inbox-how|inbox-later) continue;; esac  # rendered by script
-    grep -q "id=\"$id\"" "$P" && ok || bad "site/$page/index.html asks for #$id and has no such element"
+    grep -q "id=\"$id\"" "$P" && ok || bad "site/inbox/index.html asks for #$id and has no such element"
   done
+else
+  bad "site/inbox/index.html is missing"
+fi
+
+# -- the report form, one script drawn into two pages --------------------------
+#
+# assets/report.js draws the form into whichever page carries a mount point and
+# then finds every control by id. Those ids live in two places: the markup the
+# script renders itself, and index.html for the dialog and the button that
+# opens it. An id in neither is a control that renders fine and does nothing --
+# and on the front page, a button in the corner that opens nothing.
+REPORTJS="$ROOT/site/assets/report.js"
+REPORTCSS="$ROOT/site/assets/report.css"
+REPORTPAGE="$ROOT/site/report/index.html"
+for f in "$REPORTJS" "$REPORTCSS" "$REPORTPAGE"; do
+  [ -f "$f" ] || { echo "FAIL site  missing $f"; exit 1; }
 done
+report_ids="$(sed -nE 's/.*\$\(["'"'"']([A-Za-z-]+)["'"'"']\).*/\1/p' "$REPORTJS" | sort -u)"
+if [ -z "$report_ids" ]; then
+  bad "report.js looks up no element ids at all"
+else
+  ok
+  for id in $report_ids; do
+    if grep -q "id=\"$id\"" "$REPORTJS" || grep -q "id=\"$id\"" "$HTML"; then
+      ok
+    else
+      bad "report.js asks for #$id and neither its own markup nor index.html has such an element"
+    fi
+  done
+fi
+# The dialog and its close button are index.html's to provide, and the script
+# must be asking for them under those names, or the front page has a dead
+# button. The opener is found by attribute, not id, so that the prose link and
+# the corner button can both open it; the attribute is what has to agree.
+for id in report-dialog report-close; do
+  grep -q "id=\"$id\"" "$HTML" && ok || bad "index.html has no #$id"
+  printf '%s\n' "$report_ids" | grep -qx "$id" && ok || bad "report.js never looks up #$id, so index.html's is decoration"
+done
+grep -q '<dialog[^>]*id="report-dialog"' "$HTML" && ok || bad "#report-dialog in index.html is not a <dialog>"
+grep -q 'id="report-open"' "$HTML" && ok || bad "index.html has no #report-open button"
+grep -q 'id="report-open"[^>]*data-report-open' "$HTML" && ok || bad "#report-open does not carry data-report-open, so report.js will not wire it"
+grep -q '\[data-report-open\]' "$REPORTJS" && ok || bad "report.js never looks for [data-report-open], so nothing opens the dialog"
+# Both pages mount the form and load the script and its stylesheet.
+for p in "$HTML" "$REPORTPAGE"; do
+  rel="${p#"$ROOT"/}"
+  grep -q 'data-report-mount' "$p" && ok || bad "$rel has nowhere to mount the report form"
+  grep -qE 'src="/?assets/report\.js"' "$p" && ok || bad "$rel does not load assets/report.js"
+  grep -qE 'href="/?assets/report\.css"' "$p" && ok || bad "$rel does not load assets/report.css"
+done
+# The standalone page has no script of its own: one implementation, not two.
+grep -q '\$(' "$REPORTPAGE" && bad "report/index.html looks up ids itself; the form lives in assets/report.js" || ok
+grep -q '<form' "$REPORTPAGE" && bad "report/index.html carries its own <form>; the form lives in assets/report.js" || ok
+# The devices the form offers are exactly the ones the function accepts, and
+# neither side offers "not sure": a report names a board or is refused.
+form_devices="$(grep -oE 'name="device" value="[a-z0-9]+"' "$REPORTJS" | sed -E 's/.*value="//; s/"//' | sort -u | tr '\n' ' ')"
+api_devices="$(grep -oE 'DEVICES = \[[^]]*\]' "$ROOT/site/api/report.js" | grep -oE '"[a-z0-9]+"' | tr -d '"' | sort -u | tr '\n' ' ')"
+[ -n "$form_devices" ] && ok || bad "report.js offers no device to pick"
+[ "$form_devices" = "$api_devices" ] && ok || bad "report.js offers devices [$form_devices] and api/report.js accepts [$api_devices]"
+printf '%s' "$api_devices" | grep -qw unknown && bad "api/report.js accepts 'unknown' as a device again; a report names a board or is refused" || ok
+grep -qE 'type="radio" name="device"' "$REPORTJS" && bad "device is a radio again; it is two checkboxes, both allowed" || ok
 
 # -- the study installer's ids, spelled in two files that never see each other -
 #

--- a/site/api/report.js
+++ b/site/api/report.js
@@ -12,6 +12,13 @@
 // ten reports an hour, counted against a salted hash of the address so the
 // address itself is never stored.
 //
+// `device` names one or both of the two boards the fork runs on, comma-joined
+// ("x4pro", "sticky", "x4pro,sticky"). There is no "not sure": a person
+// reporting from a device knows which one they hold, and a report naming
+// neither is refused rather than filed under a value nobody can act on. The
+// card keeps the joined string, in a fixed order, so two reports about both
+// boards read the same.
+//
 // The photo comes in a second request because a buffered Vercel request body
 // is capped at 4.5MB and a phone photo is bigger than that until the page
 // resizes it. The page sends the report first, gets its id, then the photo.
@@ -34,7 +41,7 @@ const PHOTO_TYPES = {
   "image/png": "png",
   "image/webp": "webp",
 };
-const DEVICES = new Set(["x4pro", "sticky", "unknown"]);
+const DEVICES = ["x4pro", "sticky"];
 const VERSION = /^v?\d{1,3}\.\d{1,3}\.\d{1,3}$/;
 const EMAIL = /^[^\s@]{1,64}@[^\s@]{1,190}$/;
 
@@ -98,6 +105,22 @@ function clean(s, max) {
     .slice(0, max);
 }
 
+// "x4pro", "sticky" or both, in any order and any case, with stray spaces.
+// Returns the devices in DEVICES order, or null when the value names anything
+// else or nothing at all.
+function parseDevices(raw) {
+  const picked = new Set(
+    clean(raw, 40)
+      .toLowerCase()
+      .split(",")
+      .map((d) => d.trim())
+      .filter(Boolean),
+  );
+  if (!picked.size) return null;
+  for (const d of picked) if (!DEVICES.includes(d)) return null;
+  return DEVICES.filter((d) => picked.has(d));
+}
+
 async function recentCount(hash) {
   const since = new Date(Date.now() - 3600 * 1000).toISOString();
   const r = await rest(
@@ -135,7 +158,12 @@ async function createReport(req, res) {
   if (what.length < MIN_WHAT)
     return json(res, 400, { error: "Say a little more about what happened." });
   const kind = body.kind === "idea" ? "feature" : "bug";
-  const device = DEVICES.has(body.device) ? body.device : "unknown";
+  const devices = parseDevices(body.device);
+  if (!devices)
+    return json(res, 400, {
+      error: "Which device? Pick X4 Pro, Sticky or both.",
+    });
+  const device = devices.join(",");
   const version = clean(body.version, 16);
   if (version && !VERSION.test(version))
     return json(res, 400, {
@@ -192,11 +220,13 @@ async function createReport(req, res) {
     headers: { Prefer: "return=minimal" },
     body: JSON.stringify({
       card_id: id,
-      what: `reported from the site (${kind}, ${device})`,
+      what: `reported from the site (${kind}, ${devices.join(" and ")})`,
     }),
   });
   // The report is also an event, so the Numbers page counts reports next to
-  // installs and heartbeats. A failed count must not fail the report.
+  // installs and heartbeats. A failed count must not fail the report. The
+  // board column holds one board; a report about both leaves it empty and
+  // says so in props, rather than inventing a third value for that column.
   await rest("events", {
     method: "POST",
     headers: { Prefer: "return=minimal" },
@@ -204,8 +234,8 @@ async function createReport(req, res) {
       service: "site",
       event: "report",
       version: version || null,
-      board: device === "unknown" ? null : device,
-      props: { card: id, kind },
+      board: devices.length === 1 ? devices[0] : null,
+      props: { card: id, kind, devices },
     }),
   }).catch(() => null);
   return json(res, 201, { id });

--- a/site/assets/report.css
+++ b/site/assets/report.css
@@ -1,0 +1,376 @@
+/* The report box: the form assets/report.js draws, the dialog it lives in on
+ * the front page, the round button that opens it, and /report/ as a page.
+ * Tokens (--ink, --paper, --edge, the type stacks) come from styles.css, which
+ * every page that loads this one loads first.
+ *
+ * Everything here is prefixed report- because the same file lands on the front
+ * page, where styles.css already owns .btn and friends and a shared name would
+ * be a fight over which page wins.
+ */
+
+/* --- the button in the corner ---------------------------------------------
+ * Fixed, bottom right, on top of the page. Ink on paper with a ring of paper
+ * around it, so it separates from the black bands it scrolls over in either
+ * theme. Above the top bar (50); below the emulator's full-screen stage
+ * (200), and hidden outright while that stage is up, because the one thing a
+ * person playing full screen must not tap by accident is a form.
+ */
+.report-fab {
+  position: fixed;
+  right: calc(1rem + env(safe-area-inset-right));
+  bottom: calc(1rem + env(safe-area-inset-bottom));
+  z-index: 60;
+  width: 3.4rem;
+  height: 3.4rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--ink);
+  color: var(--paper);
+  box-shadow:
+    0 0 0 3px var(--paper),
+    0 4px 14px rgba(0, 0, 0, 0.28);
+  text-decoration: none;
+  transition: transform 0.08s ease;
+}
+.report-fab svg {
+  width: 1.6rem;
+  height: 1.6rem;
+  display: block;
+}
+.report-fab:hover {
+  transform: translateY(-2px);
+}
+.report-fab:focus-visible {
+  outline: 3px solid var(--ink);
+  outline-offset: 4px;
+}
+html.immersive .report-fab {
+  display: none;
+}
+
+/* --- the dialog -----------------------------------------------------------
+ * A centred card of about 480px on a desk; the whole bottom of the screen on
+ * a phone. The dialog itself has no padding and never scrolls: the sheet
+ * inside it does both, so a click that lands on the dialog element is a click
+ * on the backdrop and nothing else, which is what closes it.
+ */
+.report-dialog {
+  padding: 0;
+  border: 3px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  width: min(30rem, calc(100vw - 2rem));
+  max-width: none;
+  max-height: none;
+  overflow: visible;
+}
+.report-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.55);
+}
+.report-sheet {
+  max-height: calc(100vh - 2rem - 6px);
+  max-height: calc(100dvh - 2rem - 6px);
+  overflow: auto;
+  padding: 1.4rem 1.5rem 1.5rem;
+}
+html.report-open {
+  overflow: hidden;
+}
+
+.report-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0 0 1.1rem;
+}
+.report-title {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 2rem;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  margin: 0 0 0.3rem;
+}
+.report-lead {
+  font-family: var(--serif);
+  font-size: 1.15rem;
+  line-height: 1.3;
+  color: var(--muted);
+  margin: 0;
+}
+.report-close {
+  flex: none;
+  width: 2.2rem;
+  height: 2.2rem;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border: 2px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  font: inherit;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+/* --- the form -------------------------------------------------------------- */
+.report-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 1.25rem;
+}
+/* The two choices share a row. Halves put "An idea" under "Something broke";
+ * the left column takes what its chips need and the device chips, which are
+ * shorter, get the rest. */
+.report-choices {
+  grid-template-columns: max-content minmax(0, 1fr);
+}
+.report-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin: 0 0 1.1rem;
+  min-width: 0;
+}
+.report-label {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.report-label small {
+  font-size: inherit;
+  letter-spacing: 0;
+  text-transform: none;
+}
+.report-hint {
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--muted);
+  margin: 0;
+}
+.report-form textarea,
+.report-form input[type="text"],
+.report-form input[type="email"] {
+  font: inherit;
+  font-size: 1rem;
+  color: var(--ink);
+  background: var(--paper-2);
+  border: 2px solid var(--edge);
+  border-radius: 0;
+  padding: 0.65rem 0.75rem;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+.report-form textarea {
+  min-height: 7.5rem;
+  line-height: 1.45;
+  resize: vertical;
+}
+.report-form textarea:focus,
+.report-form input:focus {
+  outline: 3px solid var(--ink);
+  outline-offset: 1px;
+  border-color: var(--ink);
+}
+
+/* Choices are chips: the input stays in the document, invisible and on top
+ * of its own label, so it is still focusable and clickable; the span is what
+ * you see. */
+.report-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+.report-chips label {
+  position: relative;
+}
+.report-chips input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.report-chips span {
+  display: inline-block;
+  padding: 0.45rem 0.8rem;
+  border: 2px solid var(--edge);
+  font-size: 0.95rem;
+  line-height: 1.2;
+  cursor: pointer;
+  user-select: none;
+}
+.report-chips input:checked + span {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+.report-chips input:focus-visible + span {
+  outline: 3px solid var(--ink);
+  outline-offset: 2px;
+}
+
+.report-photo {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+.report-photo input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+.report-photo input:focus-visible + .report-btn {
+  outline: 3px solid var(--ink);
+  outline-offset: 3px;
+}
+.report-thumb {
+  max-height: 4.5rem;
+  max-width: 7rem;
+  border: 2px solid var(--edge);
+}
+
+/* Same clothes as styles.css's .btn, a size down, so the box reads as part of
+ * the site and not as a form that wandered in. */
+.report-btn {
+  font-family: var(--display);
+  font-size: 1.15rem;
+  letter-spacing: 0.03em;
+  line-height: 1.1;
+  padding: 0.45em 1em 0.33em;
+  border: 3px solid var(--ink);
+  background: var(--paper);
+  color: var(--ink);
+  display: inline-block;
+  cursor: pointer;
+  text-decoration: none;
+}
+.report-btn.primary {
+  background: var(--ink);
+  color: var(--paper);
+  font-size: 1.35rem;
+  padding: 0.5em 1.4em 0.38em;
+}
+.report-btn[disabled] {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.report-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.4rem;
+}
+.report-status {
+  flex: 1 1 12rem;
+  min-height: 1.4em;
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+.report-status.err {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.report-done {
+  border: 3px solid var(--ink);
+  padding: 1.2rem 1.3rem;
+}
+.report-done h2 {
+  font-family: var(--display);
+  font-weight: 400;
+  font-size: 2rem;
+  line-height: 1;
+  margin: 0 0 0.3rem;
+}
+.report-num {
+  font-family: var(--mono);
+  font-size: 1.3rem;
+}
+.report-done p {
+  margin: 0.4rem 0;
+}
+
+/* The honeypot: off screen, never display:none, so a bot that reads the DOM
+ * still sees a field to fill. */
+.report-hp {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+/* .report-btn is display:inline-block, which would otherwise beat the hidden
+ * attribute on the Remove button. Scoped to the mount so it cannot reach the
+ * rest of the page. */
+[data-report-mount] [hidden] {
+  display: none !important;
+}
+
+/* --- /report/ as a page of its own ------------------------------------------ */
+.report-page {
+  max-width: 34rem;
+  margin: 0 auto;
+  padding: 2.5rem var(--gutter) 5rem;
+}
+.report-page .report-title {
+  font-size: clamp(2.4rem, 8vw, 3.4rem);
+  margin-bottom: 0.5rem;
+}
+.report-page .report-lead {
+  font-size: 1.25rem;
+  margin-bottom: 1.75rem;
+}
+.report-back {
+  display: inline-block;
+  margin-top: 2rem;
+  color: var(--muted);
+}
+
+/* --- phones: a sheet up from the bottom, one column ------------------------ */
+@media (max-width: 600px) {
+  .report-dialog {
+    width: 100vw;
+    margin: 0;
+    inset: auto 0 0 0;
+    border-width: 3px 0 0 0;
+  }
+  .report-sheet {
+    max-height: calc(100vh - 3rem);
+    max-height: calc(100dvh - 3rem);
+    padding: 1.2rem var(--gutter) calc(1.25rem + env(safe-area-inset-bottom));
+  }
+  .report-title {
+    font-size: 1.8rem;
+  }
+  .report-row,
+  .report-choices {
+    grid-template-columns: 1fr;
+  }
+  .report-form textarea {
+    min-height: 6.5rem;
+  }
+  .report-foot .report-btn.primary {
+    flex: 1 1 100%;
+    text-align: center;
+  }
+  .report-status:empty {
+    display: none;
+  }
+}

--- a/site/assets/report.js
+++ b/site/assets/report.js
@@ -1,0 +1,345 @@
+/* The report box: one form, drawn wherever a page asks for it.
+ *
+ * Two pages show it. The front page keeps it in a <dialog> behind the round
+ * button in the bottom-right corner, so saying what happened never means
+ * leaving the page you were on. /report/ shows the same form as a page of its
+ * own, for the deep links and the QR code that already point there. The
+ * markup and the behaviour live here once so the two cannot drift; each page
+ * supplies the surroundings (a heading, and on the front page the dialog and
+ * whatever opens it).
+ *
+ * A page mounts the form with <div data-report-mount></div>. A <dialog
+ * id="report-dialog"> plus any element carrying data-report-open turn on the
+ * dialog behaviour; a page without them simply has the form in it. The
+ * openers keep href="/report/" so a browser without <dialog>, or without
+ * scripts, still gets somewhere.
+ *
+ * Which device is two checkboxes, not a radio with a "not sure": a person
+ * reporting from a device knows which one they hold, and a report that is
+ * about both is about both. At least one is required; the function refuses a
+ * report naming neither, so the check here is a courtesy rather than the gate.
+ */
+(function () {
+  "use strict";
+
+  var TEMPLATE = `
+<form class="report-form" id="report-form" novalidate>
+  <div class="report-row report-choices">
+    <div class="report-field">
+      <span class="report-label" id="report-kind-label">This is</span>
+      <div class="report-chips" role="radiogroup" aria-labelledby="report-kind-label">
+        <label><input type="radio" name="kind" value="bug" checked><span>Something broke</span></label>
+        <label><input type="radio" name="kind" value="idea"><span>An idea</span></label>
+      </div>
+    </div>
+    <div class="report-field">
+      <span class="report-label" id="report-device-label">On which device</span>
+      <div class="report-chips" role="group" aria-labelledby="report-device-label">
+        <label><input type="checkbox" name="device" value="x4pro"><span>X4 Pro</span></label>
+        <label><input type="checkbox" name="device" value="sticky"><span>Sticky</span></label>
+      </div>
+    </div>
+  </div>
+
+  <div class="report-field">
+    <label class="report-label" for="report-what">What happened</label>
+    <textarea id="report-what" name="what" required maxlength="4000" rows="6"
+      placeholder="What were you doing, what happened, and what did you expect instead?"></textarea>
+  </div>
+
+  <div class="report-row">
+    <div class="report-field">
+      <label class="report-label" for="report-version">Firmware version <small>(optional)</small></label>
+      <input type="text" id="report-version" name="version" inputmode="decimal" placeholder="1.12.9" autocomplete="off">
+      <p class="report-hint">Settings &gt; About on the device.</p>
+    </div>
+    <div class="report-field">
+      <label class="report-label" for="report-email">Your email <small>(optional)</small></label>
+      <input type="email" id="report-email" name="email" autocomplete="email" placeholder="you@example.com">
+      <p class="report-hint">Only if you want a reply.</p>
+    </div>
+  </div>
+
+  <div class="report-field">
+    <span class="report-label">A photo <small>(optional)</small></span>
+    <div class="report-photo">
+      <input type="file" id="report-photo" name="photo" accept="image/*">
+      <label class="report-btn" for="report-photo">Add a photo</label>
+      <img id="report-thumb" class="report-thumb" alt="" hidden>
+      <button type="button" class="report-btn" id="report-photo-clear" hidden>Remove</button>
+    </div>
+    <p class="report-hint">Of the screen, if the problem is something you can see. It is resized before it is sent.</p>
+  </div>
+
+  <div class="report-hp" aria-hidden="true">
+    <label for="report-website">Leave this empty</label>
+    <input type="text" id="report-website" name="website" tabindex="-1" autocomplete="off">
+  </div>
+
+  <input type="hidden" id="report-app" name="app" value="">
+
+  <div class="report-foot">
+    <p class="report-status" id="report-status" role="status" aria-live="polite"></p>
+    <button type="submit" class="report-btn primary" id="report-send">Send</button>
+  </div>
+</form>
+
+<section class="report-done" id="report-done" hidden>
+  <h2>Got it.</h2>
+  <p>Your report is <span class="report-num" id="report-id"></span>.</p>
+  <p>Save that number if you ever write in about it. That is all there is to do.</p>
+  <p id="report-photo-note" hidden>The photo did not make it, but the report did. You can send it again with the number above in the text.</p>
+  <p><button type="button" class="report-btn" id="report-again">Send another</button></p>
+</section>
+`;
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  // Resize on the phone, not the server: a buffered request is capped at
+  // 4.5MB and a camera photo is bigger than that. 1600px on the long side is
+  // plenty to read an e-ink screen.
+  function shrink(file) {
+    return new Promise(function (resolve) {
+      var img = new Image();
+      var url = URL.createObjectURL(file);
+      img.onload = function () {
+        var max = 1600,
+          w = img.naturalWidth,
+          h = img.naturalHeight;
+        var s = Math.min(1, max / Math.max(w, h));
+        var c = document.createElement("canvas");
+        c.width = Math.round(w * s);
+        c.height = Math.round(h * s);
+        c.getContext("2d").drawImage(img, 0, 0, c.width, c.height);
+        URL.revokeObjectURL(url);
+        c.toBlob(
+          function (b) {
+            resolve(b || file);
+          },
+          "image/jpeg",
+          0.85,
+        );
+      };
+      img.onerror = function () {
+        URL.revokeObjectURL(url);
+        resolve(null);
+      };
+      img.src = url;
+    });
+  }
+
+  // Draws the form into `root` and wires it. Returns the handful of things a
+  // host page needs: where to put focus, whether a report has been sent, and
+  // how to start over.
+  function mount(root) {
+    root.innerHTML = TEMPLATE;
+    var form = $("report-form"),
+      what = $("report-what"),
+      version = $("report-version"),
+      email = $("report-email");
+    var photo = $("report-photo"),
+      thumb = $("report-thumb"),
+      clear = $("report-photo-clear");
+    var send = $("report-send"),
+      status = $("report-status"),
+      done = $("report-done"),
+      idOut = $("report-id");
+    var photoNote = $("report-photo-note"),
+      again = $("report-again"),
+      website = $("report-website"),
+      app = $("report-app");
+    var pickedBlob = null;
+
+    function say(text, err) {
+      status.textContent = text;
+      status.className = "report-status" + (err ? " err" : "");
+    }
+
+    function devices() {
+      var out = [];
+      var boxes = form.querySelectorAll('input[name="device"]:checked');
+      for (var i = 0; i < boxes.length; i++) out.push(boxes[i].value);
+      return out;
+    }
+
+    // The device's own web UI can open the page with everything it knows
+    // filled in: /report/?device=x4pro&v=1.12.9&app=trivia&kind=bug. Two
+    // devices are a comma: device=x4pro,sticky. Values go into a selector, so
+    // only plain words are looked up at all.
+    var q = new URLSearchParams(location.search);
+    if (q.get("v")) version.value = q.get("v").replace(/^v/, "");
+    (q.get("device") || "").split(",").forEach(function (v) {
+      v = v.trim();
+      if (!/^[a-z0-9]+$/.test(v)) return;
+      var d = form.querySelector('input[name="device"][value="' + v + '"]');
+      if (d) d.checked = true;
+    });
+    if (q.get("kind") === "idea")
+      form.querySelector('input[name="kind"][value="idea"]').checked = true;
+    if (q.get("app")) app.value = q.get("app");
+
+    photo.addEventListener("change", function () {
+      var f = photo.files && photo.files[0];
+      if (!f) return;
+      shrink(f).then(function (b) {
+        if (!b) {
+          say("That file is not a photo we can read.", true);
+          photo.value = "";
+          return;
+        }
+        pickedBlob = b;
+        thumb.src = URL.createObjectURL(b);
+        thumb.hidden = false;
+        clear.hidden = false;
+        say("");
+      });
+    });
+    function dropPhoto() {
+      pickedBlob = null;
+      photo.value = "";
+      thumb.hidden = true;
+      clear.hidden = true;
+    }
+    clear.addEventListener("click", dropPhoto);
+
+    form.addEventListener("submit", function (ev) {
+      ev.preventDefault();
+      var text = what.value.trim();
+      if (text.length < 8) {
+        say("Say a little more about what happened.", true);
+        what.focus();
+        return;
+      }
+      var picked = devices();
+      if (!picked.length) {
+        say("Which device? Pick at least one.", true);
+        form.querySelector('input[name="device"]').focus();
+        return;
+      }
+      send.disabled = true;
+      say("Sending...");
+      var body = {
+        kind: form.querySelector('input[name="kind"]:checked').value,
+        what: text,
+        device: picked.join(","),
+        version: version.value.trim(),
+        email: email.value.trim(),
+        app: app.value,
+        website: website.value,
+      };
+      fetch("/api/report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+        .then(function (r) {
+          return r.json().then(function (j) {
+            return { ok: r.ok, j: j };
+          });
+        })
+        .then(function (res) {
+          if (!res.ok)
+            throw new Error(
+              (res.j && res.j.error) || "Something went wrong sending it.",
+            );
+          var id = res.j.id;
+          if (!pickedBlob || !id) return { id: id, photoOk: true };
+          say("Sending the photo...");
+          return fetch("/api/report?photo=" + id, {
+            method: "PUT",
+            headers: { "Content-Type": "image/jpeg" },
+            body: pickedBlob,
+          }).then(
+            function (r) {
+              return { id: id, photoOk: r.ok };
+            },
+            function () {
+              return { id: id, photoOk: false };
+            },
+          );
+        })
+        .then(function (out) {
+          form.hidden = true;
+          done.hidden = false;
+          idOut.textContent = "#" + out.id;
+          photoNote.hidden = out.photoOk;
+          say("");
+          done.scrollIntoView({ block: "nearest" });
+          again.focus();
+        })
+        .catch(function (err) {
+          say(err.message || "Something went wrong sending it.", true);
+          send.disabled = false;
+        });
+    });
+
+    function reset() {
+      form.reset();
+      dropPhoto();
+      send.disabled = false;
+      say("");
+      done.hidden = true;
+      form.hidden = false;
+    }
+    again.addEventListener("click", function () {
+      reset();
+      what.focus();
+    });
+
+    return {
+      focus: function () {
+        (done.hidden ? what : again).focus();
+      },
+      isDone: function () {
+        return !done.hidden;
+      },
+      reset: reset,
+    };
+  }
+
+  var root = document.querySelector("[data-report-mount]");
+  if (!root) return;
+  var box = mount(root);
+
+  // -- the dialog, on pages that have one ------------------------------------
+  var dialog = $("report-dialog");
+  if (!dialog || typeof dialog.showModal !== "function") return;
+  var closeBtn = $("report-close");
+  var openers = document.querySelectorAll("[data-report-open]");
+  var opener = null;
+
+  function open(from) {
+    opener = from || document.activeElement;
+    dialog.showModal();
+    // The page behind is inert while the dialog is up; this keeps it from
+    // scrolling under the sheet as well.
+    document.documentElement.classList.add("report-open");
+    box.focus();
+  }
+
+  // Escape is the browser's own cancel; the backdrop is the dialog element
+  // itself, since its whole box is covered by the sheet inside it.
+  dialog.addEventListener("click", function (ev) {
+    if (ev.target === dialog) dialog.close();
+  });
+  if (closeBtn)
+    closeBtn.addEventListener("click", function () {
+      dialog.close();
+    });
+  dialog.addEventListener("close", function () {
+    document.documentElement.classList.remove("report-open");
+    // A report that went through is finished; the next open is a fresh box.
+    // One that was only half written stays as it was.
+    if (box.isDone()) box.reset();
+    if (opener && typeof opener.focus === "function") opener.focus();
+    opener = null;
+  });
+  for (var i = 0; i < openers.length; i++) {
+    openers[i].addEventListener("click", function (ev) {
+      ev.preventDefault();
+      open(ev.currentTarget);
+    });
+  }
+})();

--- a/site/index.html
+++ b/site/index.html
@@ -18,6 +18,7 @@
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <link rel="stylesheet" href="styles.css">
+<link rel="stylesheet" href="assets/report.css">
 <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
 <!-- iOS ignores SVG manifest icons, and Add to Home Screen is the only real
      full screen an iPhone gets, so the home-screen icon ships as a PNG. -->
@@ -460,7 +461,7 @@
       on my own desk, joined on 2026-08-25 by a reTerminal Sticky, and
       releases are flashed to both before they ship. That is still a
       small record:
-      <a href="/report/">say what you
+      <a href="/report/" data-report-open>say what you
       find</a>, either way. One box, under a minute, no account.
     </p>
     <!-- The button that does the whole thing. It is first, and short, because
@@ -571,10 +572,50 @@
   </div>
 </footer>
 
+<!-- The report box. A round button, fixed in the bottom-right corner on top
+     of everything, opens the form in a dialog so saying what happened never
+     means leaving the page. assets/report.js draws the form into the mount
+     below and wires the dialog; the same script draws the same form into
+     /report/, which stays a page of its own for the links and QR codes that
+     point there. The button is a link to that page, so a browser without
+     scripts or without <dialog> still gets somewhere; report.js turns the
+     click into the dialog. The icon is Lucide's bug, the set the device
+     itself draws its icons from. -->
+<a class="report-fab" id="report-open" href="/report/" data-report-open
+   aria-haspopup="dialog" aria-label="Report a bug or an idea" title="Report a bug or an idea">
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"
+       stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+    <path d="M12 20v-9" />
+    <path d="M14 7a4 4 0 0 1 4 4v3a6 6 0 0 1-12 0v-3a4 4 0 0 1 4-4z" />
+    <path d="M14.12 3.88 16 2" />
+    <path d="M21 21a4 4 0 0 0-3.81-4" />
+    <path d="M21 5a4 4 0 0 1-3.55 3.97" />
+    <path d="M22 13h-4" />
+    <path d="M3 21a4 4 0 0 1 3.81-4" />
+    <path d="M3 5a4 4 0 0 0 3.55 3.97" />
+    <path d="M6 13H2" />
+    <path d="m8 2 1.88 1.88" />
+    <path d="M9 7.13V6a3 3 0 1 1 6 0v1.13" />
+  </svg>
+</a>
+<dialog class="report-dialog" id="report-dialog" aria-labelledby="report-title">
+  <div class="report-sheet">
+    <div class="report-head">
+      <div>
+        <h2 class="report-title" id="report-title">Tell CrossPlay what happened</h2>
+        <p class="report-lead">Say it however it comes out. No account, under a minute.</p>
+      </div>
+      <button class="report-close" id="report-close" type="button" aria-label="Close">&times;</button>
+    </div>
+    <div data-report-mount></div>
+  </div>
+</dialog>
+
 <!-- The Install button, and the release stamp it also fills in. It pulls
      assets/esptool.bundle.js in only when someone presses Install, so the
      175KB library costs the people just reading the page nothing. -->
 <script src="assets/install.js"></script>
+<script src="assets/report.js"></script>
 <script src="assets/avatar-data.js"></script>
 <!-- ?v=2 defeats a poisoned cache entry, not a normal cache miss. Until
      2026-08-09 /assets/ was served immutable for a year, so every browser

--- a/site/report/index.html
+++ b/site/report/index.html
@@ -6,214 +6,25 @@
 <title>Tell CrossPlay what happened</title>
 <meta name="description" content="Report a bug or send an idea for CrossPlay in under a minute. No account needed.">
 <link rel="stylesheet" href="/styles.css">
+<link rel="stylesheet" href="/assets/report.css">
 <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png">
 <meta name="theme-color" content="#111110">
-<style>
-  [hidden] { display: none !important; } /* styles.css styles buttons; the attribute must still win */
-  /* One column, one box, big targets. Everything optional is visibly optional
-     and below the one thing that matters. Tokens come from /styles.css. */
-  .report { max-width: 34rem; margin: 0 auto; padding: 2.5rem var(--gutter) 5rem; }
-  .report h1 { font-family: var(--display); font-weight: 400; font-size: clamp(2.4rem, 8vw, 3.4rem); line-height: 1; margin: 0 0 0.5rem; letter-spacing: 0.01em; }
-  .report .lead { font-family: var(--serif); font-size: 1.25rem; color: var(--muted); margin: 0 0 1.75rem; }
-  .field { display: flex; flex-direction: column; gap: 0.4rem; margin: 0 0 1.25rem; }
-  .field > label, .field > .label { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); }
-  .field .hint { font-size: 0.9rem; color: var(--muted); margin: 0; }
-  textarea, input[type="text"], input[type="email"] {
-    font: inherit; font-size: 1.05rem; color: var(--ink); background: var(--paper-2);
-    border: 1.5px solid var(--edge); border-radius: 6px; padding: 0.8rem 0.9rem; width: 100%;
-  }
-  textarea { min-height: 9.5rem; resize: vertical; line-height: 1.45; }
-  textarea:focus, input:focus { outline: 3px solid var(--ink); outline-offset: 1px; }
-  .chips { display: flex; flex-wrap: wrap; gap: 0.5rem; }
-  .chips label { position: relative; }
-  .chips input { position: absolute; opacity: 0; inset: 0; }
-  .chips span { display: inline-block; padding: 0.55rem 0.9rem; border: 1.5px solid var(--edge); border-radius: 999px; font-size: 0.98rem; cursor: pointer; user-select: none; }
-  .chips input:checked + span { background: var(--ink); color: var(--paper); border-color: var(--ink); }
-  .chips input:focus-visible + span { outline: 3px solid var(--ink); outline-offset: 2px; }
-  .chips.big span { font-size: 1.1rem; padding: 0.75rem 1.1rem; }
-  .photo { display: flex; align-items: center; gap: 0.8rem; flex-wrap: wrap; }
-  .photo input { position: absolute; opacity: 0; width: 1px; height: 1px; }
-  .btn { font: inherit; font-size: 1rem; padding: 0.7rem 1.1rem; border-radius: 6px; border: 1.5px solid var(--ink); background: transparent; color: var(--ink); cursor: pointer; }
-  .btn.primary { background: var(--ink); color: var(--paper); font-size: 1.15rem; padding: 0.9rem 1.5rem; }
-  .btn:focus-visible { outline: 3px solid var(--ink); outline-offset: 2px; }
-  .btn[disabled] { opacity: 0.55; cursor: default; }
-  .thumb { max-height: 5rem; max-width: 8rem; border: 1px solid var(--edge); border-radius: 4px; }
-  .status { min-height: 1.4em; margin: 0.9rem 0 0; color: var(--muted); }
-  .status.err { color: var(--ink); font-weight: 600; }
-  .done { border: 1.5px solid var(--ink); border-radius: 8px; padding: 1.4rem 1.5rem; }
-  .done h2 { font-family: var(--display); font-weight: 400; font-size: 2.2rem; margin: 0 0 0.4rem; line-height: 1; }
-  .done .num { font-family: var(--mono); font-size: 1.6rem; }
-  .done p { margin: 0.4rem 0; }
-  .hp { position: absolute; left: -10000px; top: auto; width: 1px; height: 1px; overflow: hidden; }
-  .back { display: inline-block; margin-top: 2rem; color: var(--muted); }
-</style>
 </head>
 <body>
-<main class="report" id="main">
-  <h1>Tell CrossPlay what happened</h1>
-  <p class="lead">One box. Say it however it comes out. No account, under a minute.</p>
+<!-- The same form the front page opens in a dialog, as a page of its own for
+     the links and QR codes that point here. The form itself is drawn by
+     assets/report.js into the mount below; this file is only the surroundings.
+     The device's web UI can prefill it: /report/?device=x4pro&v=1.12.9&app=trivia&kind=bug -->
+<main class="report-page" id="main">
+  <h1 class="report-title">Tell CrossPlay what happened</h1>
+  <p class="report-lead">One box. Say it however it comes out. No account, under a minute.</p>
 
-  <form id="report-form" novalidate>
-    <div class="field">
-      <span class="label">This is</span>
-      <div class="chips big" role="radiogroup" aria-label="Bug or idea">
-        <label><input type="radio" name="kind" value="bug" checked><span>Something broke</span></label>
-        <label><input type="radio" name="kind" value="idea"><span>An idea</span></label>
-      </div>
-    </div>
+  <div data-report-mount></div>
 
-    <div class="field">
-      <label for="report-what">What happened</label>
-      <textarea id="report-what" name="what" required maxlength="4000"
-        placeholder="What were you doing, what happened, and what did you expect instead?"></textarea>
-    </div>
-
-    <div class="field">
-      <span class="label">Which device</span>
-      <div class="chips" role="radiogroup" aria-label="Device">
-        <label><input type="radio" name="device" value="x4pro"><span>X4 Pro</span></label>
-        <label><input type="radio" name="device" value="sticky"><span>Sticky</span></label>
-        <label><input type="radio" name="device" value="unknown" checked><span>Not sure</span></label>
-      </div>
-    </div>
-
-    <div class="field">
-      <label for="report-version">Firmware version <span style="text-transform:none;letter-spacing:0">(optional)</span></label>
-      <input type="text" id="report-version" name="version" inputmode="decimal" placeholder="1.12.9" autocomplete="off">
-      <p class="hint">Settings &gt; About on the device, if you have it handy.</p>
-    </div>
-
-    <div class="field">
-      <span class="label">A photo <span style="text-transform:none;letter-spacing:0">(optional)</span></span>
-      <div class="photo">
-        <label class="btn" for="report-photo">Add a photo</label>
-        <input type="file" id="report-photo" name="photo" accept="image/*">
-        <img id="report-thumb" class="thumb" alt="" hidden>
-        <button type="button" class="btn" id="report-photo-clear" hidden>Remove</button>
-      </div>
-      <p class="hint">Of the screen, if the problem is something you can see. It gets resized before it is sent.</p>
-    </div>
-
-    <div class="field">
-      <label for="report-email">Your email <span style="text-transform:none;letter-spacing:0">(optional, only if you want a reply)</span></label>
-      <input type="email" id="report-email" name="email" autocomplete="email" placeholder="you@example.com">
-    </div>
-
-    <div class="hp" aria-hidden="true">
-      <label for="report-website">Leave this empty</label>
-      <input type="text" id="report-website" name="website" tabindex="-1" autocomplete="off">
-    </div>
-
-    <input type="hidden" id="report-app" name="app" value="">
-
-    <button type="submit" class="btn primary" id="report-send">Send</button>
-    <p class="status" id="report-status" role="status" aria-live="polite"></p>
-  </form>
-
-  <section class="done" id="report-done" hidden>
-    <h2>Got it.</h2>
-    <p>Your report is <span class="num" id="report-id"></span>.</p>
-    <p>Save that number if you ever write in about it. That is all there is to do.</p>
-    <p id="report-photo-note" hidden>The photo did not make it, but the report did. You can send it again with the number above in the text.</p>
-    <p><button type="button" class="btn" id="report-again">Send another</button></p>
-  </section>
-
-  <a class="back" href="/">Back to CrossPlay</a>
+  <a class="report-back" href="/">Back to CrossPlay</a>
 </main>
 
-<script>
-(function () {
-  "use strict";
-  var $ = function (id) { return document.getElementById(id); };
-  var form = $("report-form"), what = $("report-what"), version = $("report-version"), email = $("report-email");
-  var photo = $("report-photo"), thumb = $("report-thumb"), clear = $("report-photo-clear");
-  var send = $("report-send"), status = $("report-status"), done = $("report-done"), idOut = $("report-id");
-  var photoNote = $("report-photo-note"), again = $("report-again"), website = $("report-website"), app = $("report-app");
-  var pickedBlob = null;
-
-  // The device's own web UI can open this page with everything it knows
-  // filled in: /report/?device=x4pro&v=1.12.9&app=trivia&kind=bug
-  var q = new URLSearchParams(location.search);
-  if (q.get("v")) version.value = q.get("v").replace(/^v/, "");
-  if (q.get("device")) { var d = form.querySelector('input[name="device"][value="' + q.get("device") + '"]'); if (d) d.checked = true; }
-  if (q.get("kind") === "idea") form.querySelector('input[name="kind"][value="idea"]').checked = true;
-  if (q.get("app")) app.value = q.get("app");
-
-  function say(text, err) { status.textContent = text; status.className = "status" + (err ? " err" : ""); }
-
-  // Resize on the phone, not the server: a buffered request is capped at
-  // 4.5MB and a camera photo is bigger than that. 1600px on the long side is
-  // plenty to read an e-ink screen.
-  function shrink(file) {
-    return new Promise(function (resolve) {
-      var img = new Image();
-      var url = URL.createObjectURL(file);
-      img.onload = function () {
-        var max = 1600, w = img.naturalWidth, h = img.naturalHeight;
-        var s = Math.min(1, max / Math.max(w, h));
-        var c = document.createElement("canvas");
-        c.width = Math.round(w * s); c.height = Math.round(h * s);
-        c.getContext("2d").drawImage(img, 0, 0, c.width, c.height);
-        URL.revokeObjectURL(url);
-        c.toBlob(function (b) { resolve(b || file); }, "image/jpeg", 0.85);
-      };
-      img.onerror = function () { URL.revokeObjectURL(url); resolve(null); };
-      img.src = url;
-    });
-  }
-
-  photo.addEventListener("change", function () {
-    var f = photo.files && photo.files[0];
-    if (!f) return;
-    shrink(f).then(function (b) {
-      if (!b) { say("That file is not a photo we can read.", true); photo.value = ""; return; }
-      pickedBlob = b;
-      thumb.src = URL.createObjectURL(b); thumb.hidden = false; clear.hidden = false;
-      say("");
-    });
-  });
-  clear.addEventListener("click", function () { pickedBlob = null; photo.value = ""; thumb.hidden = true; clear.hidden = true; });
-
-  form.addEventListener("submit", function (ev) {
-    ev.preventDefault();
-    var text = what.value.trim();
-    if (text.length < 8) { say("Say a little more about what happened.", true); what.focus(); return; }
-    send.disabled = true; say("Sending...");
-    var body = {
-      kind: form.querySelector('input[name="kind"]:checked').value,
-      what: text,
-      device: form.querySelector('input[name="device"]:checked').value,
-      version: version.value.trim(),
-      email: email.value.trim(),
-      app: app.value,
-      website: website.value
-    };
-    fetch("/api/report", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) })
-      .then(function (r) { return r.json().then(function (j) { return { ok: r.ok, j: j }; }); })
-      .then(function (res) {
-        if (!res.ok) throw new Error(res.j && res.j.error || "Something went wrong sending it.");
-        var id = res.j.id;
-        if (!pickedBlob || !id) return { id: id, photoOk: true };
-        say("Sending the photo...");
-        return fetch("/api/report?photo=" + id, { method: "PUT", headers: { "Content-Type": "image/jpeg" }, body: pickedBlob })
-          .then(function (r) { return { id: id, photoOk: r.ok }; }, function () { return { id: id, photoOk: false }; });
-      })
-      .then(function (out) {
-        form.hidden = true; done.hidden = false;
-        idOut.textContent = "#" + out.id;
-        photoNote.hidden = out.photoOk;
-        say("");
-        done.scrollIntoView({ block: "start" });
-      })
-      .catch(function (err) { say(err.message || "Something went wrong sending it.", true); send.disabled = false; });
-  });
-
-  again.addEventListener("click", function () {
-    form.reset(); pickedBlob = null; thumb.hidden = true; clear.hidden = true; send.disabled = false;
-    done.hidden = true; form.hidden = false; what.focus();
-  });
-})();
-</script>
+<script src="/assets/report.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Mario's feedback on the report page: it looked made for a phone, "not sure" is not a device, and nobody should have to leave the site to say what happened.

## What changed

- A round button, fixed bottom-right on the front page, on top of everything (above the top bar, below and hidden during the emulator's full-screen stage), with Lucide's bug glyph and the label "Report a bug or an idea".
- It opens a native `<dialog>`: a centred ~480px card on a desk (kind and device side by side, version beside email), a full-width bottom sheet on a phone (one column). Escape, backdrop and a close button close it; focus goes into the text box on open and back to the opener on close; the page cannot scroll under it. The "say what you find" link in *Get it* opens the same dialog. Both keep `href="/report/"` as the no-`<dialog>`/no-script fallback.
- One implementation: `site/assets/report.js` draws the form into any page with `data-report-mount` and wires it; `site/assets/report.css` styles form, dialog and button (all `report-` prefixed). `/report/` stays as a standalone page around the same mount, for deep links and QR codes; `?device=&v=&app=&kind=` prefill still works, `device` takes a comma.
- Device is two checkboxes (X4 Pro, Sticky), at least one required, both allowed, no "not sure" anywhere. `api/report.js` accepts `x4pro`, `sticky` or `x4pro,sticky` (any order/case/spacing), stores the canonical joined string, refuses empty/missing/unknown with 400 (used to file them under "unknown"). History line names both boards; the event keeps one board or null with `props.devices` listing them.

## Verified

- `node host-tests/site/report_fn.js`: **42 checks, 0 failed** (one device, both in the wrong order, Sticky alone, `""`, `","`, `unknown`, `toaster`, `x4pro,toaster` and missing device refused with nothing stored; history and event asserted).
- `bash host-tests/site/run.sh`: **137 checks, 0 failed**. New agreement checks: every id `report.js` looks up exists in its own template or `index.html`; both pages mount the form and load script and stylesheet; `index.html` has the `<dialog>`, the close button and `#report-open` carrying `data-report-open`; `/report/` has no form or id lookups of its own; form devices equal the API's list and that list has no `unknown`. Each check was made to fail on a mutant first. `aria_roles.py` now parses the template literal in `report.js` (the site's only radiogroup moved out of every `.html`), verified against a one-radio mutant.
- Playwright against `serve.py` in Chrome, 26 checks green: focus in/back, Escape, backdrop, close button, prose link opens in place, no-device refusal with focus on the choice, both devices posted as `x4pro,sticky` against a stubbed 201, done panel, fresh form on reopen, 390px sheet full width with no sideways scroll, `/report/` prefill, light and dark. Screenshots looked at:
  - `/private/tmp/claude-501/-Users-mario-Projects-Personal-Code-Xteink/250b191d-5ea0-45ff-9c2b-e089f639f0a9/scratchpad/report-desktop.png`
  - `/private/tmp/claude-501/-Users-mario-Projects-Personal-Code-Xteink/250b191d-5ea0-45ff-9c2b-e089f639f0a9/scratchpad/report-mobile.png`

## Not verified

- A real POST to the board (`serve.py` does not answer `/api/report`; the function is covered by the node suite with the board stubbed).
- Safari or Firefox, a real phone (the sheet uses `dvh` with a `vh` fallback and `env(safe-area-inset-*)`).
- The photo path end to end.

## Decisions taken rather than asked

- No device pre-checked: a default would be sent unread.
- Closing keeps a half-written report; closing after a sent one resets.
- The corner button is an `<a>` to `/report/` that the script upgrades, for the fallback.
- The choices row sizes its left column to content (`max-content`): 1fr/1fr wrapped "An idea" under "Something broke" at 480px.
- Both-boards reports leave the event's `board` column null and list both in `props.devices`, rather than adding a third value to a column the Numbers views group by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
