### PR TITLE
autorelease: a merge that cannot reach a device is not a release

### DIFF
--- a/.github/workflows/crossplay-autorelease.yml
+++ b/.github/workflows/crossplay-autorelease.yml
@@ -1,8 +1,8 @@
 # A release starts the moment a merge passes CI. No clock, no train.
 #
 # Runs after every completed "CrossPlay" CI run on xteink. If the run was
-# green, the tip of xteink is still the commit CI verified, and something has
-# merged since the newest tag, this bumps [crossplay] version, rewrites the
+# green, the tip of xteink is still the commit CI verified, and something that
+# can reach a device image has merged since the newest tag, this bumps [crossplay] version, rewrites the
 # "What is new" block in crossplay-release.yml from the merged pull requests'
 # own lines (scripts_local/release_notes.py), commits, tags, and dispatches
 # the release workflow on that tag.
@@ -63,6 +63,13 @@ jobs:
           tip="$(git rev-parse HEAD)"
           if [ "$tip" != "$VERIFIED" ]; then
             echo "xteink moved past the commit CI verified ($VERIFIED -> $tip); the run for the new tip releases it."
+            echo "go=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # A merge that cannot change a device image (docs, site, tooling,
+          # workflows) is not a release: no bump, no tag, no update prompt on
+          # every device for nothing. scripts_local/release-needed.sh asks the
+          # one rule that knows which paths reach an image.
+          if ! bash scripts_local/release-needed.sh; then
             echo "go=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
           echo "go=true" >> "$GITHUB_OUTPUT"

--- a/host-tests/autorelease/run.sh
+++ b/host-tests/autorelease/run.sh
@@ -101,5 +101,20 @@ q git checkout -q v1.12.9 2>/dev/null; q git checkout -q -b quiet
 python3 "$TOOL" --repo-dir "$R" --pr-json "$WORK/prs.json" --dry-run 2>&1 | grep -q "NEXT_VERSION=$" && ok "nothing since the tag means no version" || bad "released with nothing merged"
 
 echo
+echo "release-needed.sh"
+mkdir -p "$R/scripts_local"
+cp "$HERE/../../scripts_local/device-build-needed.sh" "$HERE/../../scripts_local/release-needed.sh" "$R/scripts_local/"
+chmod +x "$R"/scripts_local/*.sh
+cdd "$R"
+q git add -A; q git commit -qm "chore: scripts"
+q git tag v1.12.10
+bash scripts_local/release-needed.sh >/dev/null 2>&1; [ $? -eq 1 ] && ok "nothing merged since the tag: no release" || bad "released with nothing since the tag"
+mkdir -p docs; echo words > docs/note.md; q git add -A; q git commit -qm "docs: a note"
+bash scripts_local/release-needed.sh >/dev/null 2>&1; [ $? -eq 1 ] && ok "a docs-only merge since the tag is not a release" || bad "a docs-only change would release"
+mkdir -p src; echo 'int x;' > src/x.cpp; q git add -A; q git commit -qm "fix: something a device can see"
+bash scripts_local/release-needed.sh >/dev/null 2>&1; [ $? -eq 0 ] && ok "a src change since the tag releases" || bad "a src change did not release"
+q git tag -d v1.12.10; q git tag -d v1.12.9
+bash scripts_local/release-needed.sh >/dev/null 2>&1; [ $? -eq 0 ] && ok "no tag at all means release" || bad "no tag refused to release"
+
 echo "$((PASS+FAIL)) checks, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/scripts_local/release-needed.sh
+++ b/scripts_local/release-needed.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Should a green merge into xteink become a release?
+#
+# The autorelease used to release on every green merge, a documentation edit
+# included: a version bump, a tag, four device images and an update prompt on
+# every device, for a change no device can see. The rule that already knows
+# which paths can reach a device image is scripts_local/device-build-needed.sh;
+# this asks it about the commits since the newest release tag.
+#
+#   scripts_local/release-needed.sh            # in a checkout of xteink
+#
+# Exit 0: release (something since the last tag can change a device image, or
+#         the question cannot be answered: no tag, no git; unknown means release).
+# Exit 1: nothing since the last release tag can alter a device image.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+last="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null)" || last=""
+if [ -z "$last" ]; then
+  echo "no release tag reachable: releasing"
+  exit 0
+fi
+if [ "$(git rev-list --count "$last..HEAD" 2>/dev/null || echo 1)" = "0" ]; then
+  echo "nothing merged since $last: not releasing"
+  exit 1
+fi
+if "$HERE/device-build-needed.sh" --range "$last..HEAD" --quiet; then
+  echo "something since $last can reach a device image: releasing"
+  exit 0
+fi
+echo "nothing since $last can alter a device image (docs, site, tooling, workflows only): not releasing"
+exit 1


### PR DESCRIPTION
With the brake off, every green merge released, docs edits included. `scripts_local/release-needed.sh` asks `device-build-needed.sh` (the rule that knows which paths reach a device image) about the commits since the newest `v*` tag; the autorelease gate stops when nothing can change an image. Unknown still means release.

Verified: host-tests/autorelease 18 checks. Not verified: the workflow step runs only on xteink; this PR's own merge (workflow and scripts only) is the first live test and must not produce a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)