### PR TITLE
Devices report on the requests they already make; services post the events

### DIFF
--- a/docs/workflow/events.md
+++ b/docs/workflow/events.md
@@ -1,6 +1,6 @@
 # Events: one table for every number, and every error
 
-Every service and every device posts what happens to one table on the board
+Every service posts what happens, its own and what the devices tell it, to one table on the board
 (`events`, `server/board/supabase/migrations/20260903000200_events.sql`).
 Mario's "how many people use this" is a view over it; an error posted there
 becomes a card on the board by itself, once per distinct problem.
@@ -27,9 +27,9 @@ variables. The public key can only insert; it cannot read anything back.
 | Field     | What goes in it                                                                                                                                      |
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `service` | `firmware`, `getbooks`, `anki`, `instapaper`, `site`, `release`. One word, lowercase, the same word every time.                                      |
-| `event`   | What happened: `heartbeat`, `download`, `search`, `sync`, `install`, `report`, `update`, `error`. Same rule.                                         |
+| `event`   | What happened: `download`, `search`, `sync`, `install`, `report`, `crash`, `update`, `probe`. Same rule.                                            |
 | `level`   | `info` (default) or `error`.                                                                                                                         |
-| `device`  | sha256 of the MAC and a secret the device made once and keeps in NVS: pseudonymous, the same on every post from one device, and not matchable to a MAC without that device's secret. Never the MAC, never a name. Optional for services that have no device. |
+| `device`  | The id from the device's `X-CrossPlay-Device` header (below): pseudonymous, the same on every request from one device, and not matchable to a MAC without that device's secret. Never the MAC, never a name. A service whose request carried no id may use its own salted hash of an account or token instead, or leave it out. |
 | `version` | Firmware version as printed, `1.12.9`. Optional.                                                                                                     |
 | `board`   | `x4pro` or `sticky`. Optional.                                                                                                                       |
 | `props`   | Anything else, small: a format, a byte count, a duration, a book id. For errors, `message` is required.                                              |
@@ -56,107 +56,120 @@ Send a `fingerprint` yourself when you know better than the message what
 makes two errors the same (for example the book id is what matters, not the
 timeout).
 
-## The heartbeat
+## What a device sends
 
-Once a day, when the device has Wi-Fi up for some other reason (Developer
-Mode, an app that went online; it never brings the radio up for this), the
-firmware posts one event:
+A device never makes a request just to report: it never brings the radio up
+for the board, and it never spends a request on it. Instead every request
+the firmware makes to one of CrossPlay's own services (Get Books, the Anki
+bridge, the Instapaper bridge) carries three headers, and the service posts
+what they say alongside the event it was going to post anyway:
 
 ```
-{"service":"firmware","event":"heartbeat","device":"<hash>","version":"1.12.12","board":"x4pro",
- "props":{"apps":["trivia","hackernews"],"uptime_h":31,"battery_pct":84,"heap_min_kb":112,
-          "ota":{"attempted":true,"ok":false,"error":"too_large","path":"sd"}}}
+User-Agent: CrossPlay-ESP32-1.12.13
+X-CrossPlay-Device: 9f2c...64 hex...
+X-CrossPlay-Board: x4pro
+X-CrossPlay-Report: {"battery_pct":84,"heap_min_kb":112,"uptime_h":31,
+                     "crash":{"message":"assert failed: ... (reset: panic)","version":"1.12.12","backtrace":""},
+                     "ota":{"attempted":true,"ok":false,"error":"too_large","path":"ota"}}
 ```
 
-`apps` is the set opened since the last heartbeat (shelf titles, lowercased,
-`HACKER NEWS` is `hackernews`). `uptime_h` is hours since boot, and deep
-sleep is a boot. `heap_min_kb` is the lowest free heap since boot. `ota` is
-the install attempted since the last heartbeat, from the update screen
-(`path` `ota`) or from a `.bin` picked off the card (`path` `sd`; a file
-refused before the confirmation prompt counts, it is an install the user
-could not have): `ok` is inferred from the version having moved, never from
-what the install screen said, so an install that "succeeded" into the same
-version reads as not ok with no error. That single event answers "how many
-devices are on which version",
-"how many use each app", "which version drains faster" and "who cannot
-update" (the 6.25MB slots of a device flashed before v1.5.3 come back as
-`too_large`).
+| Header               | What is in it                                                                                                                                                                                                                                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `User-Agent`         | `CrossPlay-ESP32-<version>`, as it always was. The version is read from here and nowhere else.                                                                                                                                                     |
+| `X-CrossPlay-Device` | 64 hex: sha256(MAC + a 16-byte secret the device made once from its hardware RNG and keeps in NVS, namespace `crossplay`, key `hbsecret`). The MAC and the secret are never sent; without the secret the id cannot be matched to a MAC. A full flash erase makes a new secret, so the device comes back as a new id. |
+| `X-CrossPlay-Board`  | `x4pro` or `sticky`.                                                                                                                                                                                                                               |
+| `X-CrossPlay-Report` | Compact JSON, at most 600 bytes. Always `battery_pct`, `heap_min_kb` (lowest free heap since boot) and `uptime_h` (hours since boot; deep sleep is a boot). While one is pending, `crash` and/or `ota`, below.                                        |
 
-A boot after a panic posts one more event, `{"event":"crash","level":"error",
-"props":{"message":"<panic reason>","backtrace":"<first two stack lines>"}}`,
-once, so a crash in the field opens a card by itself. Its `version` is the
-one that crashed, written down at the boot after the panic: the record waits
-for Wi-Fi, and an OTA can land in between.
+`crash` is the last panic, recorded at the boot after it and carried until a
+request delivers it: `message` is the panic reason, `version` the firmware
+that crashed (an OTA can land between the panic and the request, so it is
+written down at that boot, not read from the User-Agent), `backtrace` the
+first stack lines when the chip records any. On `x4pro` and `sticky`
+(ESP32-S3, Xtensa) only an assert or abort panic carries a reason, and none
+carries a trace: `lib/hal/HalSystem.cpp` writes the reason from
+`__wrap_panic_abort` alone. A CPU exception (LoadProhibited,
+StoreProhibited, IllegalInstruction) therefore reads `"panic without a
+recorded reason (reset: panic; last log: READER)"`, and the reset name plus
+the subsystem that logged last are what the fingerprint has to tell two of
+them apart. An assert reads `"assert failed: ... (reset: panic)"`.
 
-On `x4pro` and `sticky` (ESP32-S3, Xtensa) only an assert or abort panic
-carries a reason, and none carries a trace: `lib/hal/HalSystem.cpp` writes
-the reason from `__wrap_panic_abort` alone and its backtrace wrap captures
-the stack only on RISC-V. A CPU exception (LoadProhibited,
-StoreProhibited, IllegalInstruction) therefore posts `"panic without a
-recorded reason (reset: panic; last log: READER)"`: the `esp_reset_reason()`
-name and the subsystem that logged last before the reset are what the
-fingerprint has to tell two of them apart, and `backtrace` is empty. An
-assert reads `"assert failed: ... (reset: panic)"`. The reason is used only
-when the capture marker was still set at boot (`HalSystem::panicReasonRecorded()`,
-read in `main.cpp` before `checkPanic()` clears it): the text in RTC memory
-outlives the crash that wrote it, so an exception after an assert with no
-clean boot between posts as "without a recorded reason", not as that assert.
-Carrying the program counter and the exception cause is a card, not a
-limitation of the pipe.
+`ota` is the install attempted since the last report, from the update
+screen (`path` `ota`) or from a `.bin` picked off the card (`path` `sd`; a
+file refused before the confirmation prompt counts). `ok` is inferred from
+the version having moved, never from what the install screen said, so an
+install that "succeeded" into the same version reads as not ok with no
+error; the 6.25MB slots of a device flashed before v1.5.3 come back as
+`too_large`.
 
-`device` is sha256(MAC + a 16-byte secret the device made once from its
-hardware RNG and keeps in NVS, namespace `crossplay`, key `hbsecret`); the
-MAC and the secret are never sent, and without the secret the id cannot be
-matched to a MAC (a vendor prefix leaves 2^24 MACs, seconds of work against
-a salt that is in this repository). When NVS gives no secret the device
-falls back to sha256(MAC + that fixed salt) and logs it. A full flash erase
-makes a new secret, so the device comes back as a new id. The address
-and the public key come from the site's `/api/board-config`, fetched once and
-cached on the card as `/.crosspoint/board.json`, fetched again when the board
-answers 401 or 403 (a key rotation is a Vercel setting, not a release).
-Between heartbeats the apps set, the OTA record and a pending crash live in
-`/.crosspoint/heartbeat.json`, written whenever the state changes: a first
-open, an OTA note (the attempt and the failure), a recorded panic, a failed
-request and the answer that ends a run of them, a send, and the toggle
-going back on.
+A request that carries none of this (a browser, a curl, an older firmware)
+is served exactly as before and counted under whatever the service already
+knew: the version alone for Get Books, a salted hash of the token or the
+account for the bridges. Settings > System on the device turns the headers
+off; off sends nothing and records nothing.
 
-The post runs inline in `loop()`, with input and the power button waiting
-behind it, and the 5 s timeout is per wait, not per request. `SecureClient`
-makes two connect attempts (a TLS 1.3-capable hello, then a TLS 1.2-only
-one), each a blocking DNS lookup the timeout does not cover, then up to 5 s
-for TCP and up to 5 s for the handshake. A silent :443 therefore costs about
-10 s plus DNS (a dropped SYN spends the two TCP waits and never reaches the
-handshake; a port that accepts and says nothing spends the two handshake
-waits) and up to 20 s plus DNS when both run to the deadline. One request
-per loop pass (the board config on one pass, the event on the next). The
-real bound is the persisted backoff: a request that fails is not tried again
-for 15 minutes, then not before the next UTC day, one try a day until one is
-accepted. That wait (`retry`, `fails`) is in the state file, because deep
-sleep is a boot and a device that sleeps often would otherwise pay the stall
-at every boot.
+## What each service posts
 
