### PR TITLE
ci: let postgres take longer than 60s, and say why when it does not

### DIFF
--- a/host-tests/relwatch/run.sh
+++ b/host-tests/relwatch/run.sh
@@ -48,12 +48,19 @@ trap 'docker rm -f "$CID" >/dev/null 2>&1; rm -rf "$WORK"' EXIT
 
 psql() { docker exec -i "$CID" psql -U postgres -d board -v ON_ERROR_STOP=1 -qtA "$@"; }
 
-for _ in $(seq 1 60); do
+# 180 rather than 60: this suite runs on a CI runner that is building four
+# device images at the same time, and 60s of a loaded runner is not 60s of an
+# idle laptop. A postgres that was merely slow used to fail a pull request whose
+# diff could not touch it -- seen 2026-09-04 on a forehead word-list change.
+for _ in $(seq 1 180); do
   docker exec "$CID" pg_isready -U postgres -d board >/dev/null 2>&1 && break
   sleep 1
 done
 if ! docker exec "$CID" pg_isready -U postgres -d board >/dev/null 2>&1; then
-  echo "FAIL relwatch  postgres never came up"
+  # Say WHY. "never came up" names no cause, and the next person to read it is
+  # looking at a red build on an unrelated diff with nothing to go on.
+  echo "FAIL relwatch  postgres never came up within 180s; its own log follows"
+  docker logs "$CID" 2>&1 | tail -20 | sed 's/^/    /'
   exit 1
 fi
 


### PR DESCRIPTION
The `relwatch` suite failed [PR #53](https://github.com/ma-r-s/crossplay/pull/53), whose diff is a **Forehead word list**. The entire failure message was:

```
FAIL relwatch  postgres never came up
```

Every other pull request open at the same moment passed its build, so this is a slow start under load, not a broken suite.

## Two problems, both in this file

**The bound was 60 seconds.** This suite runs on a CI runner that is compiling four device images at the same time. 60s of a loaded runner is not 60s of an idle laptop. Now 180s.

**The failure named no cause.** A red build on an unrelated diff, with "never came up" as the only evidence, is the shape this repo keeps paying for -- one signature, several possible causes, none of them distinguished, and the reader has nothing to go on. It now prints postgres's own last 20 lines.

## Why this could not have happened before today

`host-tests/relwatch` landed in #44, merged a few hours ago, and it is **the first CI job in this repository that needs a database at all**. So every pull request in the fork can now fail for a reason that has nothing to do with its diff, and until this change that failure was mute. Worth stating plainly rather than leaving as a surprise for whoever hits it next.

I merged #44, so this is mine to fix.

## Verification

- `sh -n` clean.
- Suite run locally against a real postgres: **64 passed, 0 failed**.

**Not verified:** the failure branch itself. Exercising it needs a postgres that genuinely fails to start, which I did not manufacture -- so the `docker logs` line is unproven in the case it exists for. Reviewer should weigh that.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)