### PR TITLE
ci: one release build per tag, and assert both halves of why

### DIFF
--- a/.github/workflows/crossplay-autorelease.yml
+++ b/.github/workflows/crossplay-autorelease.yml
@@ -108,11 +108,34 @@ jobs:
           fi
           echo "Tagged v$NEXT at $(git rev-parse --short HEAD)"
 
+      # Dispatch ONLY when the tag push cannot have started the build itself.
+      #
+      # crossplay-release.yml triggers on `push: tags:` as well as on
+      # workflow_dispatch. A tag pushed with GITHUB_TOKEN starts nothing --
+      # that is GitHub's loop guard, and it is why this step exists. But the
+      # checkout above now takes `secrets.RELEASE_TOKEN || github.token`, so
+      # once that secret exists the push IS a real push, it starts the release
+      # on its own, and dispatching as well builds the same tag twice.
+      #
+      # v1.12.16 did exactly that: run 33884760714 (event=push) and 33884760111
+      # (event=workflow_dispatch), same tag, one second apart, both ~14 minutes
+      # of runner, both racing to publish the same assets. Both exited 0 and
+      # neither said anything, so nothing downstream could have noticed.
+      #
+      # Conditional rather than deleted, so the no-token path still works:
+      # without the secret the push is silent and the dispatch is the only
+      # thing that starts a build.
       - name: Build and publish the release
         if: steps.gate.outputs.go == 'true' && steps.notes.outputs.next != ''
         env:
           GH_TOKEN: ${{ github.token }}
           NEXT: ${{ steps.notes.outputs.next }}
+          PUSH_STARTS_IT: ${{ secrets.RELEASE_TOKEN != '' }}
         run: |
-          gh workflow run crossplay-release.yml --ref "v$NEXT"
-          echo "Dispatched crossplay-release.yml on v$NEXT; it builds and publishes."
+          if [ "$PUSH_STARTS_IT" = "true" ]; then
+            echo "v$NEXT was pushed with RELEASE_TOKEN, so its push already started"
+            echo "crossplay-release.yml; not dispatching a second build of the same tag."
+          else
+            gh workflow run crossplay-release.yml --ref "v$NEXT"
+            echo "Dispatched crossplay-release.yml on v$NEXT; it builds and publishes."
+          fi

--- a/.github/workflows/crossplay-release.yml
+++ b/.github/workflows/crossplay-release.yml
@@ -21,8 +21,10 @@ on:
   push:
     tags:
       - "v*"
-  # Dispatched by crossplay-autorelease.yml on the tag it just pushed, because
-  # a tag pushed with the workflow token starts nothing on its own.
+  # Also dispatchable by hand, and by crossplay-autorelease.yml -- but only
+  # when it pushed the tag with GITHUB_TOKEN, which starts nothing on its own.
+  # With RELEASE_TOKEN set the push above IS the trigger, and autorelease skips
+  # its dispatch; doing both built v1.12.16 twice, concurrently, for nothing.
   workflow_dispatch:
 
 permissions:

--- a/host-tests/release/run.sh
+++ b/host-tests/release/run.sh
@@ -880,6 +880,15 @@ fi
 
 # One pio run invocation for both devices, and the reason is three files away.
 #
+# Read this before deciding a local gate would have caught it: it could not,
+# structurally. check.sh builds one environment at a time, in a tree that
+# already contains the generated headers. The wipe needs a SECOND pio run in a
+# tree where the first one created them -- which is a fresh checkout, i.e. CI
+# and only CI. The gate was blind to the exact failure it exists to prevent,
+# and stayed green through four failed releases while being blind to it. That
+# is why this assertion lives here, reading the workflow text, rather than
+# being left to a build that cannot reach the condition.
+#
 # pio run calls clean_build_dir() once per invocation against the whole
 # .pio/build root, and rmtree's it when compute_project_checksum() differs from
 # the stored one. That checksum covers the .h files under src/ and include/,
@@ -898,6 +907,42 @@ if [ "$runs" -eq 1 ] && grep -q "pio run -e gh_release_x4pro -e gh_release_stick
 else
   failed=$((failed + 1))
   echo "FAIL release  the release must build both devices in ONE pio run invocation (found $runs); a second invocation wipes the first one's .pio/build"
