### PR TITLE
guard: a write verb counts only as a command word, outside quotes

### DIFF
--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -69,6 +69,9 @@ expect "cd out of the tree ends the tree context"   0 pretool "{\"session_id\":\
 expect "integrator bash merge allowed"          0 pretool "{\"session_id\":\"$INTEG\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd $ROOT/firmware-next && git merge app/x\"}}"
 
 echo "the build lock"
+expect "grep -ln on the tree is a read, not ln"     0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"grep -ln schedule: $ROOT/firmware-next/.github/workflows/x.yml\"}}"
+expect "a quoted 'sed -i' pattern is a read"         0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"grep -n \\\"sed -i\\\" $ROOT/firmware-next/scripts/x.sh\"}}"
+expect "sed -i with a quoted tree path is a write"   2 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sed -i '' \\\"$ROOT/firmware-next/src/a.cpp\\\"\"}}"
 expect "raw pio run refused"                    2 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd wt/x && pio run -e x4pro\"}}"
 expect "check.sh allowed"                       0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd wt/x && ./scripts_local/check.sh --tests\"}}"
 expect "pio in a word is not pio run"           0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"grep -rn 'pio run' docs\"}}"

--- a/scripts_local/hooks/guard.py
+++ b/scripts_local/hooks/guard.py
@@ -36,11 +36,15 @@ HANDBACK = re.compile(
     re.IGNORECASE,
 )
 
+# A verb counts only as a command word: not inside a flag (`grep -ln` is not
+# `ln`) and not inside a quoted string (a grep PATTERN that says "sed -i" reads
+# a file, it does not edit one). Both refused read-only commands on 2026-09-04.
 WRITE_VERB = re.compile(
-    r"(\bsed\s+-i|\btee\b|\bcp\b|\bmv\b|\brm\b|\btouch\b|\bmkdir\b|\bln\b|\btruncate\b|"
-    r"\bgit\s+(merge|commit|checkout|reset|rebase|cherry-pick|tag|push|pull|switch|stash|apply|am|clean|restore)\b|"
-    r"\bpio\s+run|\bbuild\.py|\bprecompress\.py)"
+    r"((?<![\w-])sed\s+-i|(?<![\w-])(tee|cp|mv|rm|touch|mkdir|ln|truncate)(?![\w-])|"
+    r"(?<![\w-])git\s+(merge|commit|checkout|reset|rebase|cherry-pick|tag|push|pull|switch|stash|apply|am|clean|restore)\b|"
+    r"(?<![\w-])pio\s+run|\bbuild\.py|\bprecompress\.py)"
 )
+QUOTED = re.compile(r"'[^']*'|\"[^\"]*\"")
 # A redirect whose TARGET is a file (2>&1 and >/dev/null are not writes into anything of ours).
 REDIRECT = re.compile(r"(?<![0-9&<])>{1,2}\s*(?!&)(\S+)")
 HEREDOC = re.compile(r"<<-?\s*['\"]?(\w+)['\"]?[^\n]*\n.*?\n\s*\1\s*(?=\n|$)", re.S)
@@ -214,7 +218,8 @@ def writes_into_tree(cmd):
             in_tree = "firmware-next" in m.group(1)
             continue
         names_tree = "firmware-next" in seg
-        if WRITE_VERB.search(seg) and (in_tree or names_tree):
+        # Verbs are looked for outside quotes; the tree's name anywhere counts.
+        if WRITE_VERB.search(QUOTED.sub(" ", seg)) and (in_tree or names_tree):
             return True
         for r in REDIRECT.finditer(seg):
             target = r.group(1).strip("\"'")


### PR DESCRIPTION
Two read-only commands were refused tonight: a `grep -ln` on the integration tree (because `-ln` contains `ln`) and a grep whose pattern named an in-place sed. Verbs now need a non-word, non-dash boundary and are matched with quoted strings removed; the tree's name still counts anywhere, so an in-place sed on a quoted tree path is still refused.

Verified: bugflow suite 86 checks. Not verified: nothing else changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
