### PR TITLE
ci: group the pio run invocations, so the stack checks stop depending on order

### DIFF
--- a/.github/workflows/crossplay-ci.yml
+++ b/.github/workflows/crossplay-ci.yml
@@ -88,22 +88,38 @@ jobs:
       # The two flags only add .su and .ci files beside the objects; they change
       # no code, so this is still the build the next step checks. Asking for them
       # here rather than in a second build keeps CI one firmware compile long.
-      - name: Build the x4pro firmware
-        run: PLATFORMIO_BUILD_FLAGS="-fstack-usage -fcallgraph-info=su" pio run -e x4pro
+      # BOTH device envs in ONE invocation, and that is not tidiness.
+      #
+      # pio run calls clean_build_dir() once per invocation, against the whole
+      # .pio/build ROOT, and rmtree's it when compute_project_checksum()
+      # differs from the stored one -- which on a fresh checkout it always
+      # does, because the build generates gitignored headers that the checksum
+      # covers. So every invocation wipes the previous one's output. Building
+      # x4pro and sticky separately meant the x4pro stack check below read a
+      # directory that the sticky build was about to delete, and it passed only
+      # because it was sequenced first. The same hazard emptied
+      # .pio/build/gh_release_x4pro between two steps of crossplay-release.yml
+      # and cost v1.12.14 and v1.12.15.
+      #
+      # The Sticky compiles SDK code the x4pro build never sees (mic, buzzer,
+      # sensors, IMU) and carries its own device flag, so a green x4pro build
+      # does not prove the sticky env compiles. One invocation, both envs, no
+      # ordering rule to break.
+      - name: Build both device firmwares
+        run: PLATFORMIO_BUILD_FLAGS="-fstack-usage -fcallgraph-info=su" pio run -e x4pro -e sticky
 
       # v1.0.0 shipped a render task that needed 8016 bytes of an 8192-byte
       # stack and crashed on the first device that ever ran it. Nothing here
       # measured stack, and nothing on a host could: frame sizes belong to the
       # target ABI. This reads the numbers the firmware compiler just emitted.
+      #
+      # Both checks now read build directories that nothing between them
+      # removes. stack_budget.py refuses rather than passing empty -- it exits
+      # on no frames and fails a task whose entry is missing -- so the old
+      # arrangement would have gone red rather than quiet. That is why this is
+      # a fragility fix and not a bug fix.
       - name: Stack fits its task (x4pro)
         run: python3 scripts_local/stack_budget.py --build-dir .pio/build/x4pro
-
-      # The Sticky compiles SDK code the x4pro build never sees (mic, buzzer,
-      # sensors, IMU) and carries its own device flag, so a green x4pro build
-      # does not prove the sticky env compiles. Same stack discipline, same
-      # reasons.
-      - name: Build the sticky firmware
-        run: PLATFORMIO_BUILD_FLAGS="-fstack-usage -fcallgraph-info=su" pio run -e sticky
 
       - name: Stack fits its task (sticky)
         run: python3 scripts_local/stack_budget.py --build-dir .pio/build/sticky
@@ -117,11 +133,8 @@ jobs:
       # gh_release_* was compiled for the first time by the release workflow,
       # i.e. after the tag was already pushed. A typo in release-only code cost
       # a delete-and-retag to find.
-      - name: Build the release firmware (x4pro)
-        run: pio run -e gh_release_x4pro
-
-      - name: Build the release firmware (sticky)
-        run: pio run -e gh_release_sticky
+      - name: Build both release firmwares
+        run: pio run -e gh_release_x4pro -e gh_release_sticky
 
       # Nothing is forgiven. ui:paperOnTheBand was a real baseline failure
       # once, and this step carried a carefully shaped exemption for it until

--- a/host-tests/ci/run.sh
+++ b/host-tests/ci/run.sh
@@ -173,5 +173,32 @@ publish "a tag pushed with RELEASE_TOKEN is not dispatched again"      true  0
 publish "a tag pushed with the workflow token is dispatched once"      false 1
 publish "no flag at all (no secret, older text) still dispatches once" ""    1
 