-Settings > System > "Send a daily heartbeat" (default on) turns all of it
-off, and off records nothing: no app open, no OTA note, no panic is written
-to the card while it is off, and switching it back on forgets whatever the
-file still held from before, so there is never a backlog waiting to go out.
-The site says so in one sentence beside the Install button. The rules
-are `src/network/HeartbeatCore.{h,cpp}` and `host-tests/heartbeat` pins
-them; `src/network/Heartbeat.cpp` is the clock, the card, the radio and the
-TLS. The serial log says which decision was taken and why under `HEARTBEAT`.
+The three services share one reader for the headers (`bridge/events.py` in
+`server/study-bridge` and `server/read-bridge`, byte-identical twins that a
+test keeps identical; `getbooks/events.py` in the Get Books repository) and
+trust none of it: an id that is not 64 hex is no id, a board that is not a
+short word is no board, a report over 1000 bytes or not a JSON object is
+ignored with one debug line and the request served all the same, and only
+numbers are copied out of the health fields.
+
+On every request the service accepts (a 2xx or 3xx; a 401 the device will
+retry posts nothing, so a crash is not counted twice), whatever the
+endpoint:
+
+- **The usage event it already posted** (`getbooks`/`search`,
+  `getbooks`/`download`, `anki`/`sync`, `instapaper`/`sync`, and their
+  `error` twins) gets `device` from the header (over the service's own hash
+  when both exist), `board` from the header, `version` from the User-Agent,
+  and `battery_pct`, `heap_min_kb`, `uptime_h` copied into `props` when the
+  report carried them.
+- **A report with `crash`** posts one more event, `{"service":"firmware",
+  "event":"crash","level":"error","device":..,"version":<crash.version>,
+  "board":..,"props":{"message":<crash.message>,"backtrace":<crash.backtrace>,
+  "app":"firmware","via":"getbooks"|"anki"|"instapaper"}}`, so a crash in the
+  field opens a card on the firmware's owner by itself, once per distinct
+  reason, whichever service happened to hear it.
+- **A report with `ota`** posts `{"service":"firmware","event":"update",
+  "device":..,"version":..,"board":..,"props":{...the ota object...,
+  "app":"firmware"}}` at level `info`, or at level `error` with
+  `props.message = "update failed: <error> (<path>)"` when `ok` is false and
+  an error is named, so "who cannot update" is a card with a count.
+
+Each service says `device report via <service>: crash on <version>` or
+`update <level>` in its log when it posts one. The service that heard it is
+`props.via`; the card lands on the firmware.
 
 ## Reading the numbers
 
-Signed-in users (the inbox page) read four views: `devices_by_version`
-(last 7 days), `daily_active_devices` (30 days), `events_daily` (30 days,
-by service and event), `service_users` (7 days). The inbox page shows them
-under "Numbers", next to GitHub's own download counts per release.
+Signed-in users (the inbox page) read five views over the events that carry
+a device: `devices_by_version` (distinct devices per board and version, over
+every event with a device and a version in the last 7 days),
+`daily_active_devices` (distinct devices per day, 30 days),
+`battery_by_version` (board, version, the average `battery_pct` of the
+events a device carried, averaged per device first so a reader that syncs
+ten times a day weighs the same as one that syncs once, with the device and
+report counts beside it, 7 days), `events_daily` (30 days, by service and
+event), `service_users` (7 days). The inbox page shows them under "Numbers",
+next to GitHub's own download counts per release.
+
+A device is counted when it uses a service. One that only plays games and
+never searches a book or syncs a deck is not on the board at all, and that
+is the design, not a gap: "devices heard from" means devices that used
+something. Downloads per release, from GitHub, is the number for the rest.
+The views are in `20260903000200_events.sql` as written and
+`20260904001100_devices_from_usage.sql` as they read now.
 
 ## What each owner sends (the cards)
 
 Each service has a card on the board naming the events it should post and
-where in its code. The firmware heartbeat is `src/network`; Get Books, the
-Anki bridge and the Instapaper bridge post from the pi; the site posts
-`install` and `report`. The pipe is built; the sending is the owner's.
+where in its code. The firmware puts its headers on every request it makes
+(`src/network`); Get Books, the Anki bridge and the Instapaper bridge post
+from the pi, their own events and the firmware's; the site posts `install`
+and `report`. The pipe is built; the sending is the owner's.
 
 ## The pulse: what looks from outside
 

--- a/host-tests/site/inbox_fn.js
+++ b/host-tests/site/inbox_fn.js
@@ -190,6 +190,9 @@ const expect = (label, got, want) =>
   r = await call({ pass: "open sesame", op: "numbers" });
   expect("numbers answers", r.status, 200);
   [
+    "devices_by_version",
+    "daily_active_devices",
+    "battery_by_version",
     "pulse_hosts",
     "workflow_weekly",
     "state_dwell",
@@ -207,6 +210,11 @@ const expect = (label, got, want) =>
   expect(
     "with the pulse in the answer",
     Array.isArray(r.json && r.json.pulse),
+    true,
+  );
+  expect(
+    "and the battery table",
+    Array.isArray(r.json && r.json.battery),
     true,
   );
 

--- a/server/board/supabase/migrations/20260904001100_devices_from_usage.sql
+++ b/server/board/supabase/migrations/20260904001100_devices_from_usage.sql
@@ -1,0 +1,70 @@
+-- Devices are counted from what they use, not from a heartbeat.
+--
+-- Mario's call (2026-09-04): a device never spends its radio on the board's
+-- numbers. There is no heartbeat event any more; instead every request a
+-- device makes to a CrossPlay service carries its id, board and a small
+-- report, and the service posts the usage event (getbooks/search, anki/sync,
+-- instapaper/sync) under that id with the version and the health numbers,
+-- plus firmware/crash and firmware/update events for what the report
+-- carried (docs/workflow/events.md, "What a device sends").
+--
+-- So the two device views read every event with a device on it, a third
+-- averages the battery those events carry, and the nightly "no heartbeat
+-- ever arrived" check goes: silence from a device that never touches a
+-- service is now what silence means, and the pulse already watches the
+-- services themselves.
+
+-- Same columns as before, so create or replace keeps the grants and the
+-- security_invoker option; restated below anyway.
+create or replace view devices_by_version as
+  select coalesce(board, 'unknown') as board, version,
+         count(distinct device) as devices
+  from events
+  where device is not null and version is not null and at > now() - interval '7 days'
+  group by 1, 2 order by 1, 2 desc;
+
+create or replace view daily_active_devices as
+  select date_trunc('day', at)::date as day, count(distinct device) as devices
+  from events
+  where device is not null and at > now() - interval '30 days'
+  group by 1 order by 1 desc;
+
+-- Battery by (board, version): each device's average over its own events
+-- first, then the average of those, so a reader that syncs ten times a day
+-- weighs the same as one that syncs once. devices is the denominator the
+-- number needs beside it; n is how many reports it rests on.
+drop view if exists battery_by_version;
+create view battery_by_version as
+  with per_device as (
+    select coalesce(board, 'unknown') as board, coalesce(version, 'unknown') as version,
+           device,
+           avg((props ->> 'battery_pct')::numeric) as pct,
+           count(*) as n
+    from events
+    where device is not null
+      and jsonb_typeof(props -> 'battery_pct') = 'number'
+      and at > now() - interval '7 days'
+    group by 1, 2, 3
+  )
+  select board, version,
+         round(avg(pct), 1) as battery_pct,
+         count(*) as devices,
+         sum(n) as n
+  from per_device
+  group by 1, 2 order by 1, 2 desc;
+
+alter view devices_by_version set (security_invoker = true);
+alter view daily_active_devices set (security_invoker = true);
+alter view battery_by_version set (security_invoker = true);
+
+-- The heartbeat-silence check (20260904000900) watched for a post that will
+-- never come now. Unschedule it if it is scheduled (cron.unschedule raises
+-- on a name it does not know), then drop the function.
+do $$
+begin
+  if exists (select 1 from cron.job where jobname = 'heartbeat-silence') then
+    perform cron.unschedule('heartbeat-silence');
+  end if;
+end
+$$;
+drop function if exists heartbeat_silence_check();

--- a/server/read-bridge/README.md
+++ b/server/read-bridge/README.md
@@ -114,13 +114,21 @@ ssh orange 'cd /srv/readbridge && docker compose stop cloudflared'  # kill switc
 ## Events
 
 Every finished sync posts one event to the board (`docs/workflow/events.md`):
-`instapaper`/`sync` with `{articles, seconds}` under a salted hash of the
-account id, or the same event at level `error` with `{message}` when the job
-was refused or died. `bridge/events.py` sends from its own thread with a 3 s
-timeout and drops the event after one log line if the board does not take
-it, so a board outage cannot slow or fail a sync (`tests/test_api.py` proves
-both). The module is a byte-identical twin of `study-bridge/bridge/events.py`;
-`tests/test_events.py` fails if the two drift.
+`instapaper`/`sync` with `{articles, seconds}`, or the same event at level
+`error` with `{message}` when the job was refused or died. It is counted
+under the device's own id when the request carried one (`X-CrossPlay-Device`,
+with `X-CrossPlay-Board` and the version from the User-Agent, and the
+report's `battery_pct`, `heap_min_kb`, `uptime_h` copied into the props),
+else under a salted hash of the account id. Whatever the device had to
+report rides the same headers on every request, so a middleware reads them
+on every accepted answer and posts `firmware`/`crash` and `firmware`/`update`
+events for a crash or an OTA attempt the report carries
+(`events.Client.report`). `bridge/events.py` sends from its own thread with
+a 3 s timeout and drops the event after one log line if the board does not
+take it, so a board outage cannot slow or fail a sync (`tests/test_api.py`
+proves both, and the header bodies). The module is a byte-identical twin of
+`study-bridge/bridge/events.py`; `tests/test_events.py` fails if the two
+drift.
 
 Where to post comes from two more `.env` keys, both optional:
 

--- a/server/read-bridge/bridge/app.py
+++ b/server/read-bridge/bridge/app.py
@@ -122,6 +122,21 @@ def require_device(request: Request) -> tuple[str, str]:
     return uid, th
 
 
+# ------------------------------------------------------------ device reports
+@app.middleware("http")
+async def device_reports(request: Request, call_next):
+    """A device never makes a request just to report. Whatever it has to say
+    (a crash, an update attempt) rides the X-CrossPlay-Report header of the
+    request it was making anyway, on every endpoint, so it is read here and
+    not in one handler. Posted after the answer, and only for an answer the
+    device will count as delivered, so a request it retries does not post
+    the same crash twice. events.Client.report never raises."""
+    response = await call_next(request)
+    if response.status_code < 400:
+        events.client_for(request).report(via="instapaper")
+    return response
+
+
 # -------------------------------------------------------------------- healthz
 @app.get("/healthz")
 async def healthz():
@@ -398,9 +413,11 @@ async def start_sync(request: Request, dev=Depends(require_device)):
         uid,
         work,
         service="instapaper",
-        # The account id (itself a hash of the address), salted once more: the
-        # board counts accounts and can name none of them.
-        device=events.device_id(uid),
+        # The device's own id, board, version and health, read off its
+        # headers. A reader that sends no id is counted under the account id
+        # (itself a hash of the address), salted once more: the board can
+        # name none of them.
+        client=events.client_for(request, default_device=events.device_id(uid)),
         # articles: what came down this sync, new or changed.
         props=lambda s: {"articles": len(s["articles"])},
     )

