### PR TITLE
autorelease: the token and trigger relationship at the top, and the publish step run under test

### DIFF
--- a/.github/workflows/crossplay-autorelease.yml
+++ b/.github/workflows/crossplay-autorelease.yml
@@ -15,11 +15,15 @@
 # The brake is the repository variable RELEASE_HOLD=1. While it is set this
 # job says so and does nothing.
 #
-# The tag is pushed with the workflow's own token, which is why the release
-# workflow is dispatched explicitly below: pushes made with that token do not
-# start workflows on their own. The bump commit touches platformio.ini and
-# docs/release-notes.md only: GitHub refuses workflow-file changes from the
-# default token, which is why the notes do not live in the release workflow.
+# The tag is pushed with RELEASE_TOKEN when that secret exists, and a tag
+# pushed that way starts the release workflow like any tag push. Without the
+# secret the push is made with the workflow's own token, which starts nothing,
+# and the job dispatches the release workflow itself (the last step, which
+# says why it is conditional). Never both: on 2026-09-04 v1.12.16 was built
+# and published twice, once per path. The bump commit touches platformio.ini
+# and docs/release-notes.md only: GitHub refuses workflow-file changes from
+# the default token, which is why the notes do not live in the release
+# workflow.
 name: CrossPlay autorelease
 
 on:

--- a/host-tests/ci/run.sh
+++ b/host-tests/ci/run.sh
@@ -130,5 +130,48 @@ case "$cip" in
     ;;
 esac
 
+# The release is built once per tag. host-tests/release asserts the SHAPE
+# (the dispatch is conditional on RELEASE_TOKEN, and crossplay-release.yml
+# keeps its tag trigger); this runs the step's own text, lifted from the
+# yaml, with a fake gh that records every call, so a condition that is
+# present but inverted fails here and nowhere else. v1.12.16 was built and
+# published twice on 2026-09-04, one run per path, before either existed.
+AYML="$HERE/../../.github/workflows/crossplay-autorelease.yml"
+python3 - "$AYML" 'Build and publish the release' >"$WORK/publish.sh" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+i = next(i for i, l in enumerate(lines) if l.strip() == '- name: ' + sys.argv[2])
+j = next(j for j in range(i, len(lines)) if lines[j].strip() == 'run: |')
+body, indent = [], None
+for l in lines[j + 1:]:
+    if not l.strip():
+        body.append('')
+        continue
+    cur = len(l) - len(l.lstrip())
+    if indent is None:
+        indent = cur
+    if cur < indent:
+        break
+    body.append(l[indent:])
+print('\n'.join(body))
+PY
+[ -s "$WORK/publish.sh" ] || { echo "FAIL could not extract the publish step from crossplay-autorelease.yml"; exit 1; }
+mkdir -p "$WORK/bin"
+printf '#!/bin/sh\necho "gh $*" >> "%s/gh.calls"\n' "$WORK" >"$WORK/bin/gh"; chmod +x "$WORK/bin/gh"
+publish() {  # label, PUSH_STARTS_IT value, wanted number of dispatches
+  rm -f "$WORK/gh.calls"
+  ( cd "$WORK" && PATH="$WORK/bin:$PATH" PUSH_STARTS_IT="$2" NEXT=1.2.3 bash -eo pipefail publish.sh >"$WORK/out" 2>&1 )
+  local n; n=$(grep -c 'workflow run crossplay-release.yml --ref v1.2.3' "$WORK/gh.calls" 2>/dev/null || true); [ -n "$n" ] || n=0
+  checks=$((checks + 1))
+  if [ "$n" -ne "$3" ]; then
+    failed=$((failed + 1))
+    echo "FAIL ci-autorelease  $1: crossplay-release.yml dispatched $n times, wanted $3"
+    sed 's/^/       /' "$WORK/out"
+  fi
+}
+publish "a tag pushed with RELEASE_TOKEN is not dispatched again"      true  0
+publish "a tag pushed with the workflow token is dispatched once"      false 1
+publish "no flag at all (no secret, older text) still dispatches once" ""    1
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
Follow-up on top of #46 (card #156), based on its branch so the diff is only this commit; GitHub retargets it to `xteink` when #46 merges and its branch is deleted.

Two things #48 (closed as #46's duplicate) had that #46 does not:

- The file's **header** still said the tag is pushed with the workflow's own token and that is why the release workflow is dispatched. With `RELEASE_TOKEN` that is the wrong half of the story; the header now states both paths and points at the step for the why.
- **host-tests/ci runs the publish step's own text** (lifted from the yaml) with a fake `gh` that records every call: with the secret zero dispatches, without it exactly one, with no flag at all one. host-tests/release asserts the shape (the condition is present, the tag trigger still exists); a condition that is present but inverted passes that grep and fails here.

Card #168.

**Verified**: host-tests/ci 9 checks and host-tests/release 87 checks green on this tree. The behavioural check dispatched once with the flag true on the text `xteink` ran before #46, so it fails there.

**Not verified**: nothing runs on GitHub here; the yaml change is a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)