### PR TITLE
readbridge: the running service can be asked which commit it is

### DIFF
--- a/server/read-bridge/.gitignore
+++ b/server/read-bridge/.gitignore
@@ -2,3 +2,4 @@
 data/
 .env
 __pycache__/
+BUILD

--- a/server/read-bridge/bridge/app.py
+++ b/server/read-bridge/bridge/app.py
@@ -140,9 +140,28 @@ async def device_reports(request: Request, call_next):
 
 
 # -------------------------------------------------------------------- healthz
+def build_id() -> str:
+    """The commit this service was deployed from, or "unknown".
+
+    Written by scripts/deploy.sh into bridge/BUILD at deploy time. It exists
+    because on 2026-09-03 a real sync failed against a bug that had ALREADY
+    been fixed, reviewed and merged three commits deep -- the fix was simply
+    never deployed, and nothing anywhere could say so. The running code and the
+    repository disagreed silently, which is the state this file makes visible.
+    """
+    try:
+        return (pathlib.Path(__file__).with_name("BUILD").read_text().strip() or "unknown")[:64]
+    except OSError:
+        return "unknown"
+
+
 @app.get("/healthz")
 async def healthz():
-    return {"ok": True}
+    # The build rides on healthz rather than a new endpoint so that the thing
+    # already polled every 30 minutes is the thing that reveals a stale deploy.
+    # Still no per-user state and no Instapaper call, so it stays safe to serve
+    # unauthenticated through the tunnel.
+    return {"ok": True, "build": build_id()}
 
 
 # ------------------------------------------------------------------ the pages

--- a/server/read-bridge/scripts/deploy.sh
+++ b/server/read-bridge/scripts/deploy.sh
@@ -11,6 +11,17 @@ SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # --exclude .env and --exclude data/ are load-bearing: .env exists only on the
 # pi (secrets, mode 600) and data/ is the live credential store; with --delete
 # and without them, this line would erase both.
+# Stamp the commit being shipped, so the running service can be asked what it
+# is rather than assumed to be current. A fix that is merged and not deployed
+# looks exactly like a fix that does not work -- that is what happened on
+# 2026-09-03 and cost a real sync.
+BUILD_ID="$(git -C "$SRC" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+if [ -n "$(git -C "$SRC" status --porcelain -- "$SRC" 2>/dev/null)" ]; then
+  BUILD_ID="$BUILD_ID-dirty"
+fi
+printf '%s\n' "$BUILD_ID" > "$SRC/bridge/BUILD"
+echo "shipping build $BUILD_ID"
+
 rsync -a --delete \
   --exclude .venv --exclude data/ --exclude .env --exclude __pycache__ \
   --exclude tests \


### PR DESCRIPTION
## What Mario hit

"Instapaper answered the article list in a shape this bridge does not know", on a real sync against the real API.

## What it actually was

**Not a code bug.** That was fixed three commits deep on origin — `5567b2bc`, `98e68cd3`, `e5ef5ce7` — with `normalise_listing`, `parse_delete_ids`, a fake rewritten to emit the live array shape, and a 54-check `test_listing` suite. All correct. **None of it deployed.**

The running service and the repository disagreed, and nothing could say so: not the logs, not `/healthz`, not the container. The bridge logged `POST /api/1/bookmarks/list "HTTP/1.1 200 OK"` followed by its own refusal — so sign-in and OAuth signing were working, which made it look like a live parsing bug rather than a stale binary.

I diagnosed it by md5-ing four files against the pi, and **got the direction backwards on the first read** — copied the pi's stale files over the good ones, and only caught it because `git diff --stat` said 222 deletions. That is how invisible this state is.

## The fix

- `/healthz` answers `{"ok": true, "build": "<sha>"}`.
- `deploy.sh` stamps `bridge/BUILD` from `git rev-parse --short HEAD`, appending `-dirty` when the tree is unclean.
- On `healthz` rather than a new endpoint: the thing already polled every 30 minutes is the thing that should reveal a stale deploy. Still no per-user state and no Instapaper call, so it stays safe unauthenticated through the tunnel.
- `BUILD` is gitignored; it is a deploy artifact, and committing it would make every deploy a diff.

## Verified

Deploy printed `shipping build 4eb68fa8`; the running container answers `{"ok":true,"build":"4eb68fa8"}`. Checked the fix is live **inside the process**, not on disk: `parse_delete_ids("424242424,424242425")` returns `[424242424, 424242425]`, not the characters `4, 2, 4, 2` an `isdigit()` filter would have accepted and charged the reader two cached articles for.

Suites: oauth 11, article 40, listing 54, lockout 18, window 9, engine 13, api 78 — all green.

## Not verified

No device build ran; this changes only `server/read-bridge/`. **Mario's sync itself is not re-verified** — that needs him to press SYNC again, and the bridge now carries the fix that was always meant to be there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)