--- a/server/read-bridge/bridge/events.py
+++ b/server/read-bridge/bridge/events.py
@@ -15,9 +15,29 @@ sync waits on:
 - post() never blocks the caller. The request runs on its own daemon thread
   with a short timeout, so the worst case costs the process one idle thread
   for TIMEOUT_S and the sync nothing at all.
-- The device field is a hash, never an identifier. device_id() folds the
-  caller's id (a token hash, an account id) through sha256 with a fixed salt,
-  so the board can count devices and nothing on it names one.
+- The device field is a hash, never an identifier. A device names itself with
+  the pseudonymous id in its X-CrossPlay-Device header; when it does not,
+  device_id() folds the caller's id (a token hash, an account id) through
+  sha256 with a fixed salt, so the board can count devices and nothing on it
+  names one.
+
+The device headers. A device never makes a request just to report; every
+request it makes to a CrossPlay service carries what it has to say
+(docs/workflow/events.md, "What a device sends"):
+
+    X-CrossPlay-Device: <64 hex>          the same id on every request
+    X-CrossPlay-Board:  x4pro | sticky
+    X-CrossPlay-Report: {"battery_pct":N,"heap_min_kb":N,"uptime_h":N,
+                         "crash":{...}, "ota":{...}}    compact JSON
+
+and its firmware version rides in User-Agent: CrossPlay-ESP32-<version>.
+client_of() reads all of it off a request without trusting any of it: an id
+that is not 64 hex is no id, a board that is not a short word is no board, a
+report over REPORT_MAX bytes or not a JSON object is ignored with one debug
+line, and only numbers are copied out of the health fields. The usage event
+the service posts anyway (a sync) then carries the device, its board and
+version and the three health numbers; Client.report() posts the crash and the
+update attempt the device is carrying as firmware events of their own.
 
 Byte-identical twin of the other bridge's bridge/events.py (study-bridge and
 read-bridge). Neither Dockerfile can COPY a file from outside its own
@@ -29,8 +49,10 @@ import hashlib
 import json
 import logging
 import os
+import re
 import threading
 import urllib.request
+from dataclasses import dataclass, field
 
 log = logging.getLogger("bridge.events")
 
@@ -41,6 +63,16 @@ TIMEOUT_S = 3.0
 # from elsewhere (a token hash in a state file, an account id in a log) cannot
 # be matched to a row on the board by hashing it once more.
 SALT = "crossplay-events"
+
+# The report header is at most 600 bytes from the firmware; anything past
+# this cap is not a report, whatever it says it is.
+REPORT_MAX = 1000
+# The three numbers every report carries, copied onto the usage event.
+HEALTH_KEYS = ("battery_pct", "heap_min_kb", "uptime_h")
+
+_HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
+_BOARD = re.compile(r"^[a-z0-9]{1,16}$")
+_UA = re.compile(r"^CrossPlay-ESP32-(\S{1,32})")
 
 # The whole HTTP layer, as one name the tests replace.
 _urlopen = urllib.request.urlopen
@@ -72,6 +104,8 @@ def post(
     device: str = "",
     level: str = "info",
     props: dict | None = None,
+    version: str = "",
+    board: str = "",
 ) -> threading.Thread | None:
     """Queue one event for the board. Never raises, never blocks.
 
@@ -83,6 +117,10 @@ def post(
         record = {"service": service, "event": event, "level": level}
         if device:
             record["device"] = device
+        if version:
+            record["version"] = version
+        if board:
+            record["board"] = board
         record["props"] = props or {}
         body = json.dumps(record).encode()
         url = os.environ["SUPABASE_URL"].strip().rstrip("/") + "/rest/v1/events"
@@ -117,3 +155,143 @@ def _deliver(url: str, key: str, body: bytes) -> None:
             resp.close()
     except Exception as e:
         log.warning("event dropped, the board did not take it: %s", e)
+
+
+# ------------------------------------------------------------ the device
+@dataclass
+class Client:
+    """What one request says about the device that made it.
+
+    Every field may be empty: a browser, a curl, an old firmware. device is
+    the header's id when it was a valid one, else the fallback the service
+    passed (its own hash of the token), else nothing. health holds whichever
+    of HEALTH_KEYS the report carried as numbers. crash and ota are the
+    report's objects of those names, verbatim, or None."""
+
+    device: str = ""
+    board: str = ""
+    version: str = ""
+    health: dict = field(default_factory=dict)
+    crash: dict | None = None
+    ota: dict | None = None
+
+    def props(self, base: dict | None = None) -> dict:
+        """The props of a usage event: the caller's, plus the health numbers.
+        The caller's win on a shared key."""
+        p = dict(self.health)
+        p.update(base or {})
+        return p
+
+    def report(self, via: str) -> int:
+        """Post what the device is carrying: one firmware/crash event at level
+        error, one firmware/update event. via names the service that relayed
+        it. Returns how many events went out. Never raises: a request must
+        not fail because of what rode along with it."""
+        n = 0
+        try:
+            if self.crash is not None:
+                c = self.crash
+                post(
+                    "firmware",
+                    "crash",
+                    level="error",
+                    device=self.device,
+                    # The version that crashed, written down at the boot after
+                    # the panic; the running one when the record lacks it.
+                    version=str(c.get("version") or self.version),
+                    board=self.board,
+                    props={
+                        "message": str(c.get("message") or ""),
+                        "backtrace": str(c.get("backtrace") or ""),
+                        "app": "firmware",
+                        "via": via,
+                    },
+                )
+                log.info("device report via %s: crash on %s", via, c.get("version"))
+                n += 1
+            if self.ota is not None:
+                o = self.ota
+                props = dict(o)
+                props["app"] = "firmware"
+                level = "info"
+                if o.get("ok") is False and o.get("error"):
+                    level = "error"
+                    props["message"] = (
+                        f"update failed: {o.get('error')} ({o.get('path') or 'unknown'})"
+                    )
+                post(
+                    "firmware",
+                    "update",
+                    level=level,
+                    device=self.device,
+                    version=self.version,
+                    board=self.board,
+                    props=props,
+                )
+                log.info("device report via %s: update %s", via, level)
+                n += 1
+        except Exception as e:  # a report shaped to break str() or dict()
+            log.warning("device report via %s dropped: %s", via, e)
+        return n
+
+
+def client_of(headers, default_device: str = "") -> Client:
+    """Read the device headers off a request. headers is anything with .get()
+    keyed case-insensitively (Starlette's Headers) or by lowercase name (a
+    dict in a test). Never raises."""
+    c = Client(device=default_device)
+    try:
+        get = lambda name: str(headers.get(name) or "")  # noqa: E731
+        dev = get("x-crossplay-device").strip()
+        if _HEX64.match(dev):
+            c.device = dev.lower()
+        board = get("x-crossplay-board").strip().lower()
+        if _BOARD.match(board):
+            c.board = board
+        m = _UA.match(get("user-agent"))
+        if m:
+            c.version = m.group(1)
+        raw = get("x-crossplay-report")
+        if raw:
+            report = _parse_report(raw)
+            if report is not None:
+                for k in HEALTH_KEYS:
+                    v = report.get(k)
+                    if isinstance(v, (int, float)) and not isinstance(v, bool):
+                        c.health[k] = v
+                if isinstance(report.get("crash"), dict):
+                    c.crash = report["crash"]
+                if isinstance(report.get("ota"), dict):
+                    c.ota = report["ota"]
+    except Exception as e:
+        log.debug("device headers ignored: %s", e)
+    return c
+
+
+def client_for(request, default_device: str = "") -> Client:
+    """client_of(), once per request. The Client rides the ASGI scope, so the
+    handler that posts the usage event and the middleware that posts the
+    device's report read the headers once and say so once; the handler runs
+    first, so its default_device is the one both see."""
+    c = request.scope.get("crossplay_client")
+    if c is None:
+        c = client_of(request.headers, default_device)
+        request.scope["crossplay_client"] = c
+    return c
+
+
+def _parse_report(raw: str) -> dict | None:
+    # Header values are one byte per character on the wire, so the length of
+    # the string is the length of the header.
+    if len(raw) > REPORT_MAX:
+        log.debug("X-CrossPlay-Report ignored: %d bytes, the cap is %d", len(raw), REPORT_MAX)
+        return None
+    try:
+        report = json.loads(raw)
+    except ValueError as e:
+        log.debug("X-CrossPlay-Report ignored: not JSON (%s)", e)
+        return None
+    if not isinstance(report, dict):
+        log.debug("X-CrossPlay-Report ignored: not an object")
+        return None
+    return report

--- a/server/read-bridge/bridge/jobs.py
+++ b/server/read-bridge/bridge/jobs.py
@@ -22,24 +22,28 @@ log = logging.getLogger("bridge.jobs")
 _clock = time.monotonic
 
 
-def _report(service, device, failure, summary, props, elapsed):
-    """One event per finished job: what it moved, or what it died of. Never
-    raises -- the job is already done or failed on its own terms, and the
-    board is not allowed to change that."""
+def _report(service, client, failure, summary, props, elapsed):
+    """One event per finished job: what it moved, or what it died of, under
+    the device that asked (its header id, board, version and health numbers;
+    events.Client). Never raises -- the job is already done or failed on its
+    own terms, and the board is not allowed to change that."""
     try:
         if failure is None:
             p = dict(props(summary) if props else {})
             p["seconds"] = round(elapsed, 1)
