### PR TITLE
trivia: a pack the rating run can actually produce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ flake.*
 
 # scratch for tools_local/trivia/rate_local.py: corpus, venv, per-model runs
 .rate/
+
+# scratch for tools_local/trivia/assemble_pack.py: corpus snapshot, built packs
+.pack/

--- a/docs/trivia-curation.md
+++ b/docs/trivia-curation.md
@@ -18,15 +18,15 @@ Measured with `tools_local/trivia/audit_options.py`, which deals 400 sets the
 way the device does (the answer plus three of the six stored distractors) and
 counts what could be used:
 
-| | shipped pack | rebuilt | how it was counted |
-| --- | --- | --- | --- |
-| two options that are one thing | 5.3% | **0.0%** | every stored set |
-| options not capitalised alike | 9.9% | **0.0%** | every stored set |
-| a region named, one option in it | 15.5% | **5.5%** | 400 dealt sets |
-| an option of another kind | 12.8% | **1.0%** | 400 dealt sets, see caveat |
-| an option out of its own time | 2.2% | 1.8% | 400 dealt sets, independent half only |
-| answer is the longest option (chance 25%) | 13.5% | 13.5% | 400 dealt sets |
-| playable as multiple choice | 14,388 | **18,485** | |
+|                                           | shipped pack | rebuilt    | how it was counted                    |
+| ----------------------------------------- | ------------ | ---------- | ------------------------------------- |
+| two options that are one thing            | 5.3%         | **0.0%**   | every stored set                      |
+| options not capitalised alike             | 9.9%         | **0.0%**   | every stored set                      |
+| a region named, one option in it          | 15.5%        | **5.5%**   | 400 dealt sets                        |
+| an option of another kind                 | 12.8%        | **1.0%**   | 400 dealt sets, see caveat            |
+| an option out of its own time             | 2.2%         | 1.8%       | 400 dealt sets, independent half only |
+| answer is the longest option (chance 25%) | 13.5%        | 13.5%      | 400 dealt sets                        |
+| playable as multiple choice               | 14,388       | **18,485** |                                       |
 
 Seeds 1/2/3, so none of it is one lucky draw: kind 12.8/9.0/10.8 -> 1.0/2.2/1.5,
 region 15.5/14.8/12.0 -> 5.5/5.2/5.0, period 2.2/1.8/2.8 -> 1.8/2.2/1.5.
@@ -71,14 +71,14 @@ season every July) costs one command.
 
 Already dropped, with counts from the 544,110-clue source:
 
-| Dropped | Why |
-| --- | --- |
-| 72,867 | wordplay category -- the category IS the puzzle (`WO"RR"DS`, `____UM`) |
-| 60,845 | category-dependent -- no demonstrative, meaningless standalone |
-| 14,057 | too long or too short for the screen |
-| 10,745 | media clue or presenter aside (`(Hi, I'm Marvin Hamlisch...)`) |
-| 9,079 | **the show itself declares a constraint** (see below) |
-| 6,981 | no usable difficulty (daily doubles, unscored) |
+| Dropped | Why                                                                    |
+| ------- | ---------------------------------------------------------------------- |
+| 72,867  | wordplay category -- the category IS the puzzle (`WO"RR"DS`, `____UM`) |
+| 60,845  | category-dependent -- no demonstrative, meaningless standalone         |
+| 14,057  | too long or too short for the screen                                   |
+| 10,745  | media clue or presenter aside (`(Hi, I'm Marvin Hamlisch...)`)         |
+| 9,079   | **the show itself declares a constraint** (see below)                  |
+| 6,981   | no usable difficulty (daily doubles, unscored)                         |
 
 The 9,079 are worth calling out. The dataset's `comments` column carries Alex's
 spoken category explainers -- "Each correct response will begin with that letter
@@ -93,15 +93,15 @@ ignoring.
 from special events. These are exactly the "special edition I don't want to play"
 category:
 
-| Event | Clues | Why it matters |
-| --- | --- | --- |
-| Tournament of Champions | 20,969 | much harder than a normal game |
-| Teen | 15,995 | easier, and skewed to teen pop culture |
-| College | 15,218 | skewed to campus/current topics |
-| Champions Wildcard | 6,220 | hard |
-| Teachers | 5,937 | skewed academic |
-| Celebrity | 4,012 | much easier, celebrity-focused |
-| Kids | 3,665 | easiest |
+| Event                   | Clues  | Why it matters                         |
+| ----------------------- | ------ | -------------------------------------- |
+| Tournament of Champions | 20,969 | much harder than a normal game         |
+| Teen                    | 15,995 | easier, and skewed to teen pop culture |
+| College                 | 15,218 | skewed to campus/current topics        |
+| Champions Wildcard      | 6,220  | hard                                   |
+| Teachers                | 5,937  | skewed academic                        |
+| Celebrity               | 4,012  | much easier, celebrity-focused         |
+| Kids                    | 3,665  | easiest                                |
 
 Every question in the pack carries its event tag (`ev`, empty for a regular
 game), so any of these can be included or excluded with a switch rather than a
