### PR TITLE
fix: build both devices in one pio run, and stop misdescribing why

### DIFF
--- a/.github/workflows/crossplay-release.yml
+++ b/.github/workflows/crossplay-release.yml
@@ -76,73 +76,42 @@ jobs:
       - name: Install PlatformIO
         run: pip install --upgrade platformio
 
-      - name: Build x4pro
-        run: pio run -e gh_release_x4pro
-
-      # Two .bin files per device, because the two ways of installing need
-      # different images and shipping only one of them is what went wrong
-      # before.
+      # ONE invocation for both devices, and that is load-bearing.
       #
-      #   -full.bin  bootloader + partition table + app, flashed at 0x0 over
-      #              USB. This is the one a first install needs. v1.0.0 and
-      #              v1.0.1 shipped the app on its own and told people to write
-      #              it to 0x0 -- which on an S3 is where the bootloader lives,
-      #              so it landed on top of it.
-      #   firmware.bin / firmware-sticky.bin  the app alone, one per device.
-      #              The over-the-air updater matches its own device's name
-      #              exactly (CROSSPOINT_RELEASE_ASSET); renaming one is what
-      #              silently switched both updaters off in v1.0.x.
+      # pio run calls clean_build_dir() once per invocation, against the whole
+      # .pio/build ROOT, and rmtree's all of it when compute_project_checksum()
+      # differs from .pio/build/project.checksum. That checksum includes the
+      # .h files under src/ and include/ -- and this project GENERATES some of
+      # those during the build (src/network/html/*.generated.h, lib/I18n/
+      # I18nKeys.h), all of them gitignored and so absent from a fresh
+      # checkout. So on CI the checksum after a build never matches the one
+      # stored at its start, and a SECOND pio run wipes the first one's output
+      # before compiling a byte.
       #
-      # The per-board steps are spelled out rather than looped so
-      # host-tests/release can assert offsets and filenames against literal
-      # text.
+      # That is what broke v1.12.14 and v1.12.15: bootloader.bin was built --
+      # the logs say "Building .pio/build/gh_release_x4pro/bootloader.bin" and
+      # the build reports SUCCESS -- and was gone when merge-bin looked, along
+      # with firmware.bin and partitions.bin. merge-bin only named the
+      # bootloader first.
       #
-      # -fm/-fs/-ff keep: the flash mode, size and frequency already in the
-      # bootloader header are the ones this build was configured with. Passing
-      # them again by hand is a second copy of a fact that can drift; verified
-      # byte-identical to spelling them out.
-      # Each device's artefacts are captured straight after its own build,
-      # before the next build runs. That order is load-bearing: the sticky
-      # build logs "[ComponentManager] Updated build file (55 total removals)"
-      # and .pio/build/gh_release_x4pro/ is gone afterwards, so naming both
-      # devices at the end reads the second build's leftovers for the first.
+      # v1.12.13 survived by accident: before e31dcbb0, pioarduino re-entered
+      # pio run to recompile the IDF, and that second pass stored the
+      # post-generation checksum, so the sticky invocation matched it and wiped
+      # nothing. Its log shows "Processing gh_release_x4pro" twice in one step.
+      # Removing the recompile removed the accident that was holding this shut.
       #
-      # And the bootloader is no longer a build output at all. e31dcbb0
-      # ("don't recompile Arduino IDF libs", upstream #3242) stopped compiling
-      # the IDF, and bootloader.bin was a by-product of that compile: the
-      # v1.12.13 release run compiled dozens of bootloader_support/src/*.o and
-      # the runs after it compile none. Firmware builds still pass, because
-      # only merge-bin reads the file, so v1.12.14 tagged and could not publish.
-      #
-      # The framework package ships the same bootloader prebuilt, one ELF per
-      # flash mode; both envs are dio at 80m. Not an assumption about
-      # equivalence: converted with elf2image from libs 5.5.0+sha.87912cd291,
-      # it is byte-identical to the bootloader in BOTH published v1.12.13 full
-      # images (sha256 09c6a477ac9b3372...ab6f19fb for x4pro and sticky alike).
-      # That matters because this is what lands at 0x0 on a first install,
-      # which is what broke v1.0.0 and v1.0.1.
-      #
-      # Keeping a bootloader.bin that a build did produce means this becomes a
-      # no-op if the IDF compile ever returns, rather than an override.
-      - name: The x4pro bootloader, from the framework package
-        run: |
-          pip install --upgrade esptool
-          out=".pio/build/gh_release_x4pro/bootloader.bin"
-          if [ -f "$out" ]; then
-            echo "gh_release_x4pro built its own bootloader; keeping it"
-          else
-            elf="$HOME/.platformio/packages/framework-arduinoespressif32-libs/esp32s3/bin/bootloader_dio_80m.elf"
-            test -f "$elf" || { echo "::error::no prebuilt bootloader at $elf"; exit 1; }
-            mkdir -p "$(dirname "$out")"
-            python -m esptool --chip esp32s3 elf2image \
-              --flash_mode dio --flash_freq 80m --flash_size 16MB \
-              -o "$out" "$elf"
-          fi
-          sha256sum "$out"
+      # Interleaving build-then-name per device also works, but only because
+      # each device's files reach dist/ before the next invocation starts --
+      # an ordering rule nothing states, which the next person to move a step
+      # silently breaks. One invocation means there is no second clean to lose
+      # a race with.
+      - name: Build both devices
+        run: pio run -e gh_release_x4pro -e gh_release_sticky
 
       - name: Name the x4pro artefacts
         run: |
           mkdir -p dist