-            events.post(service, "sync", device=device, props=p)
+            level = "info"
         else:
-            message = f"{type(failure).__name__}: {failure}"[:200]
-            events.post(
-                service,
-                "sync",
-                device=device,
-                level="error",
-                props={"message": message},
-            )
+            p = {"message": f"{type(failure).__name__}: {failure}"[:200]}
+            level = "error"
+        events.post(
+            service,
+            "sync",
+            device=client.device,
+            version=client.version,
+            board=client.board,
+            level=level,
+            props=client.props(p),
+        )
     except Exception:
         log.exception("event for a %s job not posted", service)
 
@@ -76,7 +80,7 @@ class Jobs:
         return None
 
     def start(
-        self, uid: str, work, *, service: str = "", device: str = "", props=None
+        self, uid: str, work, *, service: str = "", client=None, props=None
     ) -> Job:
         """work: a blocking callable run in a thread under the user lock.
         Returns the existing job instead when one is already in flight.
@@ -84,10 +88,13 @@ class Jobs:
         service names the board's row for this job (events.py): when set,
         the job's end posts one event -- `sync` with props(summary) plus the
         seconds it took, or `sync` at level error with what it died of.
-        device is the hashed id the event is counted under."""
+        client is the events.Client the request came from: the id the event
+        is counted under, the board, the version, the health numbers."""
         existing = self.active_for(uid)
         if existing:
             return existing
+        if client is None:
+            client = events.Client()
         job = Job(uid)
         self._jobs[job.id] = job
         self._active[uid] = job.id
@@ -115,7 +122,7 @@ class Jobs:
                     failure = e
                 if service:
                     _report(
-                        service, device, failure, job.summary, props, _clock() - started
+                        service, client, failure, job.summary, props, _clock() - started
                     )
 
         asyncio.get_running_loop().create_task(run())

--- a/server/read-bridge/tests/test_api.py
+++ b/server/read-bridge/tests/test_api.py
@@ -311,7 +311,7 @@ async def run(tmp, state_file):
         events._urlopen = take
         # Each job reads the clock twice; pinned so `seconds` is asserted
         # exactly rather than as "some number".
-        ticks = iter([100.0, 102.5, 200.0, 200.4, 300.0, 300.1, 400.0, 400.2])
+        ticks = iter([100.0, 102.5, 200.0, 200.4, 300.0, 300.1, 400.0, 400.2, 500.0, 502.0, 600.0, 600.5])
         jobs_mod._clock = lambda: next(ticks, time.monotonic())
         # The syncs above spent this user's window; this block gets a fresh
         # one with the same limits.
@@ -418,6 +418,105 @@ async def run(tmp, state_file):
             and wire_body["props"] == {"message": "RuntimeError: disk full"},
             f"a bridge fault posts its cause at level error, got {wire_body}",
         )
+
+        # --- the device headers: a reader that says who it is, and what it
+        # has to report, on the request it was making anyway. The sync event
+        # is counted under the header's id, not the account hash, and carries
+        # the health numbers; the crash and the update post as firmware
+        # events of their own, from the middleware, whatever the endpoint.
+        del posted[:]
+        app_mod.SYNC_USER = Window(6, 300)
+        DEV = "0" * 64
+        report = {
+            "battery_pct": 50,
+            "heap_min_kb": 100,
+            "uptime_h": 1,
+            "crash": {"message": "assert failed: x (reset: panic)", "version": "1.12.12", "backtrace": ""},
+            "ota": {"attempted": True, "ok": False, "error": "too_large", "path": "ota"},
+        }
+        talking = {
+            **headers,
+            "User-Agent": "CrossPlay-ESP32-1.12.13",
+            "X-CrossPlay-Device": DEV,
+            "X-CrossPlay-Board": "x4pro",
+            "X-CrossPlay-Report": json.dumps(report, separators=(",", ":")),
+        }
+        r = await client.post("/api/sync", json={"have": [], "archive": []}, headers=talking)
+        ok(r.status_code == 200, f"a sync with the device headers is accepted, got {r.status_code}")
+        result = await poll_job(client, headers, r.json()["job"])
+        ok(result["status"] == "done", f"and finishes, got {result}")
+        came_down = len(result["summary"]["articles"])
+        await settle(3)
+        ok(len(posted) == 3, f"the sync, the crash and the update are three events, got {len(posted)}")
+        bodies = sorted((json.loads(p.data) for p in posted), key=lambda b: (b["service"], b["event"]))
+        ok(
+            bodies[0]
+            == {
+                "service": "firmware",
+                "event": "crash",
+                "level": "error",
+                "device": DEV,
+                "version": "1.12.12",
+                "board": "x4pro",
+                "props": {"message": "assert failed: x (reset: panic)", "backtrace": "", "app": "firmware", "via": "instapaper"},
+            },
+            f"the crash posts as the firmware's, via instapaper, got {bodies[0]}",
+        )
+        ok(
+            bodies[1]
+            == {
+                "service": "firmware",
+                "event": "update",
+                "level": "error",
+                "device": DEV,
+                "version": "1.12.13",
+                "board": "x4pro",
+                "props": {"attempted": True, "ok": False, "error": "too_large", "path": "ota", "app": "firmware", "message": "update failed: too_large (ota)"},
+            },
+            f"the failed update posts as an error with its message, got {bodies[1]}",
+        )
+        ok(
+            bodies[2]
+            == {
+                "service": "instapaper",
+                "event": "sync",
+                "level": "info",
+                "device": DEV,
+                "version": "1.12.13",
+                "board": "x4pro",
+                "props": {"articles": came_down, "seconds": 2.0, "battery_pct": 50, "heap_min_kb": 100, "uptime_h": 1},
+            },
+            f"the sync is counted under the device's own id with its health, got {bodies[2]}",
+        )
+        ok(expected_device not in "".join(p.data.decode() for p in posted), "the account hash is not used when the device names itself")
+
+        # A report past the cap is not a report; the request is still served
+        # and still counted, without health, and nothing else posts.
+        del posted[:]
+        oversize = dict(talking)
+        oversize["X-CrossPlay-Report"] = json.dumps({"battery_pct": 50, "crash": {"message": "x" * 1180}})
+        ok(len(oversize["X-CrossPlay-Report"]) >= 1200, "the oversize report is at least 1200 bytes")
+        r = await client.post("/api/sync", json={"have": [], "archive": []}, headers=oversize)
+        ok(r.status_code == 200, f"an oversize report does not fail the request, got {r.status_code}")
+        result = await poll_job(client, headers, r.json()["job"])
+        ok(result["status"] == "done", f"and the sync finishes, got {result}")
+        await settle(1)
+        await asyncio.sleep(0.3)
+        ok(len(posted) == 1, f"only the sync posts, got {len(posted)}")
+        wire_body = json.loads(posted[0].data)
+        ok(
+            wire_body["device"] == DEV and wire_body["board"] == "x4pro"
+            and wire_body["props"] == {"articles": len(result["summary"]["articles"]), "seconds": 0.5},
+            f"counted under the id, with no health from the ignored report, got {wire_body}",
+        )
+
+        # A crash on a request the service refuses is not posted: the device
+        # will carry it again, and posting it now would count it twice.
+        del posted[:]
+        r = await client.post("/api/sync", json={"have": []}, headers={k: v for k, v in talking.items() if k != "Authorization"})
+        ok(r.status_code == 401, "no token is still refused, headers or not")
+        await asyncio.sleep(0.3)
+        ok(posted == [], f"and a refused request posts nothing, got {len(posted)}")
 
         events._urlopen = urllib.request.urlopen
         jobs_mod._clock = time.monotonic

--- a/server/read-bridge/tests/test_events.py
+++ b/server/read-bridge/tests/test_events.py
@@ -188,6 +188,155 @@ def main():
     )
     ok(len(sent) == before and len(cap.records) == 1, "one warning, no request")
 
+    # --- the device headers: what a request says about the device
+    via = {"study-bridge": "anki", "read-bridge": "instapaper"}.get(ROOT.name, "anki")
+    cap.records.clear()
+    cap.setLevel(logging.DEBUG)
+    log.setLevel(logging.DEBUG)
+    events._urlopen = record
+    del sent[:]
+    DEV = "ab" * 32
+    report = {
+        "battery_pct": 50,
+        "heap_min_kb": 100,
+        "uptime_h": 1,
+        "crash": {"message": "assert failed: x (reset: panic)", "version": "1.12.12", "backtrace": "0x4000 0x4001"},
+        "ota": {"attempted": True, "ok": False, "error": "too_large", "path": "ota"},
+    }
+    full = {
+        "x-crossplay-device": DEV.upper(),
+        "x-crossplay-board": "x4pro",
+        "x-crossplay-report": json.dumps(report, separators=(",", ":")),
+        "user-agent": "CrossPlay-ESP32-1.12.13",
+    }
+    c = events.client_of(full, default_device="fallback")
+    ok(c.device == DEV, f"the header id wins over the fallback, lowercased, got {c.device}")
+    ok(c.board == "x4pro" and c.version == "1.12.13", f"board and version are read, got {c.board} {c.version}")
+    ok(
+        c.health == {"battery_pct": 50, "heap_min_kb": 100, "uptime_h": 1},
+        f"the three health numbers are copied, got {c.health}",
+    )
+    ok(
+        c.props({"cards": 3}) == {"cards": 3, "battery_pct": 50, "heap_min_kb": 100, "uptime_h": 1},
+        f"props() adds the health numbers to the caller's, got {c.props({'cards': 3})}",
+    )
+    ok(
+        c.props({"battery_pct": 7}) == {"battery_pct": 7, "heap_min_kb": 100, "uptime_h": 1},
+        "and the caller's value wins on a shared key",
+    )
+    n = c.report(via)
+    for _ in range(50):
+        if len(sent) >= 2:
+            break
+        time.sleep(0.05)
+    ok(n == 2 and len(sent) == 2, f"a crash and an update post two events, got {n} / {len(sent)}")
+    bodies = sorted((json.loads(r.data) for r, _ in sent), key=lambda b: b["event"])
+    ok(
+        bodies[0]
+        == {
+            "service": "firmware",
+            "event": "crash",
+            "level": "error",
+            "device": DEV,
+            "version": "1.12.12",
+            "board": "x4pro",
+            "props": {
+                "message": "assert failed: x (reset: panic)",
+                "backtrace": "0x4000 0x4001",
+                "app": "firmware",
+                "via": via,
+            },
+        },
+        f"the crash event is the contract's, under the version that crashed, got {bodies[0]}",
+    )
+    ok(
+        bodies[1]
+        == {
+            "service": "firmware",
+            "event": "update",
+            "level": "error",
+            "device": DEV,
+            "version": "1.12.13",
+            "board": "x4pro",
+            "props": {
+                "attempted": True,
+                "ok": False,
+                "error": "too_large",
+                "path": "ota",
+                "app": "firmware",
+                "message": "update failed: too_large (ota)",
+            },
+        },
+        f"a failed update is an error with a message, under the running version, got {bodies[1]}",
+    )
+    ok(
+        sum(r.levelno == logging.INFO and "device report" in r.getMessage() for r in cap.records) == 2,
+        f"each posted report logs one info line, got {[r.getMessage() for r in cap.records]}",
+    )
+
+    del sent[:]
+    good = dict(full)
+    good["x-crossplay-report"] = json.dumps({"battery_pct": 90, "ota": {"attempted": True, "ok": True}})
+    c = events.client_of(good)
+    ok(c.report(via) == 1, "an update that worked posts one event")
+    for _ in range(50):
+        if sent:
+            break
+        time.sleep(0.05)
+    body = json.loads(sent[0][0].data)
+    ok(
+        body["level"] == "info" and body["props"] == {"attempted": True, "ok": True, "app": "firmware"},
+        f"at level info, with the ota object as its props, got {body}",
+    )
+    ok(c.health == {"battery_pct": 90} and c.crash is None, "a report may carry only some fields")
+
+    # nothing, wrong, or too much
+    del sent[:]
+    c = events.client_of({}, default_device="fallback")
+    ok(
+        c == events.Client(device="fallback"),
+        f"no headers is the fallback id and nothing else, got {c}",
+    )
+    ok(c.report(via) == 0 and sent == [] and c.props() == {}, "and nothing to report")
+    c = events.client_of({"x-crossplay-device": "ab" * 31 + "zz", "x-crossplay-board": "X4 Pro!"}, default_device="fb")
+    ok(c.device == "fb" and c.board == "", f"an id that is not 64 hex and a board that is not a word are dropped, got {c}")
+    ok(events.client_of({"user-agent": "curl/8.0"}).version == "", "a UA that is not the firmware's has no version")
+    ok(
+        events.client_of({"x-crossplay-report": json.dumps({"battery_pct": "50", "heap_min_kb": True, "uptime_h": 2.5, "crash": "boom", "ota": [1]})}).__dict__
+        == events.Client(health={"uptime_h": 2.5}).__dict__,
+        "only numbers are health, only objects are crash and ota",
+    )
+    cap.records.clear()
+    big = json.dumps({"battery_pct": 50, "crash": {"message": "x" * 1180}})
+    ok(len(big) >= 1200, "the oversize report really is over the cap")
+    c = events.client_of({"x-crossplay-device": DEV, "x-crossplay-report": big})
+    ok(
+        c.device == DEV and c.health == {} and c.crash is None,
+        f"a report over {events.REPORT_MAX} bytes is ignored and the id beside it is not, got {c}",
+    )
+    c = events.client_of({"x-crossplay-report": "{not json"})
+    ok(c.health == {} and c.crash is None, "a report that is not JSON is ignored")
+    c = events.client_of({"x-crossplay-report": "[1,2]"})
+    ok(c.health == {}, "a report that is not an object is ignored")
+    debug = [r for r in cap.records if r.levelno == logging.DEBUG and "ignored" in r.getMessage()]
+    ok(len(debug) == 3, f"each ignored report is one debug line and nothing louder, got {[r.getMessage() for r in cap.records]}")
+    ok(not any(r.levelno > logging.DEBUG for r in cap.records), "no warning for a device that talks nonsense")
+    log.setLevel(logging.INFO)
+
+    # post() carries version and board when given, and omits them when not
+    del sent[:]
+    t = events.post("anki", "sync", device=DEV, version="1.12.13", board="sticky", props={"cards": 1})
+    t.join(5)
+    body = json.loads(sent[-1][0].data)
+    ok(
+        body == {"service": "anki", "event": "sync", "level": "info", "device": DEV, "version": "1.12.13", "board": "sticky", "props": {"cards": 1}},
+        f"version and board ride the body, got {body}",
+    )
+    t = events.post("anki", "sync", device=DEV, props={})
+    t.join(5)
+    body = json.loads(sent[-1][0].data)
+    ok("version" not in body and "board" not in body, "and an empty one is no field, not an empty string")
+
     # --- the twin
     other = [s for s in ("study-bridge", "read-bridge") if s != ROOT.name]
     twin = ROOT.parent / other[0] / "bridge" / "events.py"

--- a/server/study-bridge/README.md
+++ b/server/study-bridge/README.md
@@ -56,13 +56,21 @@ converted output) to `/mnt/hdd/backups/ankibridge`. **TODO: wiring not done.**
 ## Events
 
 Every finished sync posts one event to the board (`docs/workflow/events.md`):
-`anki`/`sync` with `{cards, reviews, seconds}` under a salted hash of the
-device's token hash, or the same event at level `error` with `{message}` when
-the job died or froze. `bridge/events.py` sends from its own thread with a
-3 s timeout and drops the event after one log line if the board does not take
-it, so a board outage cannot slow or fail a sync (`tests/test_api.py` proves
-both). The module is a byte-identical twin of `read-bridge/bridge/events.py`;
-`tests/test_events.py` fails if the two drift.
+`anki`/`sync` with `{cards, reviews, seconds}`, or the same event at level
+`error` with `{message}` when the job died or froze. It is counted under the
+device's own id when the request carried one (`X-CrossPlay-Device`, with
+`X-CrossPlay-Board` and the version from the User-Agent, and the report's
+`battery_pct`, `heap_min_kb`, `uptime_h` copied into the props), else under
+a salted hash of the token hash. Whatever the device had to report rides the
+same headers on every request, so a middleware reads them on every accepted
+answer and posts `firmware`/`crash` and `firmware`/`update` events for a
+crash or an OTA attempt the report carries (`events.Client.report`).
+`bridge/events.py` sends from its own thread with a 3 s timeout and drops
+the event after one log line if the board does not take it, so a board
+outage cannot slow or fail a sync (`tests/test_api.py` proves both, and the
+header bodies). The module is a byte-identical twin of
+`read-bridge/bridge/events.py`; `tests/test_events.py` fails if the two
+drift.
 
 Where to post comes from two more `.env` keys, both optional:
 

--- a/server/study-bridge/bridge/app.py
+++ b/server/study-bridge/bridge/app.py
@@ -16,15 +16,13 @@ pairing-code scans (A3), not to be fair schedulers.
 """
 
 import asyncio
