### PR TITLE
fix: the release takes the bootloader from the framework package

### DIFF
--- a/.github/workflows/crossplay-release.yml
+++ b/.github/workflows/crossplay-release.yml
@@ -104,10 +104,44 @@ jobs:
       # bootloader header are the ones this build was configured with. Passing
       # them again by hand is a second copy of a fact that can drift; verified
       # byte-identical to spelling them out.
+      # The bootloader is no longer a build output. e31dcbb0 ("don't recompile
+      # Arduino IDF libs", upstream #3242) stopped compiling the IDF, and
+      # .pio/build/<env>/bootloader.bin was a by-product of that compile. The
+      # firmware builds still pass without it -- only merge-bin needs it -- so
+      # this surfaced as a release that tagged and then could not publish
+      # (v1.12.14).
+      #
+      # The framework package ships the same bootloader prebuilt, as an ELF per
+      # flash mode. Both envs are dio at 80m (board_build.flash_mode, and
+      # board_build.arduino.memory_type = dio_opi, where the opi half is the
+      # PSRAM), so both take bootloader_dio_80m.elf.
+      #
+      # This is not an assumption about equivalence: the .bin produced here was
+      # compared byte for byte against the first 18736 bytes of BOTH published
+      # v1.12.13 full images, x4pro and sticky, and is identical to each. That
+      # matters more than usual, because this is what gets written at 0x0 on a
+      # first install, and shipping the wrong thing there is what broke v1.0.0
+      # and v1.0.1.
+      - name: The bootloader, from the framework package
+        run: |
+          pip install --upgrade esptool
+          elf="$HOME/.platformio/packages/framework-arduinoespressif32-libs/esp32s3/bin/bootloader_dio_80m.elf"
+          test -f "$elf" || { echo "::error::no prebuilt bootloader at $elf"; exit 1; }
+          for env_name in gh_release_x4pro gh_release_sticky; do
+            out=".pio/build/$env_name/bootloader.bin"
+            if [ -f "$out" ]; then
+              echo "$env_name already built its own bootloader; keeping it"
+              continue
+            fi
+            python -m esptool --chip esp32s3 elf2image \
+              --flash_mode dio --flash_freq 80m --flash_size 16MB \
+              -o "$out" "$elf"
+          done
+          sha256sum .pio/build/gh_release_*/bootloader.bin
+
       - name: Name the x4pro artefacts
         run: |
           mkdir -p dist
-          pip install --upgrade esptool
           python -m esptool --chip esp32s3 merge-bin --format raw \
             -o "dist/crossplay-${GITHUB_REF_NAME}-x4pro-full.bin" \
             -fm keep -fs keep -ff keep \

--- a/host-tests/release/run.sh
+++ b/host-tests/release/run.sh
@@ -878,5 +878,31 @@ else
   fi
 fi
 
+# Every image merged at 0x0 needs a bootloader that exists by then.
+#
+# It used to exist because compiling the Arduino IDF produced it as a
+# by-product. e31dcbb0 stopped that compile, the firmware builds carried on
+# passing because only merge-bin ever reads the file, and v1.12.14 tagged and
+# then could not publish. So: whatever supplies bootloader.bin, a step must
+# supply it BEFORE the step that merges it, and this asserts that order rather
+# than the mechanism.
+for env_name in gh_release_x4pro gh_release_sticky; do
+  checks=$((checks + 1))
+  consumer=$(grep -n "0x0 *\.pio/build/$env_name/bootloader\.bin" "$WF" | head -1 | cut -d: -f1)
+  producer=$(grep -n "^ *out=\"\.pio/build/\$env_name/bootloader\.bin\"\|elf2image" "$WF" | head -1 | cut -d: -f1)
+  if [ -z "$consumer" ]; then
+    failed=$((failed + 1))
+    echo "FAIL release  nothing merges a bootloader at 0x0 for $env_name"
+  elif [ -z "$producer" ]; then
+    failed=$((failed + 1))
+    echo "FAIL release  $env_name merges .pio/build/$env_name/bootloader.bin at 0x0, but no step in the workflow produces it; the IDF has not been compiled since e31dcbb0"
+  elif [ "$producer" -gt "$consumer" ]; then
+    failed=$((failed + 1))
+    echo "FAIL release  the bootloader for $env_name is produced (line $producer) after it is merged (line $consumer)"
+  else
+    ok
+  fi
+done
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
## The symptom

**`v1.12.14` is tagged and has no published release.** `crossplay-release.yml`
fails at `merge-bin`, deterministically — three runs, same step, including a
`--failed` rerun:

```
[Errno 2] No such file or directory: '.pio/build/gh_release_x4pro/bootloader.bin'
```

## Why

`e31dcbb0` ("don't recompile Arduino IDF libs", upstream #3242) landed after
v1.12.13 and stopped compiling the IDF. `bootloader.bin` was a **by-product of
that compile**. Firmware builds still pass without it, because only `merge-bin`
ever reads it, so this was invisible everywhere except the one job that
publishes.

The tell is in the logs: the v1.12.13 run compiled dozens of
`bootloader_support/src/*.o`; the v1.12.14 runs compile none.

### Ruled out first, each with evidence

| Suspect | Verdict |
|---|---|
| esptool | The workflow upgrades it unpinned and got **5.4.0** where v1.12.13 used **5.1.2** — but 5.4.0 runs that exact command correctly on dummy files locally. The file really is absent. |
| PlatformIO cache | Both runs logged `Cache not found for input keys`. Neither had a hit. |
| Platform version | Pinned to `55.03.37` in platformio.ini, identical in both runs. |
| `patch_pioarduino_cache.py` no-opping | It raises `RuntimeError` when neither string matches, and the builds succeeded. |

## The change

The framework package ships the same bootloader prebuilt, one ELF per flash
mode. Both envs are `dio` at 80m (`board_build.flash_mode`, and
`board_build.arduino.memory_type = dio_opi`, where the `opi` half is PSRAM),
so both take `bootloader_dio_80m.elf`.

The step **keeps** a `bootloader.bin` that a build did produce, so if the IDF
compile ever comes back this becomes a no-op rather than an override.

## Why you can trust it at 0x0

This writes what lands at **0x0 on a first install** — the exact class of
mistake this file's own comments record from v1.0.0 and v1.0.1. So it is
verified, not reasoned about. Converted with `elf2image` from
`framework-arduinoespressif32-libs 5.5.0+sha.87912cd291` (the version CI now
resolves), the result is **byte-identical to the bootloader in both published
v1.12.13 full images**:

```
prebuilt        09c6a477ac9b33721e9ea455fda1e29dc5b2f35c85d0b858b693defcab6f19fb
x4pro shipped   09c6a477ac9b33721e9ea455fda1e29dc5b2f35c85d0b858b693defcab6f19fb
sticky shipped  09c6a477ac9b33721e9ea455fda1e29dc5b2f35c85d0b858b693defcab6f19fb
```

Same SHA-256 all three, x4pro and sticky checked separately rather than one
assumed from the other.

## The test

`host-tests/release` asserts the **ordering**, not the mechanism: whatever
supplies `bootloader.bin` must supply it before the step that merges it.
Watched it fail with the step removed — naming both envs — and pass restored.

## Verified

`./scripts_local/check.sh --tests`: **all green**, no skips.

## Not verified

Nothing has been flashed. The bytes are proven identical to what already
shipped, but no device has run an image built by this workflow. Re-running the
v1.12.14 release build is the next step, and its own "The merged images really
are merged" step gates publication.

Board card #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)