### PR TITLE
docs: review means merge on green; a hold is a card state, not a message

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -34,9 +34,13 @@ integrator`), and the card a session bound (`board bind`).
 ## What the store is
 
 The board is a Supabase project (`server/board/supabase/`: the schema and
-row security as migrations, `config.toml` for the auth addresses; apply
-with `supabase db push` or `psql -f` against the project, `supabase config
-push` for the auth part). Every session, hook and page reaches it in one of
+row security as migrations, `config.toml` for the auth addresses; apply a
+new file with `psql -f` against the project, then `notify pgrst, 'reload
+schema'`; `supabase config push` for the auth part). The project has no
+migration tracking: every file was applied by hand, so `supabase db push`
+would replay all of them from the first, which has never been tried. Apply
+the new file only, in name order, and keep version prefixes unique (two
+files once shared one). Every session, hook and page reaches it in one of
 three ways:
 
 - `board` (the CLI) with the service key from `<workspace>/.board/supabase.env`,

--- a/docs/workflow/worker-contract.md
+++ b/docs/workflow/worker-contract.md
@@ -27,3 +27,7 @@ are enforced by hooks and will refuse rather than remind.
   host suites green in your tree, pushed, a pull request open, and
   `board state <id> review`. Say in the PR what was not verified. Hardware
   always counts as not verified.
+- **Review means merge on green.** To stop a merge, move the card first
+  (`board state <id> working`, or a blocker) and only then say why: the
+  orchestrator merges from cards, and a message reaches it after its
+  current merge, not before.


### PR DESCRIPTION
Two lines of workflow docs.

**Worker contract**: a worker asked the orchestrator by message to hold #50; the orchestrator had merged it before the message was read (messages drain at the receiver's next turn, a merge is one command). The contract said a card in `review` merges on green and nothing about how to stop one: move the card first (`board state <id> working`, or a blocker), then say why.

**Board migrations** (docs/workflow/README.md): it offered `supabase db push` as one way to apply a migration. The live project has no migration tracking (checked: `supabase_migrations.schema_migrations` does not exist); every file was applied by hand with `psql -f`, so `db push` would replay every file from the first, untried. The README now says the practice as it is: the new file only, by hand, in name order, unique version prefixes (two files shared one today until #49 renamed its own).

Card #178. Docs only; the SessionStart hook prints the contract into every session, so the first line reaches every worker once `firmware-next` is pulled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)