-import base64
-import hashlib
 import json
 import logging
 import secrets
 import struct
 import time
 
-from fastapi import Depends, FastAPI, Request, Response
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 
 from . import accounts, decks, engine, events, jobs, pairing, store, wire
@@ -103,6 +101,21 @@ def require_device(request: Request) -> tuple[str, str]:
             "This device is not paired anymore. Pair it again from Study."
         )
     return uid, th
+
+
+# ------------------------------------------------------------ device reports
+@app.middleware("http")
+async def device_reports(request: Request, call_next):
+    """A device never makes a request just to report. Whatever it has to say
+    (a crash, an update attempt) rides the X-CrossPlay-Report header of the
+    request it was making anyway, on every endpoint, so it is read here and
+    not in one handler. Posted after the answer, and only for an answer the
+    device will count as delivered, so a request it retries does not post
+    the same crash twice. events.Client.report never raises."""
+    response = await call_next(request)
+    if response.status_code < 400:
+        events.client_for(request).report(via="anki")
+    return response
 
 
 # -------------------------------------------------------------------- healthz
@@ -492,9 +505,11 @@ async def start_sync(request: Request, dev=Depends(require_device)):
         uid,
         work,
         service="anki",
-        # The token hash, salted once more: the board counts readers and can
-        # name none of them, and the raw token never reaches this line at all.
-        device=events.device_id(th),
+        # The device's own id, board, version and health, read off its
+        # headers. A reader that sends no id is counted under its token hash,
+        # salted once more: the board can name none of them, and the raw
+        # token never reaches this line at all.
+        client=events.client_for(request, default_device=events.device_id(th)),
         # cards: what the reader posted, its whole hand across the chosen
         # decks; reviews: what this sync carried up into the collection.
         props=lambda s: {"cards": len(device_cards), "reviews": s["applied"]},

--- a/server/study-bridge/bridge/events.py
+++ b/server/study-bridge/bridge/events.py
@@ -15,9 +15,29 @@ sync waits on:
 - post() never blocks the caller. The request runs on its own daemon thread
   with a short timeout, so the worst case costs the process one idle thread
   for TIMEOUT_S and the sync nothing at all.
-- The device field is a hash, never an identifier. device_id() folds the
-  caller's id (a token hash, an account id) through sha256 with a fixed salt,
-  so the board can count devices and nothing on it names one.
+- The device field is a hash, never an identifier. A device names itself with
+  the pseudonymous id in its X-CrossPlay-Device header; when it does not,
+  device_id() folds the caller's id (a token hash, an account id) through
+  sha256 with a fixed salt, so the board can count devices and nothing on it
+  names one.
+
+The device headers. A device never makes a request just to report; every
+request it makes to a CrossPlay service carries what it has to say
+(docs/workflow/events.md, "What a device sends"):
+
+    X-CrossPlay-Device: <64 hex>          the same id on every request
+    X-CrossPlay-Board:  x4pro | sticky
+    X-CrossPlay-Report: {"battery_pct":N,"heap_min_kb":N,"uptime_h":N,
+                         "crash":{...}, "ota":{...}}    compact JSON
+
+and its firmware version rides in User-Agent: CrossPlay-ESP32-<version>.
+client_of() reads all of it off a request without trusting any of it: an id
+that is not 64 hex is no id, a board that is not a short word is no board, a
+report over REPORT_MAX bytes or not a JSON object is ignored with one debug
+line, and only numbers are copied out of the health fields. The usage event
+the service posts anyway (a sync) then carries the device, its board and
+version and the three health numbers; Client.report() posts the crash and the
+update attempt the device is carrying as firmware events of their own.
 
 Byte-identical twin of the other bridge's bridge/events.py (study-bridge and
 read-bridge). Neither Dockerfile can COPY a file from outside its own