+fi
+
+# The release must not be started twice for one tag.
+#
+# crossplay-release.yml triggers on a tag push AND on workflow_dispatch. A tag
+# pushed with GITHUB_TOKEN starts nothing, so autorelease dispatches; a tag
+# pushed with RELEASE_TOKEN starts it, and dispatching as well builds the same
+# tag twice. v1.12.16 did: event=push and event=workflow_dispatch, one second
+# apart, both ~14 minutes, both exiting 0 having raced to publish the same
+# assets. Silent in both directions, which is why it needs asserting.
+checks=$((checks + 1))
+AR="$ROOT/.github/workflows/crossplay-autorelease.yml"
+if ! grep -q "gh workflow run crossplay-release.yml" "$AR"; then
+  ok  # nothing dispatches, so nothing can double up
+elif grep -q "RELEASE_TOKEN != ''" "$AR"; then
+  ok
+else
+  failed=$((failed + 1))
+  echo "FAIL release  crossplay-autorelease.yml dispatches crossplay-release.yml unconditionally; with RELEASE_TOKEN set the tag push starts it too, and the tag builds twice"
+fi
+
+# And the other direction, which is worse. Skipping the dispatch is only safe
+# because the tag push starts the build instead. Remove that trigger and
+# NOTHING starts it: no duplicate, no build, no release, and no error either --
+# strictly worse than the double build this guards against. So the skip and the
+# trigger are asserted together, or the skip is not safe to assert at all.
+checks=$((checks + 1))
+if grep -q "secrets.RELEASE_TOKEN" "$AR"; then
+  if awk '/^on:/,/^jobs:/' "$WF" | grep -q '"v\*"'; then
+    ok
+  else
+    failed=$((failed + 1))
+    echo "FAIL release  autorelease skips its dispatch when RELEASE_TOKEN is set, but crossplay-release.yml has no push trigger on v* tags, so nothing would start the build at all"
+  fi
+else
+  ok
 fi
 
 echo "$checks checks, $failed failed"


### PR DESCRIPTION
Every release currently builds **twice, concurrently**, and neither run says so.

Diagnosed by the Main session, which spotted the two run events and traced them
to the token change. Verified here against both workflows before acting.

## What happens

`crossplay-release.yml` triggers on `push: tags:` **and** on
`workflow_dispatch`. A tag pushed with `GITHUB_TOKEN` starts nothing — that is
GitHub's loop guard, and it is why autorelease dispatches at all. But
autorelease's checkout takes `secrets.RELEASE_TOKEN || github.token`, so once
that secret exists the push is a real push, it starts the release itself, and
the dispatch builds the same tag again.

v1.12.16:

```
33884760714  event=push               success
33884760111  event=workflow_dispatch  success
```

Same tag, one second apart, ~14 minutes of runner each, racing to publish the
same six assets. **Both exited 0**, every step green, neither mentioning the
other — so "did a build fail" and "do assets exist" both read healthy. Two runs
on one tag is the only observable trace.

## The change

The dispatch becomes conditional on the secret being **absent**, rather than
deleted, so the no-token path still works: without `RELEASE_TOKEN` the push is
silent and the dispatch is the only thing that starts a build.

The stale comment in `crossplay-release.yml` is corrected in the same commit,
because that comment is what made this invisible — it asserted that a tag push
starts nothing, which was true in the morning and false by the afternoon.
Left alone, it tells the next person the duplicate is impossible.

## Both halves are asserted, because they are only safe together

Skipping the dispatch is correct **only while the push trigger exists**. Delete
`- "v*"` and nothing starts the build at all: no duplicate, no build, no
release, and no error either — strictly worse than what this fixes, and silent
in the same way. So `host-tests/release` asserts the pair, and I watched each
fail on its own: once with the condition removed, once with the trigger removed.

## No concurrency group, deliberately

After this, concurrent duplicates are unreachable: with the token the push
triggers and the dispatch skips; without it the push is silent and the dispatch
fires; a hand-pushed tag gets one push trigger, and autorelease runs on
`workflow_run` of CI rather than on tag push, so it does not join in. A group
would only cover a human hand-dispatching onto a live run — and would pay for
that with a mechanism whose failure mode is cancelling the run holding the
assets.

## Also written down

Why no local gate could have caught the `clean_build_dir` wipe behind #40/#41/#42:
`check.sh` builds one environment at a time in a tree that already has the
generated headers, so it cannot reach the condition. It stayed green through
four failed releases while being structurally blind to the exact failure it
exists to prevent. That now lives in a comment beside the assertion instead of
in two chat transcripts.

## Verified

`./scripts_local/check.sh --tests`: all green, no skips, on the exact bytes
pushed here.

## Not verified

The next release is the test: it should produce exactly **one** run for its tag.

Board card #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)