+          pip install --upgrade esptool
           python -m esptool --chip esp32s3 merge-bin --format raw \
             -o "dist/crossplay-${GITHUB_REF_NAME}-x4pro-full.bin" \
             -fm keep -fs keep -ff keep \
@@ -152,25 +121,6 @@ jobs:
           cp .pio/build/gh_release_x4pro/firmware.bin dist/firmware.bin
           cp .pio/build/gh_release_x4pro/firmware.elf \
              "dist/crossplay-${GITHUB_REF_NAME}-x4pro.elf"
-
-      - name: Build sticky
-        run: pio run -e gh_release_sticky
-
-      - name: The sticky bootloader, from the framework package
-        run: |
-          pip install --upgrade esptool
-          out=".pio/build/gh_release_sticky/bootloader.bin"
-          if [ -f "$out" ]; then
-            echo "gh_release_sticky built its own bootloader; keeping it"
-          else
-            elf="$HOME/.platformio/packages/framework-arduinoespressif32-libs/esp32s3/bin/bootloader_dio_80m.elf"
-            test -f "$elf" || { echo "::error::no prebuilt bootloader at $elf"; exit 1; }
-            mkdir -p "$(dirname "$out")"
-            python -m esptool --chip esp32s3 elf2image \
-              --flash_mode dio --flash_freq 80m --flash_size 16MB \
-              -o "$out" "$elf"
-          fi
-          sha256sum "$out"
 
       - name: Name the sticky artefacts
         run: |

--- a/host-tests/release/run.sh
+++ b/host-tests/release/run.sh
@@ -878,50 +878,26 @@ else
   fi
 fi
 
-# Every image merged at 0x0 needs a bootloader that exists by then.
+# One pio run invocation for both devices, and the reason is three files away.
 #
-# It used to exist because compiling the Arduino IDF produced it as a
-# by-product. e31dcbb0 stopped that compile, the firmware builds carried on
-# passing because only merge-bin ever reads the file, and v1.12.14 tagged and
-# then could not publish. So: whatever supplies bootloader.bin, a step must
-# supply it BEFORE the step that merges it, and this asserts that order rather
-# than the mechanism.
-for env_name in gh_release_x4pro gh_release_sticky; do
-  checks=$((checks + 1))
-  consumer=$(grep -n "0x0 *\.pio/build/$env_name/bootloader\.bin" "$WF" | head -1 | cut -d: -f1)
-  producer=$(grep -n "^ *out=\"\.pio/build/\$env_name/bootloader\.bin\"\|elf2image" "$WF" | head -1 | cut -d: -f1)
-  if [ -z "$consumer" ]; then
-    failed=$((failed + 1))
-    echo "FAIL release  nothing merges a bootloader at 0x0 for $env_name"
-  elif [ -z "$producer" ]; then
-    failed=$((failed + 1))
-    echo "FAIL release  $env_name merges .pio/build/$env_name/bootloader.bin at 0x0, but no step in the workflow produces it; the IDF has not been compiled since e31dcbb0"
-  elif [ "$producer" -gt "$consumer" ]; then
-    failed=$((failed + 1))
-    echo "FAIL release  the bootloader for $env_name is produced (line $producer) after it is merged (line $consumer)"
-  else
-    ok
-  fi
-done
-
-# Each device's artefacts must be captured before the NEXT build runs.
+# pio run calls clean_build_dir() once per invocation against the whole
+# .pio/build root, and rmtree's it when compute_project_checksum() differs from
+# the stored one. That checksum covers the .h files under src/ and include/,
+# and this project generates some of those during the build -- gitignored, so
+# absent on a fresh checkout. A SECOND invocation therefore always wipes the
+# first one's output before compiling anything. That is what emptied
+# .pio/build/gh_release_x4pro/ under v1.12.14 and v1.12.15, taking firmware.bin
+# and partitions.bin with the bootloader.
 #
