### PR TITLE
fix: capture each device's artefacts before the next build removes them

### DIFF
--- a/.github/workflows/crossplay-release.yml
+++ b/.github/workflows/crossplay-release.yml
@@ -79,9 +79,6 @@ jobs:
       - name: Build x4pro
         run: pio run -e gh_release_x4pro
 
-      - name: Build sticky
-        run: pio run -e gh_release_sticky
-
       # Two .bin files per device, because the two ways of installing need
       # different images and shipping only one of them is what went wrong
       # before.
@@ -104,40 +101,44 @@ jobs:
       # bootloader header are the ones this build was configured with. Passing
       # them again by hand is a second copy of a fact that can drift; verified
       # byte-identical to spelling them out.
-      # The bootloader is no longer a build output. e31dcbb0 ("don't recompile
-      # Arduino IDF libs", upstream #3242) stopped compiling the IDF, and
-      # .pio/build/<env>/bootloader.bin was a by-product of that compile. The
-      # firmware builds still pass without it -- only merge-bin needs it -- so
-      # this surfaced as a release that tagged and then could not publish
-      # (v1.12.14).
+      # Each device's artefacts are captured straight after its own build,
+      # before the next build runs. That order is load-bearing: the sticky
+      # build logs "[ComponentManager] Updated build file (55 total removals)"
+      # and .pio/build/gh_release_x4pro/ is gone afterwards, so naming both
+      # devices at the end reads the second build's leftovers for the first.
       #
-      # The framework package ships the same bootloader prebuilt, as an ELF per
-      # flash mode. Both envs are dio at 80m (board_build.flash_mode, and
-      # board_build.arduino.memory_type = dio_opi, where the opi half is the
-      # PSRAM), so both take bootloader_dio_80m.elf.
+      # And the bootloader is no longer a build output at all. e31dcbb0
+      # ("don't recompile Arduino IDF libs", upstream #3242) stopped compiling
+      # the IDF, and bootloader.bin was a by-product of that compile: the
+      # v1.12.13 release run compiled dozens of bootloader_support/src/*.o and
+      # the runs after it compile none. Firmware builds still pass, because
+      # only merge-bin reads the file, so v1.12.14 tagged and could not publish.
       #
-      # This is not an assumption about equivalence: the .bin produced here was
-      # compared byte for byte against the first 18736 bytes of BOTH published
-      # v1.12.13 full images, x4pro and sticky, and is identical to each. That
-      # matters more than usual, because this is what gets written at 0x0 on a
-      # first install, and shipping the wrong thing there is what broke v1.0.0
-      # and v1.0.1.
-      - name: The bootloader, from the framework package
+      # The framework package ships the same bootloader prebuilt, one ELF per
+      # flash mode; both envs are dio at 80m. Not an assumption about
+      # equivalence: converted with elf2image from libs 5.5.0+sha.87912cd291,
+      # it is byte-identical to the bootloader in BOTH published v1.12.13 full
+      # images (sha256 09c6a477ac9b3372...ab6f19fb for x4pro and sticky alike).
+      # That matters because this is what lands at 0x0 on a first install,
+      # which is what broke v1.0.0 and v1.0.1.
+      #
+      # Keeping a bootloader.bin that a build did produce means this becomes a
+      # no-op if the IDF compile ever returns, rather than an override.
+      - name: The x4pro bootloader, from the framework package
         run: |
           pip install --upgrade esptool
-          elf="$HOME/.platformio/packages/framework-arduinoespressif32-libs/esp32s3/bin/bootloader_dio_80m.elf"
-          test -f "$elf" || { echo "::error::no prebuilt bootloader at $elf"; exit 1; }
-          for env_name in gh_release_x4pro gh_release_sticky; do
-            out=".pio/build/$env_name/bootloader.bin"
-            if [ -f "$out" ]; then
-              echo "$env_name already built its own bootloader; keeping it"
-              continue
-            fi
+          out=".pio/build/gh_release_x4pro/bootloader.bin"
+          if [ -f "$out" ]; then
+            echo "gh_release_x4pro built its own bootloader; keeping it"
+          else
+            elf="$HOME/.platformio/packages/framework-arduinoespressif32-libs/esp32s3/bin/bootloader_dio_80m.elf"
+            test -f "$elf" || { echo "::error::no prebuilt bootloader at $elf"; exit 1; }
+            mkdir -p "$(dirname "$out")"
             python -m esptool --chip esp32s3 elf2image \
               --flash_mode dio --flash_freq 80m --flash_size 16MB \
               -o "$out" "$elf"
-          done
-          sha256sum .pio/build/gh_release_*/bootloader.bin
+          fi
+          sha256sum "$out"
 
       - name: Name the x4pro artefacts
         run: |