@@ -126,14 +126,14 @@ india, california, mexico, canada` -- which is what general knowledge looks like
 
 It sorts convincingly. Top of the ranking:
 
-- *To prevent Portugal from claiming the Spice Islands, he set out to sail around the world* = **Magellan**
-- *Prometheus' brother, cursed to bear the sky upon his back* = **Atlas**
-- *Lausanne in this country is home to the International Olympic Committee* = **Switzerland**
+- _To prevent Portugal from claiming the Spice Islands, he set out to sail around the world_ = **Magellan**
+- _Prometheus' brother, cursed to bear the sky upon his back_ = **Atlas**
+- _Lausanne in this country is home to the International Olympic Committee_ = **Switzerland**
 
 Bottom:
 
-- *Contrary to Whittier's poem, Mary Quantrill, not this title woman, waved the Union flag* = **Barbara Frietchie**
-- *As indicated in Daniel 9:3, they're what a penitent person is said to be wearing* = **sackcloth and ashes**
+- _Contrary to Whittier's poem, Mary Quantrill, not this title woman, waved the Union flag_ = **Barbara Frietchie**
+- _As indicated in Daniel 9:3, they're what a penitent person is said to be wearing_ = **sackcloth and ashes**
 
 **The score ranks, it does not delete.** Nothing is thrown away; the pack is
 sorted and you ship the top slice. Recommended slice: **top 50,000**, which is
@@ -174,7 +174,7 @@ a model would decide alone.
 ## What this does NOT solve
 
 Nobody fact-checks this corpus and neither does any of the above. The generality
-score measures how *often* an answer recurs, not whether the clue is *correct*.
+score measures how _often_ an answer recurs, not whether the clue is _correct_.
 Old clues also age: "this Yugoslavian republic", "the current world record". The
 `y` field carries the air year so a recency filter is available, but no automatic
 check will catch a clue that was true in 1994.
@@ -201,7 +201,7 @@ full pack's median (8.8), so it really is the general-knowledge core rather than
 an arbitrary cut.
 
 5,507 questions carry alternate accepted answers, parsed out of Jeopardy's own
-notation: `(Luther) Burbank` yields *Burbank* plus *Luther Burbank*, `spores (or
+notation: `(Luther) Burbank` yields _Burbank_ plus _Luther Burbank_, `spores (or
 seeds)` yields both. That recovers the alias capability I had said only TriviaQA
 had.
 
@@ -246,3 +246,162 @@ ones that have gone off.
 
 Nothing here fact-checks the corpus. The generality score measures how often an
 answer recurs, not whether the clue is right.
+
+---
+
+## Building the pack from a local rating run
+
+Everything above builds the pack from the Jeopardy TSV, where difficulty is the
+clue's dollar value. That source is **not in this repo and not on this machine**,
+and the dollar value is a fact about a 1994 television show rather than about
+four people in a bar. `tools_local/trivia/enrich_pack.py` rates the corpus
+locally instead, and `tools_local/trivia/assemble_pack.py` turns that rating run
+into a pack.
+
+Two builds, two files, on purpose. `build_pack.py` still owns the TSV path: it
+holds every filter that turns 544k raw clues into 50k shippable ones, and all of
+it needs the source columns. `assemble_pack.py` starts from the output of that
+work -- the decoded pack -- and only re-decides difficulty and options.
+
+```text
+build_pack.py     Jeopardy TSV      -> pack     difficulty from the dollar value
+assemble_pack.py  corpus + ratings  -> pack     difficulty from the local rater
+```
+
+### The command sequence, in order
+
+The rating run appends to `.rate/enriched.jsonl` as it goes and the file is
+usable at any point; a partial run just makes a smaller pack. Run this from the
+tree holding the rating run.
+
+```bash
+# 1. Is the run finished? Rated rows against the worklist it was given.
+#    (The rating tree may also hold its own untracked rate_status.py, which
+#    prints the same thing with a verdict. This line needs nothing but the run.)
+echo "$(cut -d'"' -f4 .rate/enriched.jsonl | sort -u | wc -l) rated of $(wc -l < .rate/rest40383.ids)"
+
+# 2. Assemble. --kick-us also drops US-centric questions; without it they stay.
+python3 tools_local/trivia/assemble_pack.py \
+    --corpus .rate/corpus_repaired.jsonl \
+    --enriched .rate/enriched.jsonl \
+    --out .rate/out/pack.jsonl \
+    --dat .rate/out/pack.dat
+
+# 3. The gate. All 21 must pass; the pack is not shippable at 20/21.
+python3 tools_local/trivia/test_pack.py .rate/out/pack.jsonl
+
+# 4. What a cold player could exploit without knowing anything.
+python3 tools_local/trivia/audit_options.py .rate/out/pack.jsonl
+
+# 5. On the card, beside the .state file the build wrote next to it.
+cp .rate/out/pack.dat  <sd>/trivia/pack.dat
+cp .rate/out/pack.state <sd>/trivia/pack.state
+```
+
+**`pack.state` must be replaced together with `pack.dat`.** State is fixed-width
+and addressed by index, so a state file left over from a different pack marks
+the wrong questions seen. `assemble_pack.py --dat` writes a fresh zeroed one
+beside the pack every time; copy both or neither.
+
+### Three rules in that tool, each of which fails silently when undone
+
+**Join on the corpus's stored id. Never re-derive it.** Ids are a sha1 of
+normalised clue text and `pack_format.py` re-derives them, which is right when
+the text is the text the id was made from. It is wrong here:
+`corpus_repaired.jsonl` deliberately carries pre-repair ids beside post-repair
+clue text, because the pack is addressed by index and moving an id moves a
+question out from under `pack.state`. **349 rows are in that state.** Re-deriving
+drops their ratings, an unrated question is simply excluded, and the result is
+a slightly smaller pack with no error anywhere. The tool prints what re-deriving
+would have cost on every run, which is the only place that number is visible.
+Board card #146.
+
+**A question with fewer than three sound options loses the `w` key entirely.**
+Not a shortened key: no key. A two-option set fails `test_pack.py`'s "every MC
+has at least 3 distractors" and would put two choices on a four-option screen.
+Without the key the question is quizmaster-only and completely correct. Topping
+these up is board card #172.
+
+**`r` maps to `d` by fixed absolute thresholds, never by quantile.** Each level
+is a two-point band on the rater's own 0-10 scale (`LEVELS` in the tool). A
+quantile mapping would be perfectly balanced and would redefine every level each
+time the run is re-cut, so "level 3" would mean one thing at 18,000 rated rows
+and another at 40,000, and a player's difficulty setting would mean nothing
+across builds.
+
+`test_assemble.py` exists to make undoing any of the three loud, and
+`check.sh --tests` runs it.
+
+### The longest-option defect, and why banding alone did not fix it
+
+Model-generated options failed `test_pack.py`'s guessability check: the answer
+was **strictly the longest of the four options 20.6% of the time**, against a bar
+of 15% and a chance rate of 25%. An answer visibly longer than every option is a
+tell a player uses without knowing the subject at all.
+
+Head to head on the same 7,768 questions, the old rule-based picker was 4.2%
+strictly longest and 72.2% tied-longest; the model 20.7% strict and 12.4% tied.
+**Mean option length was 7.5 characters against a 7.7-character answer in both.**
+The model is not writing short options. It is writing options of scattered
+lengths -- stdev 1.63 against the picker's 0.49 -- and scatter is what leaves the
+answer alone at the top. The cause is spread, not bias, and that is why raising
+the option lengths would not have helped.
+
+`distractors.length_ok` is the band the rule-based picker already uses. Applying
+it moved 20.6% to 15.7%: better, and still failing. **Banding cannot finish the
+job, because "the answer is the longest" is a property of the SET.** Three
+options each individually inside the band can still all be shorter than the
+answer.
+
+So the guarantee is constructed rather than sampled for: **every option set
+carries at least one option at least as long as the answer**, and the set is
+then filled by closeness in length. The answer is never strictly longest, on
+every draw the device can make, rather than on average. A question whose
+candidates cannot supply a covering option keeps its clue and loses its options.
+
+Rule-based candidates top up the model's three, so a set that cannot reach three
+in band on model options alone usually still can.
+
+### Exactly three options are stored, where the TSV build stores six
+
+`build_pack.py` stores six and lets the device draw three, so replaying a
+question varies. `assemble_pack.py` stores three. Two reasons, and the trade is
+deliberate:
+
+- **Six is not available for half the pack.** 8,582 of 16,680 questions with a
+  sound option set have only three candidates that survive the band at all.
+- **With three stored, the set on the panel is the set the gate checked.** The
+  cover guarantee is then exact rather than a property of one sampled draw of
+  three from six. Storing six leaves the answer strictly longest on about 4.6%
+  of possible draws while the first three read 0.0%, which is precisely the kind
+  of number that passes a test and reaches a player anyway.
+
+The cost is that replaying a question shows the same three options.
+
+### What a run of this looks like
+
+At 20,706 of 40,383 rated:
+
+```text
+corpus            : 50,000
+ratings           : 20,706
+  ids that moved  : 349 rows carry a pre-repair id
+  re-derive would : lose 156 ratings SILENTLY (card #146)
+  dropped  29,294  unrated (not yet reached by the run)
+  dropped       8  rejected: unanswerable
+
+pack              : 20,698
+  solo MC ready   : 15,945 (3 stored options each)
+  read-aloud only : 4,753 (no sound option set; card #172)
+  difficulty      : {1: 3041, 2: 5701, 3: 4120, 4: 3137, 5: 4699}
+```
+
+`test_pack.py` passes 21/21 on that pack.
+
+**Watch the difficulty spread as the run finishes.** The gate wants no tier more
+than 2.5x the smallest, and the fixed thresholds put that at 5,701 against 3,041
+-- a ratio of 1.87. That is comfortable but it is not guaranteed: the thresholds
+are absolute by design, so a second half of the run that rates differently from
+the first will move the tiers. If `difficulty reasonably spread` fails, the
+answer is to look at the r histogram and move `LEVELS`, once, deliberately, and
+say so here. It is not to switch to quantiles.

--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -452,6 +452,19 @@ else
   FAILED=1
 fi
 
+# The rating-fed assembler. Same argument as above, plus one of its own: three
+# of its rules fail SILENTLY when undone -- a dropped rating, a short option
+# set and a refitted difficulty level all produce a pack that builds, ships and
+# reads fine, so only a test says the rule is still there.
+if (cd "$REPO" && python3 tools_local/trivia/test_assemble.py) \
+    > "$LOGS/trivia-assemble.log" 2>&1; then
+  printf "  %-12s ok\n" "assemble"
+else
+  printf "  %-12s FAILED\n" "assemble"
+  tail -10 "$LOGS/trivia-assemble.log" | sed 's/^/      /'
+  FAILED=1
+fi
+
 # The sync bridge server suites. Their venvs are not committed; uv rebuilds them
 # in a --committed trial worktree (warm uv cache makes that cheap). A missing
 # toolchain FAILS rather than skips: a bridge change riding a green gate whose

--- a/tools_local/trivia/assemble_pack.py
+++ b/tools_local/trivia/assemble_pack.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Assemble a shippable trivia pack from the decoded corpus plus a local rating run.
+
+build_pack.py cannot do this, and that is why this file exists. build_pack.py
+rebuilds from the Jeopardy season TSV (544k rows, not in this repo and not on
+this machine) and derives difficulty from the clue's DOLLAR VALUE. A local
+rating run produces something the dollar value cannot express -- how hard the
+question actually is for a group of people in a bar -- and there was no path
+from that number to a pack at all. Adding a source-less second mode to
+build_pack.py would have made --src conditionally required and left its whole
+filter body dead in that mode, so the two builds are two files:
+
+    build_pack.py     Jeopardy TSV     -> pack   (difficulty from dollar value)
+    assemble_pack.py  corpus + ratings -> pack   (difficulty from the rater)
+
+Inputs:
+
+  --corpus    the decoded pack, one JSON object per line, carrying the fields
+              the device already ships: d, y, q, a, alt, w, id
+  --enriched  enrich_pack.py's output: id, r, w, bad, us, topic, n_gen, n_kept
+              r is 0-10 on the international scale, HIGH r meaning EASY.
+
+    python3 tools_local/trivia/assemble_pack.py \\
+        --corpus .rate/corpus_repaired.jsonl \\
+        --enriched .rate/enriched.jsonl \\
+        --out pack.jsonl --dat pack.dat
+    python3 tools_local/trivia/test_pack.py pack.jsonl
+
+Three rules here were each paid for. Do not quietly undo any of them; the tests
+in test_assemble.py exist to make undoing one loud.
+"""
+
+import argparse
+import collections
+import hashlib
+import json
+import os
+import random
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import build_pack
+import distractors
+
+
+# --- rule 1: the corpus's stored id is the join key --------------------------
+# Pack ids are a sha1 of normalised clue text, and build_pack.py re-derives them
+# from the text it is holding. That is right when the text IS the text the id
+# was made from, and wrong here: corpus_repaired.jsonl deliberately carries
+# PRE-repair ids beside POST-repair clue text, because the pack is addressed by
+# index and moving an id would move a question out from under pack.state. 349
+# rows are in that state. Re-deriving drops their ratings, and an unrated
+# question is simply excluded from the pack, so the loss shows up as nothing at
+# all -- no error, no warning, a slightly smaller pack. Board card #146.
+#
+# So: join on the stored id, and REPORT what re-deriving would have cost, which
+# is the only way that number is ever visible.
+def rederive(clue):
+    return hashlib.sha1(re.sub(r"[^a-z0-9]", "", clue.lower()).encode()).hexdigest()[
+        :12
+    ]
+
+
+# --- rule 3: r -> d by fixed absolute thresholds, never by quantile ----------
+# Each level is a two-point band on the rater's own 0-10 scale. Absolute, so
+# "level 3" means the same question difficulty in a pack built from 18,000
+# rated rows and in one built from 40,000. Quantile bands would be balanced by
+# construction and would silently redefine every level each time the run is
+# re-cut, which makes a difficulty setting meaningless across builds.
+#
+# r is "out of ten groups, how many get it right", so HIGH r is EASY and level
+# 1 is the easiest tier -- the same direction as build_pack.py's dollar tiers.
+# The bottom band is three points wide because 11 values do not split into 5.
+LEVELS = ((9, 1), (7, 2), (5, 3), (3, 4))
+
+
+def level(r):
+    for floor, d in LEVELS:
+        if r >= floor:
+            return d
+    return 5
+
+
+# --- the longest-option defect ----------------------------------------------
+# test_pack.py fails a pack whose answer is strictly the longest of the four
+# options more than 15% of the time, because that is a tell a player uses
+# without knowing anything about the subject. Model-generated options fail it
+# at 20.7%. The rule-based picker, head to head on the same 7,768 questions,
+# is at 4.2%.
+#
+# The cause is SPREAD, not bias. Mean option length is 7.5 characters against a
+# 7.7-character answer in both, so the model is not writing short options; it
+# is writing options of scattered lengths (stdev 1.63 against the picker's
+# 0.49), and scatter is what leaves the answer alone at the top.
+#
+# distractors.length_ok is the band the picker already uses, and applying it
+# here moves 20.7% -> 15.7%: better, still failing. Banding cannot finish the
+# job because "the answer is the longest" is a property of the SET, not of any
+# one option -- three individually in-band options can all still be shorter.
+#
+# So the guarantee is constructed rather than sampled for: every option set
+# carries at least one option AT LEAST AS LONG as the answer. The answer is
+# then never strictly longest, by construction, on every draw the device can
+# make -- not merely on average. A question whose candidates cannot supply one
+# keeps its clue and loses its options; it is still playable read-aloud.
+def pick_options(answer, alts, model_w, rule_w, want=3):
+    """Choose `want` distractors, or [] if no sound set exists.
+
+    model_w comes from the rating run and is topically the better material, so
+    it is offered first; rule_w is distractors.choose()'s output for the same
+    question and is used to top up. Every returned option is inside the length
+    band, and at least one is at least as long as the answer.
+    """
+    banned = {answer.lower()} | {a.lower() for a in alts}
+    pool = []
+    for c in list(model_w) + list(rule_w):
+        c = distractors.display_case(c)
+        if c.lower() in banned:
+            continue
+        if any(c.lower() == p.lower() for p in pool):
+            continue
+        if not distractors.length_ok(answer, c):
+            continue
+        if distractors.odd_case(c) or c[:1].isalpha() != answer[:1].isalpha():
+            continue
+        if distractors.twins(c, answer) or any(distractors.twins(c, a) for a in alts):
+            continue
+        if any(distractors.twins(c, p) for p in pool):
+            continue
+        pool.append(c)
+
+    if len(pool) < want:
+        return []
+    covers = [c for c in pool if len(c) >= len(answer)]
+    if not covers:
+        return []
+    # The tightest cover, so the set reads as a tie rather than making the
+    # longest option the new tell. Then fill by closeness in length, which is
+    # what pulls the spread down toward the picker's.
+    lead = min(covers, key=lambda c: (len(c) - len(answer), pool.index(c)))
+    rest = sorted(
+        (c for c in pool if c is not lead),
+        key=lambda c: (abs(len(c) - len(answer)), pool.index(c)),
+    )
+    return ([lead] + rest)[:want]
+
+
+# Exactly three are stored, where build_pack.py stores six and lets the device
+# draw three. Two reasons, and the trade is deliberate: half the rated rows
+# (8,582 of 16,680) have only three sound candidates at all, so six is not
+# available for them; and with three stored the set on the panel IS the set
+# checked here, which makes the cover guarantee exact instead of a property of
+# one sampled draw. The cost is that replaying a question shows the same three
+# options. See docs/trivia-curation.md.
+STORED = 3
+
+
+def assemble(corpus, enriched, kick_us=False, seed=20260904):
+    """corpus and enriched are lists/dicts of already-parsed rows."""
+    stats = collections.Counter()
+
+    # Pass 1: which questions survive, on ratings alone. The rule-based picker
+    # draws from the SHIPPED slice, so it has to be indexed over the survivors
+    # rather than over the corpus -- an option must be an answer the player
+    # could otherwise have met.
+    keep = []
+    for x in corpus:
+        e = enriched.get(x["id"])
+        if e is None:
+            stats["unrated (not yet reached by the run)"] += 1
+            continue
+        if e.get("r") is None:
+            stats["rated, but the rater returned no number"] += 1
+            continue
+        if e.get("bad"):
+            stats["rejected: unanswerable"] += 1
+            continue
+        if kick_us and e.get("us"):
+            stats["rejected: us_centric (--kick-us)"] += 1
+            continue
+        item = {
+            "id": x["id"],
+            "q": x["q"],
+            "a": x["a"],
+            "d": level(e["r"]),
+            "y": x["y"],
+        }
+        if x.get("alt"):
+            item["alt"] = list(x["alt"])
+        item["_model_w"] = list(e.get("w") or [])
+        item["_corpus_w"] = list(x.get("w") or [])
+        keep.append(item)
+
+    if not keep:
+        return [], stats
+
+    # Pass 2: options. The rule-based picker supplies candidates the model did
+    # not, which is what lets a set reach three in band.
+    rng = random.Random(seed)
+    index = distractors.TypeIndex(keep)
+    used = collections.Counter()
+    order = sorted(range(len(keep)), key=lambda i: rng.random())
+    rule = {}
+    for i in order:
+        picks = distractors.choose(index, keep[i], index.keys[i], used, rng)
+        if picks:
+            rule[keep[i]["id"]] = picks
+
+    for x in keep:
+        model_w = x.pop("_model_w")
+        corpus_w = x.pop("_corpus_w")
+        # rule 2: fewer than three sound options means NO `w` key at all, not a
+        # short one. A two-option set fails test_pack.py's "every MC has at
+        # least 3 distractors" and would put two choices on a four-option
+        # screen; without the key the question is read-aloud and correct.
+        # Topping these up is board card #172.
+        w = pick_options(
+            x["a"], x.get("alt", ()), model_w, rule.get(x["id"], []) + corpus_w, STORED
+        )
+        if len(w) >= 3:
+            x["w"] = w
+            stats["_mc"] += 1
+        else:
+            stats["_readaloud"] += 1
+        x["a"] = distractors.display_case(x["a"])
+        if x.get("alt"):
+            x["alt"] = [distractors.display_case(a) for a in x["alt"]]
+
+    build_pack.dedash(keep)
+    return keep, stats
+
+
+def load_enriched(path):
+    """Last write wins, and duplicates are counted rather than swallowed: the
+    file is append-only and resumable, so a duplicate id is a resume artefact
+    worth seeing. Same rule as export_enriched.py."""
+    out, dupes = {}, 0
+    for line in open(path, encoding="utf-8"):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+        except ValueError:
+            continue
+        if "id" not in r:
+            continue
+        if r["id"] in out:
+            dupes += 1
+        out[r["id"]] = r
+    return out, dupes
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument(
+        "--corpus", required=True, help="decoded pack jsonl: d,y,q,a,alt,w,id"
+    )
+    ap.add_argument("--enriched", required=True, help="enrich_pack.py output jsonl")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--dat", default="", help="also write the on-card binary pack")
+    ap.add_argument(
+        "--kick-us",
+        action="store_true",
+        help="also drop us_centric questions (default: keep them)",
+    )
+    ap.add_argument(
+        "--verdicts",
+        default="tools_local/trivia/verdicts.tsv",
+        help="hand verdicts; a `bad` id is dropped whatever the rater said",
+    )
+    a = ap.parse_args()
+
+    corpus = [json.loads(l) for l in open(a.corpus, encoding="utf-8") if l.strip()]
+    enriched, dupes = load_enriched(a.enriched)
+    if not enriched:
+        sys.exit(f"{a.enriched}: no usable records")
+
+    # Hand verdicts outrank the rater in both directions of trust: a person
+    # looked at the question. Applied before assembly so a `bad` id can never
+    # reach the pack through a rating that liked it.
+    n_verdict = 0
+    if a.verdicts and os.path.exists(a.verdicts):
+        bad = set()
+        for line in open(a.verdicts, encoding="utf-8"):
+            parts = line.strip().split("\t")
+            if (
+                len(parts) >= 2
+                and not line.startswith("#")
+                and parts[1].strip() == "bad"
+            ):
+                bad.add(parts[0].strip())
+        before = len(corpus)
+        corpus = [x for x in corpus if x["id"] not in bad]
+        n_verdict = before - len(corpus)
+
+    pack, stats = assemble(corpus, enriched, a.kick_us)
+
+    # What re-deriving the ids would have cost, printed whether or not it is
+    # zero. It is the number card #146 is about and it is invisible everywhere
+    # else: a dropped rating just means a question quietly absent from the pack.
+    moved = sum(1 for x in corpus if rederive(x["q"]) != x["id"])
+    lost = sum(
+        1 for x in corpus if x["id"] in enriched and rederive(x["q"]) not in enriched
+    )
+
+    with open(a.out, "w", encoding="utf-8") as f:
+        for x in pack:
+            f.write(json.dumps(x, ensure_ascii=False, separators=(",", ":")) + "\n")
+
+    print(
+        f"corpus            : {len(corpus):,}"
+        + (f"  ({n_verdict} dropped by verdicts.tsv)" if n_verdict else "")
+    )
+    print(
+        f"ratings           : {len(enriched):,}"
+        + (f"  ({dupes} duplicate ids, last kept)" if dupes else "")
+    )
+    print(f"  ids that moved  : {moved:,} rows carry a pre-repair id")
+    print(f"  re-derive would : lose {lost:,} ratings SILENTLY (card #146)")
+    for k, v in stats.most_common():
+        if not k.startswith("_"):
+            print(f"  dropped {v:>7,}  {k}")
+    print(f"\npack              : {len(pack):,}")
+    print(f"  solo MC ready   : {stats['_mc']:,} ({STORED} stored options each)")
+    print(
+        f"  read-aloud only : {stats['_readaloud']:,} (no sound option set; card #172)"
+    )
+    print(f"  with alternates : {sum(1 for x in pack if x.get('alt')):,}")
+    print(
+        f"  difficulty      : {dict(sorted(collections.Counter(x['d'] for x in pack).items()))}"
+    )
+    print(f"  size            : {os.path.getsize(a.out) / 1e6:.1f} MB")
+
+    if a.dat:
+        import pack_format
+
+        n = pack_format.write(pack, a.dat)
+        pack_format.write_state(pack_format.state_path(a.dat), len(pack))
+        print(f"  on-card pack    : {a.dat} ({n / 1e6:.2f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools_local/trivia/test_assemble.py
+++ b/tools_local/trivia/test_assemble.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""The rating-fed assembler's invariants, as the failures that earned them.
+
+    python3 tools_local/trivia/test_assemble.py
+
+Standard library only and no corpus needed, so this never skips. Every case is
+a real defect measured on the local rating run, written so that undoing the fix
+turns it red rather than quietly costing questions nobody counts.
+"""
+
+import os
+import statistics
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import assemble_pack as A  # noqa: E402
+
+FAILED = []
+
+
+def check(name, ok, detail=""):
+    print(
+        f"  [{'ok  ' if ok else 'FAIL'}] {name}{('  -- ' + detail) if detail and not ok else ''}"
+    )
+    if not ok:
+        FAILED.append(name)
+
+
+# --- rule 3: r -> d is absolute -----------------------------------------------
+def test_levels():
+    check(
+        "r maps to d with high r easy",
+        A.level(10) == 1 and A.level(0) == 5,
+        f"level(10)={A.level(10)} level(0)={A.level(5)}",
+    )
+    check(
+        "every r in 0..10 lands in 1..5", all(1 <= A.level(r) <= 5 for r in range(11))
+    )
+    check(
+        "the mapping is monotonic",
+        all(A.level(r) >= A.level(r + 1) for r in range(10)),
+        [A.level(r) for r in range(11)],
+    )
+    # The point of rule 3: the same r must give the same d whatever else is in
+    # the run. A quantile mapping passes every check above and fails this one.
+    small = [A.level(r) for r in (9, 7, 5, 3, 1)]
+    large = [A.level(r) for r in (9, 7, 5, 3, 1)] * 40
+    check(
+        "a level does not depend on the size of the run",
+        small == large[: len(small)] and set(large) == set(small),
+    )
+    check(
+        "level() reads no state at all",
+        A.level.__code__.co_freevars == () and "LEVELS" in A.level.__code__.co_names,
+    )
+
+
+# --- rule 1: join on the stored id --------------------------------------------
+def test_stored_id():
+    # A row exactly like the 349: the clue text was repaired after the id was
+    # minted, so the id no longer hashes its own text. It must still join.
+    corpus = [
+        {
+            "id": "aaaaaaaaaaaa",
+            "q": "This general surrendered at Appomattox to Ulysses S. Grant in 1865",
+            "a": "Robert E. Lee",
+            "y": 1990,
+            "alt": [],
+            "w": [],
+        }
+    ]
+    enriched = {"aaaaaaaaaaaa": {"id": "aaaaaaaaaaaa", "r": 6, "w": [], "bad": False}}
+    pack, _ = A.assemble(corpus, enriched)
+    check(
+        "a repaired clue still joins on its stored id",
+        len(pack) == 1,
+        f"{len(pack)} rows",
+    )
+    check(
+        "the stored id survives into the pack",
+        pack and pack[0]["id"] == "aaaaaaaaaaaa",
+        pack[0]["id"] if pack else "-",
+    )
+    # ...and the id really has moved, so the test above is not vacuous: if the
+    # assembler re-derived, the join would miss and the row would vanish.
+    check(
+        "the case really is a moved id",
+        A.rederive(corpus[0]["q"]) != corpus[0]["id"],
+        "rederive matches, so this row would join either way",
+    )
+    # An unrated question is simply excluded, which is why re-deriving is
+    # invisible: no error, just a smaller pack.
+    pack2, _ = A.assemble(
+        corpus, {A.rederive(corpus[0]["q"]): enriched["aaaaaaaaaaaa"]}
+    )
+    check(
+        "keying on the re-derived id loses the row with no error",
+        len(pack2) == 0,
+        f"{len(pack2)} rows",
+    )
+
+
+# --- rule 2: no `w` key below three options -----------------------------------
+def test_short_option_sets():
+    for n in (0, 1, 2):
+        w = A.pick_options("Australia", (), ["Argentina", "Indonesia"][:n], [])
+        check(f"{n} candidate(s) yields no option set", w == [], str(w))
+    corpus = [
+        {
+            "id": "b" * 12,
+            "q": "This continent was sighted by Willem Jansz in 1606",
+            "a": "Australia",
+            "y": 1990,
+            "alt": [],
+            "w": [],
+        }
+    ]
+    enriched = {
+        "b" * 12: {
+            "id": "b" * 12,
+            "r": 5,
+            "w": ["Argentina", "Indonesia"],
+            "bad": False,
+        }
+    }
+    pack, _ = A.assemble(corpus, enriched)
+    check("a 2-option question keeps its clue", len(pack) == 1, f"{len(pack)} rows")
+    check(
+        "a 2-option question carries NO w key",
+        pack and "w" not in pack[0],
+        str(pack[0].get("w")) if pack else "-",
+    )
+    # The reason the key is dropped rather than shortened: test_pack.py asserts
+    # every question that HAS options has at least three of them.
+    mc = [x for x in pack if x.get("w")]
+    check("test_pack's MC invariant holds", all(len(x["w"]) >= 3 for x in mc))
+
+
+# --- the longest-option defect ------------------------------------------------
+def test_answer_never_longest():
+    # Model options at their measured worst: in-band individually, all shorter
+    # than the answer, so the set gives the answer away without any knowledge.
+    answer = "Mediterranean"
+    scattered = ["Caribbean", "Baltic Sea", "Adriatic"]
+    check(
+        "the case is really the defect",
+        all(A.distractors.length_ok(answer, c) for c in scattered)
+        and all(len(c) < len(answer) for c in scattered)
+        and len(scattered) >= 3,
+        "the fixture no longer reproduces the bug",
+    )
+    w = A.pick_options(answer, (), scattered, [])
+    check(
+        "three in-band but all-shorter options are refused outright",
+        w == [],
+        str(w),
+    )
+    # Given a candidate that CAN cover, the set must use it.
+    w = A.pick_options(answer, (), scattered, ["Bering Strait"])
+    check("a covering option is pulled in when one exists", len(w) == 3, str(w))
+    check(
+        "the answer is not strictly the longest option",
+        w and max(len(c) for c in w) >= len(answer),
+        f"answer {len(answer)} vs longest option {max((len(c) for c in w), default=0)}",
+    )
+    check(
+        "the covering option leads, so it survives any truncation to 3",
+        w and len(w[0]) >= len(answer),
+        str(w),
+    )
+
+
+def test_band_holds():
+    """The band is what pulls the spread down; the cover is what kills the tell.
+    Both must survive, so a fix to one cannot silently drop the other."""
+    answer = "Rome"
+    # 12 characters is outside 4/0.55 = 7.3, so it must not be selected even
+    # though it would satisfy the cover rule on its own.
+    w = A.pick_options(answer, (), ["Constantinople", "Ravenna", "Milan", "Pisa"], [])
+    check(
+        "an out-of-band option is refused even though it covers",
+        "Constantinople" not in w,
+        str(w),
+    )
+    check(
+        "all selected options are inside the band",
+        all(A.distractors.length_ok(answer, c) for c in w),
+        str(w),
+    )
+
+    # The spread the defect is actually about: scattered lengths around a fixed
+    # answer must come back tighter than they went in.
+    answer = "Napoleon"
+    noisy = ["Xerxes", "Charlemagne", "Attila", "Augustus", "Tiberius", "Nero"]
+    w = A.pick_options(answer, (), noisy, [])
+    before = statistics.pstdev([len(c) for c in noisy[:3]] + [len(answer)])
+    after = statistics.pstdev([len(c) for c in w] + [len(answer)])
+    check(
+        "selection narrows the length spread",
+        after < before,
+        f"{before:.2f} -> {after:.2f}",
+    )
+
+
+def test_pack_shape():
+    """An assembled row must be exactly what pack_format.write can encode."""
+    corpus = [
+        {
+            "id": "c" * 12,
+            "q": "This Italian city is built on more than a hundred islands",
+            "a": "Venice",
+            "y": 1995,
+            "alt": ["Venezia"],
+            "w": ["Naples", "Verona"],
+        }
+    ]
+    enriched = {
+        "c" * 12: {
+            "id": "c" * 12,
+            "r": 8,
+            "w": ["Genoa", "Turin", "Ravenna"],
+            "bad": False,
+        }
+    }
+    pack, _ = A.assemble(corpus, enriched)
+    x = pack[0]
+    check("d, y, q, a and id are all present", {"d", "y", "q", "a", "id"} <= set(x))
+    check("d is in 1..5", 1 <= x["d"] <= 5, str(x["d"]))
+    check(
+        "a `bad` rating removes the question",
+        A.assemble(corpus, {"c" * 12: {"id": "c" * 12, "r": 8, "bad": True}})[0] == [],
+    )
+    check(
+        "exactly STORED options are kept when available",
+        x.get("w") and len(x["w"]) == A.STORED,
+        str(x.get("w")),
+    )
+    check(
+        "no distractor equals the answer",
+        all(c.lower() != x["a"].lower() for c in x.get("w", [])),
+    )
+
+
+def main():
+    print("assemble_pack invariants\n")
+    for t in (
+        test_levels,
+        test_stored_id,
+        test_short_option_sets,
+        test_answer_never_longest,
+        test_band_holds,
+        test_pack_shape,
+    ):
+        t()
+    print(f"\n{len(FAILED)} failed")
+    return 1 if FAILED else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The local rating run (PID 7404, ~19h left) has been writing `id, r, w, bad, us, topic` rows all morning and **nothing committed could turn them into a pack**. This adds the missing half.

## The gap, verified before building on it

All five claims checked in this tree, not taken on trust:

| Claim | Verified |
| --- | --- |
| `build_pack.py --src` needs a Jeopardy TSV | `find` over the whole workspace: absent |
| `d` comes from the DOLLAR VALUE | `difficulty(row)` reads `row['clue_value']` |
| No `--ratings` / `--enriched` flag | argparse has `--src --out --limit --verdicts --keep-events --dat` |
| No 0-10 -> 1-5 mapping anywhere | repo-wide grep: nothing |
| `export_enriched.py` names `difficulty.py` as its consumer | line 8; `difficulty.py` does not exist |

## What this adds

`tools_local/trivia/assemble_pack.py`. Two builds, two files, deliberately:

```
build_pack.py     Jeopardy TSV      -> pack     difficulty from the dollar value
assemble_pack.py  corpus + ratings  -> pack     difficulty from the local rater
```

`build_pack.py` keeps the TSV path and every filter that needs its source columns. Adding a source-less second mode would have made `--src` conditionally required and left its whole filter body dead in that mode.

## Three rules, each of which fails silently when undone

- **Join on the corpus's stored id, never re-derive it.** `corpus_repaired.jsonl` carries pre-repair ids beside post-repair clue text for 349 rows. Re-deriving drops their ratings, and an unrated question is simply excluded, so the loss is a slightly smaller pack and no error at all. **Measured at 156 lost right now, ~349 at full coverage.** The tool prints that number every run, which is the only place it is visible. Card #146.
- **Fewer than three sound options means no `w` key, not a short one.** A 2-option set fails `test_pack.py`'s own MC invariant. Without the key the question is quizmaster-only and correct. Card #172 tops them up later.
- **`r` -> `d` by fixed absolute thresholds.** "Level 3" must mean the same thing at 18k rated rows and at 40k.

## The longest-option defect: the cause is spread, not bias

`test_pack.py` was failing at **20.6% strictly-longest** against a 15% bar. Mean option length is 7.5 chars against a 7.7-char answer, *identical* to the rule-based picker's, so the model is not writing short options. It does not band: stdev 1.63 against the picker's 0.49.

Applying `distractors.length_ok` moves 20.6% -> 15.7%. **Still failing** — banding cannot finish, because "the answer is longest" is a property of the SET, and three individually in-band options can all be shorter.

So the guarantee is constructed rather than sampled for: **every set carries at least one option at least as long as the answer**, then fills by closeness in length. Three are stored rather than six, because half the rows have only three sound candidates anyway, and because with three the set on the panel *is* the set the gate checked (six leaves 4.6% of possible draws bad while the first three read 0.0%).

Not fixed by loosening the check.

## Verification

- **Pack built from the live run** at 20,706 rated rows: 20,698 questions, 15,945 solo-MC, `test_pack.py` **21/21**.
- **Watched it fail.** Five mutations, each revert diffed first so a no-op could not read as a pass. Removing the cover rule, the band, the stored-id join, the short-set rule, or the fixed thresholds each turns a named check red. With band and cover both gone, `test_pack.py` reports **20.6% strictly longest and fails** — the original defect, reproduced.
- `./scripts_local/check.sh --tests` **all green**, with `test_assemble.py` wired into it.
- The rating job was untouched: nothing written inside `wt/localrate/.rate/`, the local model never called, PID 7404 still ADVANCING (20,668 rows at start, 21,222 at finish).

## What I could NOT verify

- **The device-side C++ reader against a real `.dat`.** `pack_format.write` produced a 2.70 MB `pack.dat` and `TriviaCore.cpp` mirrors that format, but nothing here decoded it on hardware or in the simulator. A 3-distractor record is a shape the shipped pack has never contained (it has always stored 6), so `playableAsChoice()` (`wrongCount_ >= 3`) and the partial Fisher-Yates draw in `TriviaCore.cpp:216` are exercised at their boundary for the first time. **Worth one simulator run before this pack ships to a card.**
- **The finished run.** Everything here is measured on 20,706 of 40,383 rated rows. The difficulty spread check passes at a ratio of 1.87 against a 2.5 bar, which is comfortable but not guaranteed once the second half lands; `docs/trivia-curation.md` says what to do if it moves, and that the answer is not to switch to quantiles.
- **Whether the options read well to a person.** The gate measures a length tell. Nobody has read a sheet of these sets cold, which is the instrument that found the original Layer 0 problem.

## Docs

`docs/trivia-curation.md` carries the exact command sequence for when the run finishes, including that `pack.state` must be replaced alongside `pack.dat`. It deliberately does **not** reference `rate_status.py`, which is untracked in `wt/localrate` — naming an uncommitted consumer is precisely the defect this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