+# The two stack-checked device envs build in ONE pio run invocation.
+#
+# pio run wipes the whole .pio/build root on every invocation
+# (clean_build_dir, whose checksum changes because the build generates
+# gitignored headers). Split across two invocations, the x4pro stack check
+# passes only because it is sequenced before the sticky build that deletes its
+# directory -- correct today, guaranteed by nothing, and one moved step from
+# reading a directory that no longer exists.
+#
+# Asserting the grouping rather than the spacing, because the spacing is
+# satisfied by the broken arrangement too: each check already follows its own
+# build. What is missing there is the guarantee, not the order.
+#
+# stack_budget.py refuses rather than passing empty (it exits on no frames and
+# fails an unchecked task), so the split would have gone red rather than
+# silent. That is why this is fragility and not a defect -- and why it is
+# asserted here instead of waiting for someone to trip it.
+checks=$((checks + 1))
+stack_builds=$(grep -c 'fstack-usage.*pio run' "$YML")
+if [ "$stack_builds" -ne 1 ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci  expected ONE stack-flagged pio run covering both device envs, found $stack_builds; each extra invocation wipes .pio/build and leaves the stack checks depending on step order"
+elif ! grep -q 'fstack-usage.*pio run -e x4pro -e sticky' "$YML"; then
+  failed=$((failed + 1))
+  echo "FAIL ci  the stack-flagged build does not cover both x4pro and sticky in one invocation"
+fi
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
Found by the Main session while reviewing the same hazard in `check.sh`. **Not
broken today** — and that distinction is load-bearing, see below.

## The shape

`crossplay-ci.yml`'s build job ran **five** separate `pio run` invocations:
`x4pro`, `sticky`, `simulator_x4_pro`, `gh_release_x4pro`, `gh_release_sticky`.

Each one calls `clean_build_dir()` against the whole `.pio/build` **root** and
`rmtree`s it when `compute_project_checksum()` differs — which on a fresh
checkout it always does, because the build generates gitignored headers the
checksum covers. So every invocation wipes the previous one's output.

"Stack fits its task (x4pro)" reads `.pio/build/x4pro`, and the sticky build
immediately after it deletes that directory. It passes **only because it is
sequenced first**. Same hazard that emptied `.pio/build/gh_release_x4pro`
between two steps of `crossplay-release.yml` and cost v1.12.14 and v1.12.15.

## Why this is fragility and not a defect

`scripts_local/stack_budget.py` refuses rather than passing empty: it exits when
no frames are found, fails a task whose entry is missing, and its own comment
records that printing "All tasks fit" over an empty list was the previous
behaviour someone already removed. A broken ordering here goes **red**, not
quiet.

So nothing is wrong today. It is correct-by-ordering, guaranteed by nothing, and
a step reordering is exactly the edit someone makes without thinking about build
directories.

## The change

Both stack-flagged device envs in one invocation with both checks after it, and
the two release envs in another. **Five invocations become three.**

## The test, and a correction to it

`host-tests/ci` asserts the **grouping**, not the spacing.

My first version asserted what the report described — that no `pio run` sits
between a build and its stack check — and **it passed on the broken arrangement
too**. Each check already immediately follows its own build, in both layouts, so
the spacing was never the missing property. The missing property is the
guarantee. Only mutation-testing caught it; green said nothing.

The corrected assertion was watched failing with the pair split back into two
invocations, naming the count.

## Verified

`./scripts_local/check.sh --tests`: all green, no skips. Rebased onto `xteink`
and `host-tests/ci` re-run green after the rebase.

## Not verified

This changes how CI builds, not what it produces. The next CI run on `xteink` is
the test.

Board card #187.

🤖 Generated with [Claude Code](https://claude.com/claude-code)