@@ -151,6 +152,25 @@ jobs:
           cp .pio/build/gh_release_x4pro/firmware.bin dist/firmware.bin
           cp .pio/build/gh_release_x4pro/firmware.elf \
              "dist/crossplay-${GITHUB_REF_NAME}-x4pro.elf"
+
+      - name: Build sticky
+        run: pio run -e gh_release_sticky
+
+      - name: The sticky bootloader, from the framework package
+        run: |
+          pip install --upgrade esptool
+          out=".pio/build/gh_release_sticky/bootloader.bin"
+          if [ -f "$out" ]; then
+            echo "gh_release_sticky built its own bootloader; keeping it"
+          else
+            elf="$HOME/.platformio/packages/framework-arduinoespressif32-libs/esp32s3/bin/bootloader_dio_80m.elf"
+            test -f "$elf" || { echo "::error::no prebuilt bootloader at $elf"; exit 1; }
+            mkdir -p "$(dirname "$out")"
+            python -m esptool --chip esp32s3 elf2image \
+              --flash_mode dio --flash_freq 80m --flash_size 16MB \
+              -o "$out" "$elf"
+          fi
+          sha256sum "$out"
 
       - name: Name the sticky artefacts
         run: |

--- a/host-tests/release/run.sh
+++ b/host-tests/release/run.sh
@@ -904,5 +904,25 @@ for env_name in gh_release_x4pro gh_release_sticky; do
   fi
 done
 
+# Each device's artefacts must be captured before the NEXT build runs.
+#
+# The second build tears down the first's output directory -- the sticky build
+# logs "[ComponentManager] Updated build file (55 total removals)" and
+# .pio/build/gh_release_x4pro/ does not survive it. Naming both devices at the
+# end therefore reads files that are gone, which is how v1.12.14 tagged and
+# then failed to publish three times.
+checks=$((checks + 1))
+name_x4=$(grep -n "name: Name the x4pro artefacts" "$WF" | head -1 | cut -d: -f1)
+build_sticky=$(grep -n "run: pio run -e gh_release_sticky" "$WF" | head -1 | cut -d: -f1)
+if [ -z "$name_x4" ] || [ -z "$build_sticky" ]; then
+  failed=$((failed + 1))
+  echo "FAIL release  cannot find the x4pro naming step or the sticky build"
+elif [ "$name_x4" -gt "$build_sticky" ]; then
+  failed=$((failed + 1))
+  echo "FAIL release  the sticky build (line $build_sticky) runs before the x4pro artefacts are named (line $name_x4); it removes .pio/build/gh_release_x4pro"
+else
+  ok
+fi
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
Follow-up to #40, which was **half a fix**.

## What #40 got right, and what it missed

#40 supplied the bootloader that stopped being built when `e31dcbb0` ("don't
recompile Arduino IDF libs") ended the IDF compile. That was real: the
v1.12.13 run compiled dozens of `bootloader_support/src/*.o`, the runs after
it compile none.

Then v1.12.15 failed one step **earlier**, writing the file instead of reading
it:

```
FileNotFoundError: [Errno 2] No such file or directory:
  '.pio/build/gh_release_x4pro/bootloader.bin'
```

Not the file. The **directory**. After both builds, x4pro's output directory
does not exist — and the sticky build mentions it in passing:

```
[ComponentManager] Updated build file (55 total removals)
```

Two faults stacked, and fixing the visible one exposed the other. Naming both
devices' artefacts at the end reads the second build's leftovers for the
first. `firmware.bin` and `partitions.bin` were exactly as exposed as the
bootloader; `merge-bin` only happened to name the bootloader first, which is
what sent the first investigation after the wrong thing.

## The change

Each device is now **built, given its bootloader, and named** before the next
build starts:

```
Build x4pro  →  x4pro bootloader  →  Name x4pro artefacts
Build sticky →  sticky bootloader →  Name sticky artefacts
```

That is robust without knowing exactly what ComponentManager removes or why,
which is the right shape of fix for a teardown this repo does not control.

## The test

`host-tests/release` asserts the order that broke: the sticky build must not
run before the x4pro artefacts are named. Watched it fail with the old order
put back — naming both line numbers — and pass restored.

## Verified

- `./scripts_local/check.sh --tests`: every suite passed, no skips. Rebased
  onto `xteink` since, with `host-tests/release` (89 checks) and the
  whole-tree formatter re-run green on the rebased tree.
- The bootloader bytes are unchanged from #40 and remain byte-identical to
  both published v1.12.13 full images.

## Not verified

No device has run an image from this workflow. The next release build is the
test; its own "The merged images really are merged" step gates publication.

Board card #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)