### PR TITLE
ci: xteink queues its runs instead of cancelling them, so releases fire

### DIFF
--- a/.github/workflows/crossplay-ci.yml
+++ b/.github/workflows/crossplay-ci.yml
@@ -23,12 +23,27 @@ permissions:
 
 # One run per branch at a time. A push on top of a pull request supersedes
 # the run for the commit it replaced; five runs of one branch were once
-# sharing the runners while a merge waited on its own build. On xteink the
-# same rule folds two quick merges into one run, and the autorelease that
-# listens for this workflow releases them together.
+# sharing the runners while a merge waited on its own build.
+#
+# Not on xteink, and this is the whole reason for the expression below.
+# Superseding was meant to fold two quick merges into one run that releases
+# them together, which works when a run survives to the end. It does not
+# survive a STREAM of merges: on the night of 2026-09-03 they landed at
+# 22:58, 23:05, 23:42, 23:47 (three), 23:56, 00:16 and 00:29 -- every 13 to
+# 20 minutes, and this build takes longer than that. Each merge cancelled the
+# previous merge's run, three in a row reached no conclusion at all, and
+# crossplay-autorelease.yml fires on `workflow_run` with conclusion success.
+# A cancelled run is not a success, so nothing released for six merges while
+# RELEASE_HOLD was 0 and nobody was holding anything. Every individual
+# cancellation looked exactly like this rule working correctly.
+#
+# So pull requests still supersede, and xteink queues. crossplay-emulator.yml
+# already does the second thing (cancel-in-progress: false), which is why its
+# run for 2b9f3a84 finished while this workflow's run for the same commit was
+# cancelled -- the same merge, the two rules, two outcomes.
 concurrency:
   group: crossplay-ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/xteink' }}
 
 jobs:
   build:

--- a/host-tests/ci/run.sh
+++ b/host-tests/ci/run.sh
@@ -105,5 +105,30 @@ for ini in "$HERE/../.."/platformio*.ini; do
   done < <(grep -oE '^[^;#]*=(https?|git)://[^ ]*#[0-9a-f]+' "$ini" | sed 's/.*#//')
 done
 
+# The release trigger, which is a concurrency setting three files away.
+#
+# crossplay-autorelease.yml fires on `workflow_run` with conclusion success.
+# A run cancelled by the next merge has no conclusion, so it releases nothing.
+# With cancel-in-progress true on xteink, a stream of merges arriving faster
+# than this build takes cancels every run in turn and NOTHING ever releases,
+# while each individual cancellation looks like the concurrency rule working.
+# That ran for six merges on 2026-09-03 with RELEASE_HOLD at 0.
+#
+# Superseding is still right on a pull request, so this asserts the shape
+# rather than the absence: cancellation must be conditional on the ref.
+checks=$((checks + 1))
+cip=$(grep -A 2 '^concurrency:' "$YML" | grep 'cancel-in-progress:' | cut -d: -f2- | tr -d ' ')
+case "$cip" in
+  true|"")
+    failed=$((failed + 1))
+    echo "FAIL ci  crossplay-ci.yml cancels in progress unconditionally: a merge on xteink kills the previous merge's run, and the autorelease only fires on a run that reached success"
+    ;;
+  *xteink*) ;;
+  *)
+    failed=$((failed + 1))
+    echo "FAIL ci  crossplay-ci.yml's cancel-in-progress ('$cip') does not mention xteink, so it cannot be exempting the branch the autorelease listens to"
+    ;;
+esac
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
## The symptom

Nothing has released since `v1.12.13` at 01:34, six merges ago, with
`RELEASE_HOLD` at `0` and nobody holding anything.

## Why

`crossplay-autorelease.yml` fires on `workflow_run` with `conclusion ==
'success'`. `crossplay-ci.yml` cancelled in progress on **every** ref, so on
`xteink` each merge killed the run started by the merge before it. A cancelled
run has no conclusion, so it releases nothing.

That is fine when merges are occasional — superseding was meant to fold two
quick merges into one run that releases them together, and it does exactly
that. It is not fine under a stream. Last night they landed at 22:58, 23:05,
23:42, 23:47 (three), 23:56, 00:16 and 00:29: every 13 to 20 minutes, and this
build takes longer than that. Three runs in a row were cancelled before
reaching any conclusion.

```
cancelled  CrossPlay  2b9f3a84   <- killed by 92c47e6b
cancelled  CrossPlay  92c47e6b   <- killed by 2ff516d1
           CrossPlay  2ff516d1
```

Nobody caught it because each individual cancellation is the concurrency rule
working exactly as designed. The failure only exists in the aggregate.

**The tell:** `crossplay-emulator.yml` has used `cancel-in-progress: false`
all along. For merge `2b9f3a84` its run finished while this workflow's run for
the same commit was cancelled — same merge, two rules, two outcomes.

## The change

One expression. Pull requests still supersede, which is where that rule earns
its keep; only `xteink` queues.

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/xteink' }}
```

## The test

`host-tests/ci` asserts the **shape**, not the absence, because cancelling is
still correct on a pull request: `cancel-in-progress` must be conditional and
must name the branch the autorelease listens to. I put the literal `true`
back and watched it fail, then restored it and watched it pass.

The cost is runner time: `xteink` runs no longer collapse into one. That is
the price of the release actually firing, and the emulator workflow has been
paying it without complaint.

## Verified

`./scripts_local/check.sh --tests`: **all green**, no skips.

## Not verified

The thing this fixes cannot be observed until several merges land on `xteink`
in quick succession and each run is seen to survive. Found while landing
#26, which is also why that PR's own release never cut.

Board card #143.

🤖 Generated with [Claude Code](https://claude.com/claude-code)