@@ -29,8 +49,10 @@ import hashlib
 import json
 import logging
 import os
+import re
 import threading
 import urllib.request
+from dataclasses import dataclass, field
 
 log = logging.getLogger("bridge.events")
 
@@ -41,6 +63,16 @@ TIMEOUT_S = 3.0
 # from elsewhere (a token hash in a state file, an account id in a log) cannot
 # be matched to a row on the board by hashing it once more.
 SALT = "crossplay-events"
+
+# The report header is at most 600 bytes from the firmware; anything past
+# this cap is not a report, whatever it says it is.
+REPORT_MAX = 1000
+# The three numbers every report carries, copied onto the usage event.
+HEALTH_KEYS = ("battery_pct", "heap_min_kb", "uptime_h")
+
+_HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
+_BOARD = re.compile(r"^[a-z0-9]{1,16}$")
+_UA = re.compile(r"^CrossPlay-ESP32-(\S{1,32})")
 
 # The whole HTTP layer, as one name the tests replace.
 _urlopen = urllib.request.urlopen
@@ -72,6 +104,8 @@ def post(
     device: str = "",
     level: str = "info",
     props: dict | None = None,
+    version: str = "",
+    board: str = "",
 ) -> threading.Thread | None:
     """Queue one event for the board. Never raises, never blocks.
 
@@ -83,6 +117,10 @@ def post(
         record = {"service": service, "event": event, "level": level}
         if device:
             record["device"] = device
+        if version:
+            record["version"] = version
+        if board:
+            record["board"] = board
         record["props"] = props or {}
         body = json.dumps(record).encode()
         url = os.environ["SUPABASE_URL"].strip().rstrip("/") + "/rest/v1/events"
@@ -117,3 +155,143 @@ def _deliver(url: str, key: str, body: bytes) -> None:
             resp.close()
     except Exception as e:
         log.warning("event dropped, the board did not take it: %s", e)
+
+
+# ------------------------------------------------------------ the device
+@dataclass
+class Client:
+    """What one request says about the device that made it.
+
+    Every field may be empty: a browser, a curl, an old firmware. device is
+    the header's id when it was a valid one, else the fallback the service
+    passed (its own hash of the token), else nothing. health holds whichever
+    of HEALTH_KEYS the report carried as numbers. crash and ota are the
+    report's objects of those names, verbatim, or None."""
+
+    device: str = ""
+    board: str = ""
+    version: str = ""
+    health: dict = field(default_factory=dict)
+    crash: dict | None = None
+    ota: dict | None = None
+
+    def props(self, base: dict | None = None) -> dict:
+        """The props of a usage event: the caller's, plus the health numbers.
+        The caller's win on a shared key."""
+        p = dict(self.health)
+        p.update(base or {})
+        return p
+
+    def report(self, via: str) -> int:
+        """Post what the device is carrying: one firmware/crash event at level
+        error, one firmware/update event. via names the service that relayed
+        it. Returns how many events went out. Never raises: a request must
+        not fail because of what rode along with it."""
+        n = 0
+        try:
+            if self.crash is not None:
+                c = self.crash
+                post(
+                    "firmware",
+                    "crash",
+                    level="error",
+                    device=self.device,
+                    # The version that crashed, written down at the boot after
+                    # the panic; the running one when the record lacks it.
+                    version=str(c.get("version") or self.version),
+                    board=self.board,
+                    props={
+                        "message": str(c.get("message") or ""),
+                        "backtrace": str(c.get("backtrace") or ""),
+                        "app": "firmware",
+                        "via": via,
+                    },
+                )
+                log.info("device report via %s: crash on %s", via, c.get("version"))
+                n += 1
+            if self.ota is not None:
+                o = self.ota
+                props = dict(o)
+                props["app"] = "firmware"
+                level = "info"
+                if o.get("ok") is False and o.get("error"):
+                    level = "error"
+                    props["message"] = (
+                        f"update failed: {o.get('error')} ({o.get('path') or 'unknown'})"
+                    )
+                post(
+                    "firmware",
+                    "update",
+                    level=level,
+                    device=self.device,
+                    version=self.version,
+                    board=self.board,
+                    props=props,
+                )
+                log.info("device report via %s: update %s", via, level)
+                n += 1
+        except Exception as e:  # a report shaped to break str() or dict()
+            log.warning("device report via %s dropped: %s", via, e)
+        return n
+
+
+def client_of(headers, default_device: str = "") -> Client:
+    """Read the device headers off a request. headers is anything with .get()
+    keyed case-insensitively (Starlette's Headers) or by lowercase name (a
+    dict in a test). Never raises."""
+    c = Client(device=default_device)
+    try:
+        get = lambda name: str(headers.get(name) or "")  # noqa: E731
+        dev = get("x-crossplay-device").strip()
+        if _HEX64.match(dev):
+            c.device = dev.lower()
+        board = get("x-crossplay-board").strip().lower()
+        if _BOARD.match(board):
+            c.board = board
+        m = _UA.match(get("user-agent"))
+        if m:
+            c.version = m.group(1)
+        raw = get("x-crossplay-report")
+        if raw:
+            report = _parse_report(raw)
+            if report is not None:
+                for k in HEALTH_KEYS:
+                    v = report.get(k)
+                    if isinstance(v, (int, float)) and not isinstance(v, bool):
+                        c.health[k] = v
+                if isinstance(report.get("crash"), dict):
+                    c.crash = report["crash"]
+                if isinstance(report.get("ota"), dict):
+                    c.ota = report["ota"]
+    except Exception as e:
+        log.debug("device headers ignored: %s", e)
+    return c
+
+
+def client_for(request, default_device: str = "") -> Client:
+    """client_of(), once per request. The Client rides the ASGI scope, so the
+    handler that posts the usage event and the middleware that posts the
+    device's report read the headers once and say so once; the handler runs
+    first, so its default_device is the one both see."""
+    c = request.scope.get("crossplay_client")
+    if c is None:
+        c = client_of(request.headers, default_device)
+        request.scope["crossplay_client"] = c
+    return c
+
+
+def _parse_report(raw: str) -> dict | None:
+    # Header values are one byte per character on the wire, so the length of
+    # the string is the length of the header.
+    if len(raw) > REPORT_MAX:
+        log.debug("X-CrossPlay-Report ignored: %d bytes, the cap is %d", len(raw), REPORT_MAX)
+        return None
+    try:
+        report = json.loads(raw)
+    except ValueError as e:
+        log.debug("X-CrossPlay-Report ignored: not JSON (%s)", e)
+        return None
+    if not isinstance(report, dict):
+        log.debug("X-CrossPlay-Report ignored: not an object")
+        return None
+    return report

--- a/server/study-bridge/bridge/jobs.py
+++ b/server/study-bridge/bridge/jobs.py
@@ -22,24 +22,28 @@ log = logging.getLogger("bridge.jobs")
 _clock = time.monotonic
 
 
-def _report(service, device, failure, summary, props, elapsed):
-    """One event per finished job: what it moved, or what it died of. Never
-    raises -- the job is already done or failed on its own terms, and the
-    board is not allowed to change that."""
+def _report(service, client, failure, summary, props, elapsed):
+    """One event per finished job: what it moved, or what it died of, under
+    the device that asked (its header id, board, version and health numbers;
+    events.Client). Never raises -- the job is already done or failed on its
+    own terms, and the board is not allowed to change that."""
     try:
         if failure is None:
             p = dict(props(summary) if props else {})
             p["seconds"] = round(elapsed, 1)
-            events.post(service, "sync", device=device, props=p)
+            level = "info"
         else:
-            message = f"{type(failure).__name__}: {failure}"[:200]
-            events.post(
-                service,
-                "sync",
-                device=device,
-                level="error",
-                props={"message": message},
-            )
+            p = {"message": f"{type(failure).__name__}: {failure}"[:200]}
+            level = "error"
+        events.post(
+            service,
+            "sync",
+            device=client.device,
+            version=client.version,
+            board=client.board,
+            level=level,
+            props=client.props(p),
+        )
     except Exception:
         log.exception("event for a %s job not posted", service)
 