-# The second build tears down the first's output directory -- the sticky build
-# logs "[ComponentManager] Updated build file (55 total removals)" and
-# .pio/build/gh_release_x4pro/ does not survive it. Naming both devices at the
-# end therefore reads files that are gone, which is how v1.12.14 tagged and
-# then failed to publish three times.
+# Splitting the build back into one invocation per device restores it exactly,
+# whether or not the artefacts are named in between.
 checks=$((checks + 1))
-name_x4=$(grep -n "name: Name the x4pro artefacts" "$WF" | head -1 | cut -d: -f1)
-build_sticky=$(grep -n "run: pio run -e gh_release_sticky" "$WF" | head -1 | cut -d: -f1)
-if [ -z "$name_x4" ] || [ -z "$build_sticky" ]; then
-  failed=$((failed + 1))
-  echo "FAIL release  cannot find the x4pro naming step or the sticky build"
-elif [ "$name_x4" -gt "$build_sticky" ]; then
-  failed=$((failed + 1))
-  echo "FAIL release  the sticky build (line $build_sticky) runs before the x4pro artefacts are named (line $name_x4); it removes .pio/build/gh_release_x4pro"
-else
+runs=$(grep -c "run: pio run -e gh_release" "$WF")
+if [ "$runs" -eq 1 ] && grep -q "pio run -e gh_release_x4pro -e gh_release_sticky" "$WF"; then
   ok
+else
+  failed=$((failed + 1))
+  echo "FAIL release  the release must build both devices in ONE pio run invocation (found $runs); a second invocation wipes the first one's .pio/build"
 fi
 
 echo "$checks checks, $failed failed"


### PR DESCRIPTION
Follow-up to #40 and #41, which fixed the release and **got the reason wrong
twice**. This states the mechanism and removes the hazard instead of routing
around it.

Found by the Main session's agent, which had the run logs and the platformio
source. Verified here independently before acting.

## The bootloader was never missing from the build

Both invocations emit it, and both report SUCCESS:

```
Build x4pro   13:13:26  Building .pio/build/gh_release_x4pro/bootloader.bin
Build sticky  13:17:13  Building .pio/build/gh_release_sticky/bootloader.bin
```

It was gone by 13:17:52. #40 read that line as PlatformIO announcing *intent*
and inferred from the absence of `bootloader_support/*.o` that nothing was
produced — but whether the IDF is **compiled** and whether `bootloader.bin` is
**emitted** are different questions. #41 then blamed ComponentManager, equally
wrong: the two builds were already fully sequential (x4pro SUCCESS 13:14:05,
sticky starts 13:14:05).

## What actually happens

`pio run` calls `clean_build_dir()` **once per invocation**, against the whole
`.pio/build` **root**, and `fs.rmtree`s all of it when
`compute_project_checksum()` differs from `.pio/build/project.checksum`.

That checksum covers the `.h` files under `src/` and `include/` — and this
project **generates** some of those during the build
(`src/network/html/*.generated.h`, `lib/I18n/I18nKeys.h`), all gitignored and
so absent from a fresh checkout. The checksum after a build therefore never
matches the one stored at its start, and **the second invocation wipes the
first one's output before compiling a byte**.

It took `firmware.bin` and `partitions.bin` with it. `merge-bin` only named
the bootloader first, which is what sent the first two attempts after the
wrong thing.

### v1.12.13 survived by accident

Before `e31dcbb0`, pioarduino re-entered `pio run` to recompile the IDF, and
that second pass stored the **post-generation** checksum, so the sticky
invocation matched it and wiped nothing. Its log shows `Processing
gh_release_x4pro` twice inside one step; v1.12.15's shows it once. Removing the
recompile removed the accident that was holding this shut.

## The change

One invocation, both envs. Interleaving build-and-name per device (what #41
did) also works — but only because each device's files reach `dist/` before the
next invocation starts, an ordering rule nothing stated and the next person to
move a step would silently break. One invocation means there is no second
clean to lose a race with.

The prebuilt-ELF fallback from #40 goes with it. It was insurance against a
premise that turned out to be false, and worse: a fallback that silently
supplies a bootloader would mask the next wipe while `firmware.bin` and
`partitions.bin` stayed missing. Removing it also removed the `pip install
--upgrade esptool` the naming steps depend on, which is restored here.

## The test

`host-tests/release` asserts the single invocation, in place of the ordering
rule it was asserting. Watched it fail with the build split back into two, and
pass with one.

## Why no local gate could have caught any of this

`check.sh` builds one environment at a time in a tree that already has the
generated files. The wipe happens at the start of a **second** `pio run`
invocation on a **fresh** checkout. No amount of building one env reproduces it.

## Verified

`./scripts_local/check.sh --tests`: all green, no skips.

## Not verified

No device has run an image from this workflow. The next release build is the
test, and its own "The merged images really are merged" step gates publication.

Board card #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)