@@ -70,7 +74,7 @@ class Jobs:
         return None
 
     def start(
-        self, uid: str, work, *, service: str = "", device: str = "", props=None
+        self, uid: str, work, *, service: str = "", client=None, props=None
     ) -> Job:
         """work: a blocking callable run in a thread under the user lock.
         Returns the existing job instead when one is already in flight.
@@ -78,10 +82,13 @@ class Jobs:
         service names the board's row for this job (events.py): when set,
         the job's end posts one event -- `sync` with props(summary) plus the
         seconds it took, or `sync` at level error with what it died of.
-        device is the hashed id the event is counted under."""
+        client is the events.Client the request came from: the id the event
+        is counted under, the board, the version, the health numbers."""
         existing = self.active_for(uid)
         if existing:
             return existing
+        if client is None:
+            client = events.Client()
         job = Job(uid)
         self._jobs[job.id] = job
         self._active[uid] = job.id
@@ -109,7 +116,7 @@ class Jobs:
                     failure = e
                 if service:
                     _report(
-                        service, device, failure, job.summary, props, _clock() - started
+                        service, client, failure, job.summary, props, _clock() - started
                     )
 
         asyncio.get_running_loop().create_task(run())

--- a/server/study-bridge/tests/test_api.py
+++ b/server/study-bridge/tests/test_api.py
@@ -405,7 +405,7 @@ async def run(tmp):
         events._urlopen = take
         # Each job reads the clock twice; pinned so `seconds` is asserted
         # exactly rather than as "some number".
-        ticks = iter([100.0, 102.5, 200.0, 200.4, 300.0, 300.1, 400.0, 400.2])
+        ticks = iter([100.0, 102.5, 200.0, 200.4, 300.0, 300.1, 400.0, 400.2, 500.0, 502.0, 600.0, 600.5])
         jobs_mod._clock = lambda: next(ticks, time.monotonic())
         # The syncs above spent this user's window; this block gets a fresh
         # one with the same limits.
@@ -513,6 +513,112 @@ async def run(tmp):
             and wire_body["props"] == {"message": "Frozen: AnkiWeb wants an upload."},
             f"a frozen sync posts its sentence at level error, got {wire_body}",
         )
+
+        # --- The device headers: a reader that says who it is, and what it
+        # has to report, on the request it was making anyway. The sync event
+        # is counted under the header's id, not the token hash, and carries
+        # the health numbers; the crash and the update post as firmware
+        # events of their own, from the middleware, whatever the endpoint.
+        del posted[:]
+        app_mod.SYNC_USER = Window(6, 300)
+        DEV = "0" * 64
+        report = {
+            "battery_pct": 50,
+            "heap_min_kb": 100,
+            "uptime_h": 1,
+            "crash": {"message": "assert failed: x (reset: panic)", "version": "1.12.12", "backtrace": ""},
+            "ota": {"attempted": True, "ok": False, "error": "too_large", "path": "ota"},
+        }
+        talking = {
+            **dev,
+            "User-Agent": "CrossPlay-ESP32-1.12.13",
+            "X-CrossPlay-Device": DEV,
+            "X-CrossPlay-Board": "x4pro",
+            "X-CrossPlay-Report": json.dumps(report, separators=(",", ":")),
+        }
+        r = await web.post(
+            "/api/sync",
+            headers=talking,
+            content=struct.pack("<I", len(empty_header)) + empty_header,
+        )
+        ok(r.status_code == 200, f"a sync with the device headers is accepted, got {r.status_code}")
+        status = await finish(r.json()["job"])
+        ok(status["status"] == "done", f"and finishes, got {status}")
+        await settle(3)
+        ok(len(posted) == 3, f"the sync, the crash and the update are three events, got {len(posted)}")
+        bodies = sorted((json.loads(p.data) for p in posted), key=lambda b: (b["service"], b["event"]))
+        ok(
+            bodies[0]
+            == {
+                "service": "anki",
+                "event": "sync",
+                "level": "info",
+                "device": DEV,
+                "version": "1.12.13",
+                "board": "x4pro",
+                "props": {"cards": 0, "reviews": 0, "seconds": 2.0, "battery_pct": 50, "heap_min_kb": 100, "uptime_h": 1},
+            },
+            f"the sync is counted under the device's own id with its health, got {bodies[0]}",
+        )
+        ok(
+            bodies[1]
+            == {
+                "service": "firmware",
+                "event": "crash",
+                "level": "error",
+                "device": DEV,
+                "version": "1.12.12",
+                "board": "x4pro",
+                "props": {"message": "assert failed: x (reset: panic)", "backtrace": "", "app": "firmware", "via": "anki"},
+            },
+            f"the crash posts as the firmware's, via anki, got {bodies[1]}",
+        )
+        ok(
+            bodies[2]
+            == {
+                "service": "firmware",
+                "event": "update",
+                "level": "error",
+                "device": DEV,
+                "version": "1.12.13",
+                "board": "x4pro",
+                "props": {"attempted": True, "ok": False, "error": "too_large", "path": "ota", "app": "firmware", "message": "update failed: too_large (ota)"},
+            },
+            f"the failed update posts as an error with its message, got {bodies[2]}",
+        )
+        ok(expected_device not in "".join(p.data.decode() for p in posted), "the token hash is not used when the device names itself")
+
+        # A report past the cap is not a report; the request is still served
+        # and still counted, without health, and nothing else posts.
+        del posted[:]
+        oversize = dict(talking)
+        oversize["X-CrossPlay-Report"] = json.dumps({"battery_pct": 50, "crash": {"message": "x" * 1180}})
+        ok(len(oversize["X-CrossPlay-Report"]) >= 1200, "the oversize report is at least 1200 bytes")
+        r = await web.post(
+            "/api/sync",
+            headers=oversize,
+            content=struct.pack("<I", len(empty_header)) + empty_header,
+        )
+        ok(r.status_code == 200, f"an oversize report does not fail the request, got {r.status_code}")
+        status = await finish(r.json()["job"])
+        ok(status["status"] == "done", f"and the sync finishes, got {status}")
+        await settle(1)
+        await asyncio.sleep(0.3)
+        ok(len(posted) == 1, f"only the sync posts, got {len(posted)}")
+        wire_body = json.loads(posted[0].data)
+        ok(
+            wire_body["device"] == DEV and wire_body["board"] == "x4pro"
+            and wire_body["props"] == {"cards": 0, "reviews": 0, "seconds": 0.5},
+            f"counted under the id, with no health from the ignored report, got {wire_body}",
+        )
+
+        # A crash on a request the service refuses is not posted: the device
+        # will carry it again, and posting it now would count it twice.
+        del posted[:]
+        r = await web.get("/api/decks", headers={k: v for k, v in talking.items() if k != "Authorization"})
+        ok(r.status_code == 401, "no token is still refused, headers or not")
+        await asyncio.sleep(0.3)
+        ok(posted == [], f"and a refused request posts nothing, got {len(posted)}")
 
         events._urlopen = urllib.request.urlopen
         jobs_mod._clock = time.monotonic

--- a/server/study-bridge/tests/test_events.py
+++ b/server/study-bridge/tests/test_events.py
@@ -188,6 +188,155 @@ def main():
     )
     ok(len(sent) == before and len(cap.records) == 1, "one warning, no request")
 
+    # --- the device headers: what a request says about the device
+    via = {"study-bridge": "anki", "read-bridge": "instapaper"}.get(ROOT.name, "anki")
+    cap.records.clear()
+    cap.setLevel(logging.DEBUG)
+    log.setLevel(logging.DEBUG)
+    events._urlopen = record
+    del sent[:]
+    DEV = "ab" * 32
+    report = {
+        "battery_pct": 50,
+        "heap_min_kb": 100,
+        "uptime_h": 1,
+        "crash": {"message": "assert failed: x (reset: panic)", "version": "1.12.12", "backtrace": "0x4000 0x4001"},
+        "ota": {"attempted": True, "ok": False, "error": "too_large", "path": "ota"},
+    }
+    full = {
+        "x-crossplay-device": DEV.upper(),
+        "x-crossplay-board": "x4pro",
+        "x-crossplay-report": json.dumps(report, separators=(",", ":")),
+        "user-agent": "CrossPlay-ESP32-1.12.13",
+    }
+    c = events.client_of(full, default_device="fallback")
+    ok(c.device == DEV, f"the header id wins over the fallback, lowercased, got {c.device}")
+    ok(c.board == "x4pro" and c.version == "1.12.13", f"board and version are read, got {c.board} {c.version}")
+    ok(
+        c.health == {"battery_pct": 50, "heap_min_kb": 100, "uptime_h": 1},
+        f"the three health numbers are copied, got {c.health}",
+    )
+    ok(
+        c.props({"cards": 3}) == {"cards": 3, "battery_pct": 50, "heap_min_kb": 100, "uptime_h": 1},
+        f"props() adds the health numbers to the caller's, got {c.props({'cards': 3})}",
+    )
+    ok(
+        c.props({"battery_pct": 7}) == {"battery_pct": 7, "heap_min_kb": 100, "uptime_h": 1},
+        "and the caller's value wins on a shared key",
+    )
+    n = c.report(via)
+    for _ in range(50):
+        if len(sent) >= 2:
+            break
+        time.sleep(0.05)
+    ok(n == 2 and len(sent) == 2, f"a crash and an update post two events, got {n} / {len(sent)}")
+    bodies = sorted((json.loads(r.data) for r, _ in sent), key=lambda b: b["event"])
+    ok(
+        bodies[0]
+        == {
+            "service": "firmware",
+            "event": "crash",
+            "level": "error",
+            "device": DEV,
+            "version": "1.12.12",
+            "board": "x4pro",
+            "props": {
+                "message": "assert failed: x (reset: panic)",
+                "backtrace": "0x4000 0x4001",
+                "app": "firmware",
+                "via": via,
+            },
+        },
+        f"the crash event is the contract's, under the version that crashed, got {bodies[0]}",
+    )
+    ok(
+        bodies[1]
+        == {
+            "service": "firmware",
+            "event": "update",
+            "level": "error",
+            "device": DEV,
+            "version": "1.12.13",
+            "board": "x4pro",
+            "props": {
+                "attempted": True,
+                "ok": False,
+                "error": "too_large",
+                "path": "ota",
+                "app": "firmware",
+                "message": "update failed: too_large (ota)",
+            },
+        },
+        f"a failed update is an error with a message, under the running version, got {bodies[1]}",
+    )
+    ok(
+        sum(r.levelno == logging.INFO and "device report" in r.getMessage() for r in cap.records) == 2,
+        f"each posted report logs one info line, got {[r.getMessage() for r in cap.records]}",
+    )
+
+    del sent[:]
+    good = dict(full)
+    good["x-crossplay-report"] = json.dumps({"battery_pct": 90, "ota": {"attempted": True, "ok": True}})
+    c = events.client_of(good)
+    ok(c.report(via) == 1, "an update that worked posts one event")
+    for _ in range(50):
+        if sent:
+            break
+        time.sleep(0.05)
+    body = json.loads(sent[0][0].data)
+    ok(
+        body["level"] == "info" and body["props"] == {"attempted": True, "ok": True, "app": "firmware"},
+        f"at level info, with the ota object as its props, got {body}",
+    )
+    ok(c.health == {"battery_pct": 90} and c.crash is None, "a report may carry only some fields")
+
+    # nothing, wrong, or too much
+    del sent[:]
+    c = events.client_of({}, default_device="fallback")
+    ok(
+        c == events.Client(device="fallback"),
+        f"no headers is the fallback id and nothing else, got {c}",
+    )
+    ok(c.report(via) == 0 and sent == [] and c.props() == {}, "and nothing to report")
+    c = events.client_of({"x-crossplay-device": "ab" * 31 + "zz", "x-crossplay-board": "X4 Pro!"}, default_device="fb")
+    ok(c.device == "fb" and c.board == "", f"an id that is not 64 hex and a board that is not a word are dropped, got {c}")
+    ok(events.client_of({"user-agent": "curl/8.0"}).version == "", "a UA that is not the firmware's has no version")
+    ok(
+        events.client_of({"x-crossplay-report": json.dumps({"battery_pct": "50", "heap_min_kb": True, "uptime_h": 2.5, "crash": "boom", "ota": [1]})}).__dict__
+        == events.Client(health={"uptime_h": 2.5}).__dict__,
+        "only numbers are health, only objects are crash and ota",
+    )
+    cap.records.clear()
+    big = json.dumps({"battery_pct": 50, "crash": {"message": "x" * 1180}})
+    ok(len(big) >= 1200, "the oversize report really is over the cap")
+    c = events.client_of({"x-crossplay-device": DEV, "x-crossplay-report": big})
+    ok(
+        c.device == DEV and c.health == {} and c.crash is None,
+        f"a report over {events.REPORT_MAX} bytes is ignored and the id beside it is not, got {c}",
+    )
+    c = events.client_of({"x-crossplay-report": "{not json"})
+    ok(c.health == {} and c.crash is None, "a report that is not JSON is ignored")
+    c = events.client_of({"x-crossplay-report": "[1,2]"})
+    ok(c.health == {}, "a report that is not an object is ignored")
+    debug = [r for r in cap.records if r.levelno == logging.DEBUG and "ignored" in r.getMessage()]
+    ok(len(debug) == 3, f"each ignored report is one debug line and nothing louder, got {[r.getMessage() for r in cap.records]}")
+    ok(not any(r.levelno > logging.DEBUG for r in cap.records), "no warning for a device that talks nonsense")
+    log.setLevel(logging.INFO)
+
+    # post() carries version and board when given, and omits them when not
+    del sent[:]
+    t = events.post("anki", "sync", device=DEV, version="1.12.13", board="sticky", props={"cards": 1})
+    t.join(5)
+    body = json.loads(sent[-1][0].data)
+    ok(
+        body == {"service": "anki", "event": "sync", "level": "info", "device": DEV, "version": "1.12.13", "board": "sticky", "props": {"cards": 1}},
+        f"version and board ride the body, got {body}",
+    )
+    t = events.post("anki", "sync", device=DEV, props={})
+    t.join(5)
+    body = json.loads(sent[-1][0].data)
+    ok("version" not in body and "board" not in body, "and an empty one is no field, not an empty string")
+
     # --- the twin
     other = [s for s in ("study-bridge", "read-bridge") if s != ROOT.name]
     twin = ROOT.parent / other[0] / "bridge" / "events.py"

--- a/site/api/inbox.js
+++ b/site/api/inbox.js
@@ -11,7 +11,7 @@
 //
 // Operations:
 //   list     -> {inbox: [open blockers that need Mario, with their card], cards: [every card]}
-//   numbers  -> {byVersion, daily, services, errors, pulse, weekly, dwell, latency, byApp}
+//   numbers  -> {byVersion, daily, battery, services, errors, pulse, weekly, dwell, latency, byApp}
 //   answer   -> closes one blocker: {card_id, n, choice, note}
 
 const crypto = require("node:crypto");
@@ -84,6 +84,7 @@ async function opNumbers() {
   const [
     byVersion,
     daily,
+    battery,
     services,
     errors,
     pulse,
@@ -94,6 +95,7 @@ async function opNumbers() {
   ] = await Promise.all([
     q("devices_by_version?select=*"),
     q("daily_active_devices?select=*"),
+    q("battery_by_version?select=*"),
     q("service_users?select=*"),
     q(
       "error_fingerprints?select=service,message,count,last_seen,card_id&order=last_seen.desc&limit=20",
@@ -107,6 +109,7 @@ async function opNumbers() {
   return {
     byVersion,
     daily,
+    battery,
     services,
     errors,
     pulse,

--- a/site/inbox/index.html
+++ b/site/inbox/index.html
@@ -217,11 +217,12 @@
       var devices7 = (n.byVersion || []).reduce(function (a, r) { return a + (r.devices || 0); }, 0);
       var today = (n.daily || []).length ? n.daily[0].devices : 0;
       var h = '<div class="num-grid">' +
-        '<div class="tile"><b>' + devices7 + '</b><span>devices heard from, 7 days</span></div>' +
+        '<div class="tile"><b>' + devices7 + '</b><span>devices that used a service, 7 days</span></div>' +
         '<div class="tile"><b>' + today + '</b><span>devices today</span></div>' +
         '<div class="tile"><b>' + (n.errors || []).filter(function (e) { return e.card_id; }).length + '</b><span>distinct errors with a card</span></div>' +
         '</div>';
       h += '<p class="nums-h">Devices by version, 7 days</p>' + tbl(["board", "version", "devices"], (n.byVersion || []).map(function (r) { return [r.board, r.version, r.devices]; }));
+      h += '<p class="nums-h">Battery by version, 7 days</p>' + tbl(["board", "version", "avg %", "devices"], (n.battery || []).map(function (r) { return [r.board, r.version, r.battery_pct, r.devices]; }));
       h += '<p class="nums-h">Who uses each service, 7 days</p>' + tbl(["service", "devices", "events"], (n.services || []).map(function (r) { return [r.service, r.devices_7d, r.events_7d]; }));
       h += '<p class="nums-h">Downloads per release, from GitHub, all time</p>' + tbl(["release", "published", "downloads"], releases.map(function (r) {
         var d = (r.assets || []).filter(function (a) { return /firmware(-sticky)?\.bin$|-full\.bin$/.test(a.name); }).reduce(function (a, x) { return a + (x.download_count || 0); }, 0);
@@ -234,7 +235,7 @@
       h += '<p class="nums-h">The workflow, by week</p>' + tbl(["week", "opened", "closed", "asks to you", "answers", "error cards", "refusals", "releases"], (n.weekly || []).map(function (r) { return [r.week, r.cards_opened, r.cards_closed, r.asks_to_mario, r.answers_from_mario, r.error_cards, r.refusals, r.releases]; }));
       h += '<p class="nums-h">Hours a card sits in each state, 30 days</p>' + tbl(["state", "cards", "median", "longest"], (n.dwell || []).map(function (r) { return [r.state, r.n, r.median_h, r.max_h]; }));
       h += '<p class="nums-h">Open cards by app</p>' + tbl(["app", "open", "untriaged", "oldest, days"], (n.byApp || []).map(function (r) { return [r.app, r.open, r.untriaged, r.oldest_d]; }));
-      if (!(n.byVersion || []).length && !(n.services || []).length) h += '<p class="status">No events yet. Devices and services start posting once their owners wire the heartbeat and the events in docs/workflow/events.md.</p>';
+      if (!(n.byVersion || []).length && !(n.services || []).length) h += '<p class="status">No events yet. Devices are counted from the requests they make to the services; see docs/workflow/events.md.</p>';
       body.innerHTML = h;
     });
   }


### PR DESCRIPTION
A device never makes a request just to report. The three services now read what a device says on the requests it already makes, and the board counts devices from that.

## What changed

- **Both bridges** (`server/study-bridge`, `server/read-bridge`; `bridge/events.py` stays byte-identical twins): the sync event is counted under `X-CrossPlay-Device`, with `X-CrossPlay-Board`, the version from the User-Agent and the report's `battery_pct`/`heap_min_kb`/`uptime_h` in the props; a middleware on every endpoint posts `firmware/crash` (error, `props.via` = the bridge) and `firmware/update` (error with `update failed: <error> (<path>)` when `ok` is false) for what `X-CrossPlay-Report` carries. Requests without the headers behave exactly as before.
- **Board**: `devices_by_version` and `daily_active_devices` read every event with a device (no heartbeat any more); new `battery_by_version` (per-device average first, then across devices, with device and report counts); `heartbeat-silence` cron unscheduled and `heartbeat_silence_check()` dropped. Inbox page gets "Battery by version, 7 days"; `docs/workflow/events.md` replaces the heartbeat section with the header contract and what each service posts.
- **Get Books** (outside this repo, not a git repository): same reader in `getbooks/events.py`, `DeviceReportMiddleware` inside Basic auth; deployed.

## Verified

- Get Books `./scripts/test.sh`: all green (+13 header checks through the whole middleware stack).
- study `test_events` 50/0, `test_api` 60/0; read `test_events` 50/0, `test_api` 78/0; engine/window/oauth/article/lockout green; `host-tests/study` PASS, `host-tests/instapaper` 92/0, `host-tests/site` 103/0.
- Migration applied live with psql: `cron.job` lists events-rollup, pulse-collect, pulse-fire; the three views carry `security_invoker`.
- Deployed: Get Books (healthy, `board events on`, `/healthz` 200), ankibridge (`deploy.sh` + isolation test green, `events on`, `/` 200), readbridge (`deploy.sh` "deployed, and confined", `events on`, `/` 200).
- Live proof from the pi: one curl with the three headers against `/opds/search?q=dune` produced `getbooks/search` `{q_len, results, battery_pct:50, heap_min_kb:100, uptime_h:1}` under device `000…0`, version 9.9.9, board x4pro, plus `firmware/crash` (error, `via: getbooks`) which opened card #132; `devices_by_version` and `battery_by_version` showed the device. Test rows, fingerprint and card deleted afterwards.

## Not verified

- No real device has sent the headers yet; the firmware PR must match this contract byte for byte (header names, `crash.version`, `ota.ok`/`error`/`path`).
- Reports are posted only for answers under 400, assuming the firmware keeps a report until a request carrying it succeeds. If the firmware drops it on any answer, a report riding a 401 or 5xx is lost.
- `site/index.html`'s installer sentence about "Send a daily heartbeat" is left to the firmware PR that decides that setting's fate.

## Decisions (also in the commit bodies)

- Report read in a middleware on every endpoint, not in the sync handler: the device attaches it to whatever request it makes, and the server cannot know which one the firmware treats as delivered.
- Parsed once per request, cached on the ASGI scope, so a bad report logs one debug line, not two.
- Nothing in the headers is trusted: non-64-hex id is no id, board must match `[a-z0-9]{1,16}` (a future board needs no server change), report over 1000 bytes or not an object is ignored, only numbers are copied out of the health fields.
- One commit for both bridges: the twin test fails on a per-bridge split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
