### PR TITLE
US-centric trivia stops shipping, and the levels are recalibrated for it

### DIFF
--- a/docs/trivia-curation.md
+++ b/docs/trivia-curation.md
@@ -264,8 +264,9 @@ it needs the source columns. `assemble_pack.py` starts from the output of that
 work -- the decoded pack -- and only re-decides difficulty and options.
 
 ```text
-build_pack.py     Jeopardy TSV      -> pack     difficulty from the dollar value
-assemble_pack.py  corpus + ratings  -> pack     difficulty from the local rater
+build_pack.py       Jeopardy TSV      -> pack   difficulty from the dollar value
+assemble_pack.py    corpus + ratings  -> pack   difficulty from the local rater
+calibrate_levels.py corpus + ratings  -> advice which r maps to which level
 ```
 
 ### The command sequence, in order
@@ -280,7 +281,8 @@ tree holding the rating run.
 #    prints the same thing with a verdict. This line needs nothing but the run.)
 echo "$(cut -d'"' -f4 .rate/enriched.jsonl | sort -u | wc -l) rated of $(wc -l < .rate/rest40383.ids)"
 
-# 2. Assemble. --kick-us also drops US-centric questions; without it they stay.
+# 2. Assemble. US-centric questions are dropped by default; --keep-us includes
+#    them. Nothing is deleted from the corpus or the ratings either way.
 python3 tools_local/trivia/assemble_pack.py \
     --corpus .rate/corpus_repaired.jsonl \
     --enriched .rate/enriched.jsonl \
@@ -303,7 +305,7 @@ and addressed by index, so a state file left over from a different pack marks
 the wrong questions seen. `assemble_pack.py --dat` writes a fresh zeroed one
 beside the pack every time; copy both or neither.
 
-### Three rules in that tool, each of which fails silently when undone
+### Four rules in that tool, each of which fails silently when undone
 
 **Join on the corpus's stored id. Never re-derive it.** Ids are a sha1 of
 normalised clue text and `pack_format.py` re-derives them, which is right when
@@ -323,14 +325,79 @@ Without the key the question is quizmaster-only and completely correct. Topping
 these up is board card #172.
 
 **`r` maps to `d` by fixed absolute thresholds, never by quantile.** Each level
-is a two-point band on the rater's own 0-10 scale (`LEVELS` in the tool). A
-quantile mapping would be perfectly balanced and would redefine every level each
-time the run is re-cut, so "level 3" would mean one thing at 18,000 rated rows
-and another at 40,000, and a player's difficulty setting would mean nothing
-across builds.
+is a band on the rater's own 0-10 scale (`LEVELS` in the tool). A quantile
+mapping would be perfectly balanced and would redefine every level each time the
+run is re-cut, so "level 3" would mean one thing at 20,000 rated rows and
+another at 40,000, and a player's difficulty setting would mean nothing across
+builds.
 
-`test_assemble.py` exists to make undoing any of the three loud, and
+Fixed does not mean arbitrary. The constants are still chosen on a population,
+and when that population changes they have to be chosen again -- as fixed
+numbers, on the new population. See "Recalibrating the thresholds" below.
+
+**US-centric questions do not ship, and are not deleted.** Mario's call on
+2026-09-04: they should not show up, until and unless a toggle is written for
+them. The filter is therefore at the pack build and nowhere upstream of it.
+`enrich_pack.py` still writes `us` as a field rather than a deletion, every
+US-centric row keeps its rating, and `--keep-us` rebuilds the inclusive pack
+from exactly the same inputs. **When the toggle is written, nothing needs
+re-rating.** Deleting the rows instead would cost 5,905 ratings that took hours
+of local model time and cannot be recovered from the pack.
+
+`test_assemble.py` exists to make undoing any of the four loud, and
 `check.sh --tests` runs it.
+
+### Recalibrating the thresholds
+
+Dropping the US-centric questions broke the difficulty spread, and the reason is
+real rather than a bug: **for an international table, the US-centric questions
+genuinely are the hard ones.** Measured on the 2026-09-04 run, mean `r` was 1.30
+for them against 6.36 for the rest, and under the old floors 86% of them sat in
+level 5. Take them out and level 5 goes from 5,926 questions to 845, a 4.2%
+tier, and `test_pack.py` fails `difficulty reasonably spread` at 20/21.
+
+The fix is different fixed numbers measured on the international-only
+population, so that a level means "hard for an international table" -- which is
+what the ratings measure and what the pack now contains. `LEVELS` moved from
+floors `(9, 7, 5, 3)` to `(9, 8, 7, 5)`:
+
+| level | r band | before (US kept) | after |
+| ----- | ------ | ---------------- | ----- |
+| 1     | 9-10   | 3,772            | 3,754 |
+| 2     | 8      | 6,883            | 3,849 |
+| 3     | 7      | 5,165            | 3,022 |
+| 4     | 5-6    | 4,222            | 5,101 |
+| 5     | 0-4    | 5,926            | 4,337 |
+
+Bands are narrow at the easy end and wide at the hard end because that is where
+the international mass sits. Level 1 still means "9 or 10 groups in 10 get it"
+and level 5 still means "at most 4 do"; the numbers are absolute, not quantiles.
+
+**These constants are provisional.** They were chosen at 25,977 rated rows of a
+run that will finish near 50,000, so re-derive them when it does -- one command,
+which prints how the shipped constants stand on the current data and what it
+would choose instead:
+
+```bash
+python3 tools_local/trivia/calibrate_levels.py \
+    --corpus .rate/corpus_repaired.jsonl \
+    --enriched .rate/enriched.jsonl
+```
+
+It prints rather than edits, deliberately: constants a build step rewrites are
+quantiles with extra steps. Adopting a new set means editing `LEVELS`, updating
+the `CALIBRATED ON` comment above it with the date and population, rebuilding
+and re-running `test_pack.py`.
+
+It scores candidates by their **worst** spread ratio across three views of the
+run -- all rated rows, the half rated first, the half rated last -- not by the
+best on the pooled data. `enriched.jsonl` is append-ordered and mixes rows rated
+under different shot configurations, so its halves genuinely disagree: on
+2026-09-04 `r=5` was 20.1% of the first half and 7.7% of the second. A candidate
+tuned to the pooled distribution can look best and then fail on the rows still
+to come, and the half rated last is the closest proxy for those. On that day
+`(9, 8, 7, 5)` was the only candidate that passed on all three views (worst
+1.98); the runner-up already failed at 2.70.
 
 ### The longest-option defect, and why banding alone did not fix it
 
@@ -393,28 +460,36 @@ the real writer as well.
 
 ### What a run of this looks like
 
-At 20,706 of 40,383 rated:
+At 25,977 rated, with US-centric questions dropped:
 
 ```text
 corpus            : 50,000
-ratings           : 20,706
+ratings           : 25,977
   ids that moved  : 349 rows carry a pre-repair id
-  re-derive would : lose 156 ratings SILENTLY (card #146)
-  dropped  29,294  unrated (not yet reached by the run)
-  dropped       8  rejected: unanswerable
+  re-derive would : lose 193 ratings SILENTLY (card #146)
+  dropped  24,023  unrated (not yet reached by the run)
+  dropped   5,905  rejected: us_centric (default; --keep-us to include)
+  dropped       9  rejected: unanswerable
 
-pack              : 20,698
-  solo MC ready   : 15,945 (3 stored options each)
-  read-aloud only : 4,753 (no sound option set; card #172)
-  difficulty      : {1: 3041, 2: 5701, 3: 4120, 4: 3137, 5: 4699}
+pack              : 20,063
+  solo MC ready   : 15,244 (3 stored options each)
+  read-aloud only : 4,819 (no sound option set; card #172)
+  difficulty      : {1: 3754, 2: 3849, 3: 3022, 4: 5101, 5: 4337}
 ```
 
 `test_pack.py` passes 21/21 on that pack.
 
 **Watch the difficulty spread as the run finishes.** The gate wants no tier more
-than 2.5x the smallest, and the fixed thresholds put that at 5,701 against 3,041
--- a ratio of 1.87. That is comfortable but it is not guaranteed: the thresholds
-are absolute by design, so a second half of the run that rates differently from
-the first will move the tiers. If `difficulty reasonably spread` fails, the
-answer is to look at the r histogram and move `LEVELS`, once, deliberately, and
-say so here. It is not to switch to quantiles.
+than 2.5x the smallest, and the current thresholds put that at 5,101 against
+3,022 -- a ratio of 1.69. That is comfortable but it is not guaranteed: the
+thresholds are absolute by design, so a second half of the run that rates
+differently from the first will move the tiers, and this run's two halves
+already do disagree.
+
+This has now happened once, which is what "Recalibrating the thresholds" above
+is about. When `difficulty reasonably spread` fails, look at the r histogram and
+move `LEVELS`, once, deliberately, and say so here. **It is not to switch to
+quantiles, and it is not to weaken the check** -- the check exists because
+levels 1 and 5 feeling identical is the complaint that started this work.
+`calibrate_levels.py` is the histogram-reading step, written down so the next
+person does not have to re-derive the method along with the numbers.

--- a/tools_local/trivia/assemble_pack.py
+++ b/tools_local/trivia/assemble_pack.py
@@ -26,7 +26,11 @@ Inputs:
         --out pack.jsonl --dat pack.dat
     python3 tools_local/trivia/test_pack.py pack.jsonl
 
-Three rules here were each paid for. Do not quietly undo any of them; the tests
+US-centric questions are DROPPED BY DEFAULT (rule 4). `--keep-us` builds the
+inclusive pack from the same inputs; nothing is deleted from the corpus or from
+the ratings, so a future in-app toggle needs no re-rating.
+
+Four rules here were each paid for. Do not quietly undo any of them; the tests
 in test_assemble.py exist to make undoing one loud.
 """
 
@@ -63,16 +67,35 @@ def rederive(clue):
 
 
 # --- rule 3: r -> d by fixed absolute thresholds, never by quantile ----------
-# Each level is a two-point band on the rater's own 0-10 scale. Absolute, so
-# "level 3" means the same question difficulty in a pack built from 18,000
-# rated rows and in one built from 40,000. Quantile bands would be balanced by
-# construction and would silently redefine every level each time the run is
-# re-cut, which makes a difficulty setting meaningless across builds.
+# Each level is a band on the rater's own 0-10 scale. Absolute, so "level 3"
+# means the same question difficulty in a pack built from 20,000 rated rows and
+# in one built from 40,000. Quantile bands would be balanced by construction
+# and would silently redefine every level each time the run is re-cut, which
+# makes a difficulty setting meaningless across builds.
 #
 # r is "out of ten groups, how many get it right", so HIGH r is EASY and level
 # 1 is the easiest tier -- the same direction as build_pack.py's dollar tiers.
-# The bottom band is three points wide because 11 values do not split into 5.
-LEVELS = ((9, 1), (7, 2), (5, 3), (3, 4))
+#
+# CALIBRATED ON: the INTERNATIONAL half of the rating run, 2026-09-04, 20,063
+# surviving rows (25,968 rated, minus the 5,905 flagged us_centric that no
+# longer ship). That population is the whole reason these numbers changed. The
+# previous floors (9, 7, 5, 3) were chosen when US-centric questions still
+# shipped, and for an international table those questions genuinely ARE the
+# hard ones: 68% of them rate r<=1, against 2% of the rest. Dropping them took
+# level 5 from 5,926 questions to 845 and the pack failed test_pack.py's
+# difficulty spread. These floors are the same fixed-constant scheme measured
+# against the population that actually ships.
+#
+# Bands are narrow at the easy end and wide at the hard end because that is
+# where the international mass sits, not as a balancing trick: level 1 still
+# means "9 or 10 groups in 10 get it" and level 5 still means "at most 4 do".
+#
+# Re-derive them in one command when the rating run finishes:
+#     python3 tools_local/trivia/calibrate_levels.py \
+#         --corpus .rate/corpus_repaired.jsonl --enriched .rate/enriched.jsonl
+# It prints how these constants stand on the current data and what it would
+# choose instead. See docs/trivia-curation.md.
+LEVELS = ((9, 1), (8, 2), (7, 3), (5, 4))
 
 
 def level(r):
@@ -156,15 +179,29 @@ def pick_options(answer, alts, model_w, rule_w, want=3):
 STORED = 3
 
 
-def assemble(corpus, enriched, kick_us=False, seed=20260904):
-    """corpus and enriched are lists/dicts of already-parsed rows."""
-    stats = collections.Counter()
+# --- rule 4: US-centric questions do not ship, and are not deleted either -----
+# Mario's call, 2026-09-04: "US centric trivia needs to go. At least for now.
+# Not removed from our data, but for now and until we decide to write a toggle.
+# They shouldn't show up."
+#
+# So the filter lives HERE, at the pack build, and nowhere upstream of it.
+# enrich_pack.py still writes `us` as a field rather than a deletion, the
+# ratings file still carries every US-centric row with its rating intact, and
+# --keep-us rebuilds the inclusive pack from exactly the same inputs. When the
+# toggle is written, nothing needs re-rating.
+KICK_US_BY_DEFAULT = True
 
-    # Pass 1: which questions survive, on ratings alone. The rule-based picker
-    # draws from the SHIPPED slice, so it has to be indexed over the survivors
-    # rather than over the corpus -- an option must be an answer the player
-    # could otherwise have met.
-    keep = []
+
+def survivors(corpus, enriched, kick_us=KICK_US_BY_DEFAULT, stats=None):
+    """Yield (corpus_row, rating_row) for every question that reaches the pack.
+
+    Split out of assemble() so that calibrate_levels.py measures the population
+    that actually SHIPS rather than a second, hand-copied idea of it. A
+    calibration run against a different filter would choose thresholds for a
+    pack nobody builds, and would look exactly like a correct one.
+    """
+    if stats is None:
+        stats = collections.Counter()
     for x in corpus:
         e = enriched.get(x["id"])
         if e is None:
@@ -177,8 +214,21 @@ def assemble(corpus, enriched, kick_us=False, seed=20260904):
             stats["rejected: unanswerable"] += 1
             continue
         if kick_us and e.get("us"):
-            stats["rejected: us_centric (--kick-us)"] += 1
+            stats["rejected: us_centric (default; --keep-us to include)"] += 1
             continue
+        yield x, e
+
+
+def assemble(corpus, enriched, kick_us=KICK_US_BY_DEFAULT, seed=20260904):
+    """corpus and enriched are lists/dicts of already-parsed rows."""
+    stats = collections.Counter()
+
+    # Pass 1: which questions survive, on ratings alone. The rule-based picker
+    # draws from the SHIPPED slice, so it has to be indexed over the survivors
+    # rather than over the corpus -- an option must be an answer the player
+    # could otherwise have met.
+    keep = []
+    for x, e in survivors(corpus, enriched, kick_us, stats):
         item = {
             "id": x["id"],
             "q": x["q"],
@@ -252,6 +302,24 @@ def load_enriched(path):
     return out, dupes
 
 
+def apply_verdicts(corpus, path):
+    """Drop every id a person marked `bad`, whatever the rater said about it.
+
+    Hand verdicts outrank the rater in both directions of trust: a person
+    looked at the question. Applied before assembly so a `bad` id can never
+    reach the pack through a rating that liked it. Shared with
+    calibrate_levels.py so both see the same corpus.
+    """
+    if not path or not os.path.exists(path):
+        return list(corpus)
+    bad = set()
+    for line in open(path, encoding="utf-8"):
+        parts = line.strip().split("\t")
+        if len(parts) >= 2 and not line.startswith("#") and parts[1].strip() == "bad":
+            bad.add(parts[0].strip())
+    return [x for x in corpus if x["id"] not in bad]
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument(
@@ -261,9 +329,9 @@ def main():
     ap.add_argument("--out", required=True)
     ap.add_argument("--dat", default="", help="also write the on-card binary pack")
     ap.add_argument(
-        "--kick-us",
+        "--keep-us",
         action="store_true",
-        help="also drop us_centric questions (default: keep them)",
+        help="include us_centric questions (default: they are dropped)",
     )
     ap.add_argument(
         "--verdicts",
@@ -277,25 +345,11 @@ def main():
     if not enriched:
         sys.exit(f"{a.enriched}: no usable records")
 
-    # Hand verdicts outrank the rater in both directions of trust: a person
-    # looked at the question. Applied before assembly so a `bad` id can never
-    # reach the pack through a rating that liked it.
-    n_verdict = 0
-    if a.verdicts and os.path.exists(a.verdicts):
-        bad = set()
-        for line in open(a.verdicts, encoding="utf-8"):
-            parts = line.strip().split("\t")
-            if (
-                len(parts) >= 2
-                and not line.startswith("#")
-                and parts[1].strip() == "bad"
-            ):
-                bad.add(parts[0].strip())
-        before = len(corpus)
-        corpus = [x for x in corpus if x["id"] not in bad]
-        n_verdict = before - len(corpus)
+    before = len(corpus)
+    corpus = apply_verdicts(corpus, a.verdicts)
+    n_verdict = before - len(corpus)
 
-    pack, stats = assemble(corpus, enriched, a.kick_us)
+    pack, stats = assemble(corpus, enriched, kick_us=not a.keep_us)
 
     # What re-deriving the ids would have cost, printed whether or not it is
     # zero. It is the number card #146 is about and it is invisible everywhere

--- a/tools_local/trivia/calibrate_levels.py
+++ b/tools_local/trivia/calibrate_levels.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Choose assemble_pack.LEVELS against the population that actually ships.
+
+    python3 tools_local/trivia/calibrate_levels.py \\
+        --corpus .rate/corpus_repaired.jsonl --enriched .rate/enriched.jsonl
+
+Prints where the SHIPPED constants stand on the current data and what it would
+choose instead. Nothing is written; the output is a tuple to paste into
+assemble_pack.py, on purpose -- see "why not automatic" below.
+
+Why this file exists
+--------------------
+`r -> d` uses fixed absolute thresholds so that a level means the same thing at
+20,000 rated rows and at 40,000 (assemble_pack.py, rule 3). Fixed does not mean
+arbitrary: the constants still have to be CHOSEN on some population, and the
+population changed underneath them when US-centric questions stopped shipping
+(rule 4). For an international table those questions are genuinely the hard
+ones -- 68% of them rate r<=1 against 2% of the rest -- so thresholds picked
+while they still shipped put almost nothing in level 5, and test_pack.py's
+difficulty-spread check failed on a pack that was, correctly, all one flavour.
+
+The answer is different fixed numbers on the right population, not a switch to
+quantiles. This tool is what makes that re-derivable instead of hand-tuned: a
+constant nobody can reproduce is the thing to avoid, and the current ones were
+chosen on a PARTIAL run that will roughly double in size.
+
+Why not automatic
+-----------------
+It prints rather than edits. Constants that a build step rewrites are quantiles
+with extra steps: every re-cut of the run would silently redefine level 3 and a
+player's difficulty setting would stop meaning anything across builds, which is
+the exact failure rule 3 exists to prevent. Changing a level is a decision with
+a date on it, so it goes through a diff.
+
+The choosing rule
+-----------------
+The population is the one assemble_pack.survivors() yields, so this cannot
+drift from what the pack contains. Candidates are every set of four floors over
+the 0-10 scale. The score is the WORST spread ratio across three views of the
+run rather than the best on all of it:
+
+    all rated rows, the half rated first, the half rated last
+
+because enriched.jsonl is append-ordered and mixes rows rated under different
+shot configurations, so its two halves really do disagree (r=5 was 20.1% of the
+first half and 7.7% of the second on 2026-09-04). A candidate tuned to the
+pooled distribution can be the best on paper and fail on the rows still to
+come; the half rated last is the closest proxy for those. Minimax picks the set
+that still passes when the population moves, which is the property actually
+wanted from a constant chosen on partial data.
+"""
+
+import argparse
+import collections
+import itertools
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import assemble_pack  # noqa: E402
+
+# test_pack.py's difficulty-spread check, which is the thing being satisfied:
+#   check('difficulty reasonably spread', hi <= lo * 2.5)
+SPREAD_LIMIT = 2.5
+
+
+def level_with(r, floors):
+    """assemble_pack.level(), parameterised by a candidate floor tuple."""
+    for d, floor in enumerate(floors, start=1):
+        if r >= floor:
+            return d
+    return len(floors) + 1
+
+
+def spread(rs, floors):
+    """Level counts and the hi/lo ratio for one r-value population."""
+    counts = collections.Counter(level_with(r, floors) for r in rs)
+    if len(counts) < len(floors) + 1:
+        return counts, float("inf")  # an empty level is not a difficulty tier
+    return counts, max(counts.values()) / min(counts.values())
+
+
+def choose(samples, limit=SPREAD_LIMIT):
+    """Pick the floors minimising the worst spread ratio over `samples`.
+
+    samples is a list of (name, r-values) pairs. Returns a list of
+    (worst_ratio, floors, {name: ratio}) sorted best first. Deterministic: ties
+    break on the floor tuple itself, never on dict or set order.
+    """
+    scored = []
+    for combo in itertools.combinations(range(1, 12), 4):
+        floors = tuple(reversed(combo))  # descending: level 1 is the easiest
+        ratios = {n: spread(rs, floors)[1] for n, rs in samples}
+        worst = max(ratios.values())
+        if worst == float("inf"):
+            continue
+        scored.append((worst, floors, ratios))
+    scored.sort(key=lambda t: (t[0], t[1]))
+    return scored
+
+
+def views(rows):
+    """The three populations a candidate must survive.
+
+    `rows` must arrive in RATING order (enriched.jsonl's append order), which
+    is why the caller sorts it that way rather than taking the assembler's
+    corpus order. The run appends as it goes and its shot configuration changed
+    mid-file, so rating order is the axis the drift lies along: on 2026-09-04
+    r=5 was 20.1% of the first half and 7.7% of the second. Splitting on any
+    other axis averages that away and reports a stability the data lacks, and
+    the second half is the closest proxy for the rows still to be rated.
+    """
+    half = len(rows) // 2
+    return [
+        ("all", rows),
+        ("rated first", rows[:half]),
+        ("rated last", rows[half:]),
+    ]
+
+
+def table(samples, floors, note=""):
+    counts, ratio = spread(samples[0][1], floors)
+    bands = []
+    for d, f in enumerate(list(floors) + [0], start=1):
+        hi = 10 if d == 1 else floors[d - 2] - 1
+        lo = f if d <= len(floors) else 0
+        bands.append((d, lo, hi))
+    print(f"\n  floors {list(floors)}{note}")
+    print(f"    {'level':<6} {'r band':<10} {'questions':>10}   share")
+    total = sum(counts.values()) or 1
+    for d, lo, hi in bands:
+        band = f"{lo}-{hi}" if lo != hi else str(lo)
+        print(
+            f"    {d:<6} {band:<10} {counts.get(d, 0):>10,}   "
+            f"{100 * counts.get(d, 0) / total:4.1f}%"
+        )
+    for name, rs in samples:
+        _, r = spread(rs, floors)
+        verdict = "PASS" if r <= SPREAD_LIMIT else "FAIL"
+        print(f"    spread on {name:<12} {r:6.3f}  (limit {SPREAD_LIMIT})  {verdict}")
+    return ratio
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--corpus", required=True)
+    ap.add_argument("--enriched", required=True)
+    ap.add_argument(
+        "--verdicts",
+        default="tools_local/trivia/verdicts.tsv",
+        help="same hand verdicts the assembler applies",
+    )
+    ap.add_argument(
+        "--keep-us",
+        action="store_true",
+        help="calibrate on the US-inclusive pack instead (default: as shipped)",
+    )
+    ap.add_argument("--top", type=int, default=5, help="candidates to list")
+    a = ap.parse_args()
+
+    corpus = [
+        json.loads(line) for line in open(a.corpus, encoding="utf-8") if line.strip()
+    ]
+    corpus = assemble_pack.apply_verdicts(corpus, a.verdicts)
+    enriched, _ = assemble_pack.load_enriched(a.enriched)
+    if not enriched:
+        sys.exit(f"{a.enriched}: no usable records")
+
+    # The population is whatever the assembler would ship, taken from the
+    # assembler itself so the two cannot drift apart.
+    #
+    # Then re-ordered by RATING order. survivors() walks the corpus, which is a
+    # fixed 50k file in its own arbitrary order and says nothing about when a
+    # row was rated; views() needs the append order of enriched.jsonl, because
+    # that is the axis the run's configuration drift lies along. load_enriched
+    # builds its dict by reading the file top to bottom, so dict order is that
+    # order (a duplicate id keeps its first position, which is what we want:
+    # resume artefacts should not reshuffle the run).
+    stats = collections.Counter()
+    kick = not a.keep_us
+    rank = {rid: i for i, rid in enumerate(enriched)}
+    surviving = list(assemble_pack.survivors(corpus, enriched, kick, stats))
+    surviving.sort(key=lambda xe: rank[xe[0]["id"]])
+    rows = [e["r"] for _, e in surviving]
+    if not rows:
+        sys.exit("no rated rows survive the filters; nothing to calibrate")
+
+    kicked = sum(v for k, v in stats.items() if k.startswith("rejected: us_centric"))
+    print(f"corpus            : {len(corpus):,}")
+    print(f"rated             : {len(enriched):,}")
+    print(f"population        : {len(rows):,} rows that would ship")
+    print(
+        f"  us_centric      : {kicked:,} dropped"
+        if kick
+        else "  us_centric      : kept (--keep-us)"
+    )
+    print(f"  r distribution  : {dict(sorted(collections.Counter(rows).items()))}")
+
+    samples = views(rows)
+
+    shipped = tuple(f for f, _ in assemble_pack.LEVELS)
+    print("\n--- the constants in assemble_pack.py today ---")
+    table(samples, shipped)
+
+    scored = choose(samples)
+    print(f"\n--- best {a.top} candidates on this data (minimax over the views) ---")
+    for worst, floors, ratios in scored[: a.top]:
+        detail = "  ".join(f"{n} {r:.3f}" for n, r in ratios.items())
+        mark = "  <- shipped" if floors == shipped else ""
+        print(f"  worst {worst:6.3f}  floors {list(floors)}   {detail}{mark}")
+
+    best = scored[0][1]
+    print("\n--- recommended ---")
+    table(samples, best)
+    if best == shipped:
+        print("\nThe shipped constants are still the best choice. Nothing to do.")
+    else:
+        print(
+            "\nTo adopt, edit LEVELS in tools_local/trivia/assemble_pack.py:\n"
+            f"    LEVELS = {tuple((f, d) for d, f in enumerate(best, start=1))}\n"
+            "and update the CALIBRATED ON comment above it with today's date and\n"
+            f"population ({len(rows):,} rows). Then rebuild the pack and re-run\n"
+            "test_pack.py, which is what the spread numbers above predict."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools_local/trivia/export_enriched.py
+++ b/tools_local/trivia/export_enriched.py
@@ -16,16 +16,23 @@ question softer than the archive, and the international framing then pushes the
 American questions back down. Averaging them would produce a number on neither
 scale. Point the build at one file or the other.
 
-KICKING IS A FLAG, NOT A DEFAULT. --kick-us adds us_centric questions to the
-verdicts file; without it only `bad` is kicked. A US-inclusive pack stays
-buildable from exactly the same data, which is the reason enrich_pack.py stored
-the two as separate fields in the first place.
+KICKING IS A FLAG HERE, AND A DEFAULT IN THE PACK BUILD. --kick-us adds
+us_centric questions to the verdicts file; without it only `bad` is kicked. This
+tool exports RATINGS, so it stays inclusive by default: a US-inclusive pack has
+to remain buildable from exactly the same data, which is why enrich_pack.py
+stored the two as separate fields in the first place.
+
+The decision about what SHIPS lives in assemble_pack.py, which drops us_centric
+by default (rule 4) and takes --keep-us to put them back. The two defaults point
+opposite ways on purpose: nothing is removed from the data, and nothing
+US-centric reaches a player. See docs/trivia-curation.md.
 
     python3 tools_local/trivia/export_enriched.py --enriched .rate/enriched.jsonl \\
         --out-ratings .rate/local_difficulty.tsv \\
         --out-verdicts .rate/local_verdicts.tsv \\
         --out-options .rate/local_options.jsonl
 """
+
 import argparse, collections, json, statistics, sys
 
 
@@ -57,16 +64,26 @@ def main():
     ap.add_argument("--out-ratings", default="")
     ap.add_argument("--out-verdicts", default="")
     ap.add_argument("--out-options", default="")
-    ap.add_argument("--kick-us", action="store_true",
-                    help="also kick us_centric questions (default: only `bad`)")
-    ap.add_argument("--min-options", type=int, default=3,
-                    help="only export option sets with at least this many (default 3)")
+    ap.add_argument(
+        "--kick-us",
+        action="store_true",
+        help="also kick us_centric questions (default: only `bad`)",
+    )
+    ap.add_argument(
+        "--min-options",
+        type=int,
+        default=3,
+        help="only export option sets with at least this many (default 3)",
+    )
     a = ap.parse_args()
 
     recs, dupes = load(a.enriched)
     if not recs:
         sys.exit(f"{a.enriched}: no usable records")
-    print(f"{len(recs):,} questions read" + (f"  ({dupes} duplicate ids, last kept)" if dupes else ""))
+    print(
+        f"{len(recs):,} questions read"
+        + (f"  ({dupes} duplicate ids, last kept)" if dupes else "")
+    )
 
     if a.out_ratings:
         rated = {i: r["r"] for i, r in recs.items() if r.get("r") is not None}
@@ -77,8 +94,10 @@ def main():
             for i in sorted(rated):
                 f.write(f"{i}\t{float(rated[i]):.2f}\t1\n")
         v = sorted(rated.values())
-        print(f"  ratings  -> {a.out_ratings}  {len(rated):,} "
-              f"(mean {statistics.mean(v):.2f}, median {statistics.median(v):.2f})")
+        print(
+            f"  ratings  -> {a.out_ratings}  {len(rated):,} "
+            f"(mean {statistics.mean(v):.2f}, median {statistics.median(v):.2f})"
+        )
 
     if a.out_verdicts:
         bad = {i for i, r in recs.items() if r.get("bad")}
@@ -88,10 +107,15 @@ def main():
             f.write("# id\tverdict\n")
             for i in sorted(kick):
                 f.write(f"{i}\tbad\n")
-        print(f"  verdicts -> {a.out_verdicts}  {len(kick):,} kicked "
-              f"({len(bad):,} unanswerable"
-              + (f" + {len(us - bad):,} us_centric)" if a.kick_us
-                 else f"; {len(us):,} us_centric NOT kicked, pass --kick-us)"))
+        print(
+            f"  verdicts -> {a.out_verdicts}  {len(kick):,} kicked "
+            f"({len(bad):,} unanswerable"
+            + (
+                f" + {len(us - bad):,} us_centric)"
+                if a.kick_us
+                else f"; {len(us):,} us_centric NOT kicked, pass --kick-us)"
+            )
+        )
 
     if a.out_options:
         n = 0
@@ -99,12 +123,18 @@ def main():
             for i in sorted(recs):
                 w = recs[i].get("w") or []
                 if len(w) >= a.min_options:
-                    f.write(json.dumps({"id": i, "w": w[:3]}, ensure_ascii=False) + "\n")
+                    f.write(
+                        json.dumps({"id": i, "w": w[:3]}, ensure_ascii=False) + "\n"
+                    )
                     n += 1
-        print(f"  options  -> {a.out_options}  {n:,} sets of >={a.min_options} "
-              f"({100*n/len(recs):.1f}% of what was rated)")
+        print(
+            f"  options  -> {a.out_options}  {n:,} sets of >={a.min_options} "
+            f"({100 * n / len(recs):.1f}% of what was rated)"
+        )
 
-    topics = collections.Counter(r.get("topic") for r in recs.values() if r.get("topic"))
+    topics = collections.Counter(
+        r.get("topic") for r in recs.values() if r.get("topic")
+    )
     print("  topics   : " + ", ".join(f"{t} {c:,}" for t, c in topics.most_common(8)))
 
 

--- a/tools_local/trivia/test_assemble.py
+++ b/tools_local/trivia/test_assemble.py
@@ -14,6 +14,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import assemble_pack as A  # noqa: E402
+import calibrate_levels as CAL  # noqa: E402
 
 FAILED = []
 
@@ -241,6 +242,149 @@ def test_pack_shape():
     )
 
 
+# --- rule 4: US-centric is filtered at the build, never deleted ---------------
+def us_row(flag):
+    corpus = [
+        {
+            "id": "d" * 12,
+            "q": "This president appears on the United States one-dollar bill",
+            "a": "Washington",
+            "y": 1995,
+            "alt": [],
+            "w": [],
+        }
+    ]
+    enriched = {
+        "d" * 12: {"id": "d" * 12, "r": 2, "w": [], "bad": False, "us": flag},
+    }
+    return corpus, enriched
+
+
+def test_us_default():
+    corpus, enriched = us_row(True)
+    pack, stats = A.assemble(corpus, enriched)
+    check(
+        "a us_centric question does NOT ship by default",
+        len(pack) == 0,
+        f"{len(pack)} rows reached the pack",
+    )
+    check(
+        "and the drop is counted rather than silent",
+        any(k.startswith("rejected: us_centric") for k in stats),
+        str(dict(stats)),
+    )
+    # Checked on the KICKING path, which is the only path that reads the flag.
+    # Asserting this after a --keep-us run instead proves nothing: `kick_us and
+    # e.get("us")` short-circuits there, so a filter that consumed the flag
+    # would never run and the check would pass. Two paths, one of them live.
+    check(
+        "kicking reads the flag without consuming it",
+        enriched["d" * 12].get("us") is True,
+        "the default path mutated the ratings; --keep-us could not restore it",
+    )
+    # Not vacuous: the identical row without the flag must ship, or the check
+    # above would pass for any reason at all.
+    corpus, enriched = us_row(False)
+    check(
+        "the same question without the flag still ships",
+        len(A.assemble(corpus, enriched)[0]) == 1,
+    )
+    # Mario's decision was "not removed from our data". --keep-us must rebuild
+    # the inclusive pack from the very same inputs, with no re-rating.
+    corpus, enriched = us_row(True)
+    pack, _ = A.assemble(corpus, enriched, kick_us=False)
+    check("--keep-us brings it back from the same inputs", len(pack) == 1)
+    check(
+        "the rating record still carries its us flag afterwards",
+        enriched["d" * 12].get("us") is True,
+        "assemble() mutated the ratings; a future toggle would need re-rating",
+    )
+    check(
+        "the corpus row is untouched too",
+        corpus[0]["q"].startswith("This president"),
+    )
+    check("kicking is the default, not the flag", A.KICK_US_BY_DEFAULT is True)
+
+
+# --- the thresholds are re-derivable, not hand-tuned --------------------------
+def test_calibrator_models_the_shipped_mapping():
+    """calibrate_levels must score the function that actually ships.
+
+    If the two mappings drift apart the calibration is about a different tool,
+    and it would still print a confident recommendation.
+    """
+    floors = tuple(f for f, _ in A.LEVELS)
+    check(
+        "the calibrator's mapping agrees with assemble_pack.level for every r",
+        all(CAL.level_with(r, floors) == A.level(r) for r in range(11)),
+        str([(r, CAL.level_with(r, floors), A.level(r)) for r in range(11)]),
+    )
+    check(
+        "the shipped floors are strictly descending",
+        all(floors[i] > floors[i + 1] for i in range(len(floors) - 1)),
+        str(floors),
+    )
+    check(
+        "the shipped floors are a candidate the calibrator can reach",
+        len(floors) == 4 and all(1 <= f <= 11 for f in floors),
+        str(floors),
+    )
+
+
+def test_calibration_is_minimax():
+    """The chooser must optimise the WORST view, not the pooled one.
+
+    Thresholds get chosen on a partial run, so a set that is best on the rows
+    rated so far and falls apart on a shifted population is the failure mode
+    this rule exists to prevent. Scoring on the pooled distribution instead
+    passes every other check in this file.
+    """
+    w1 = [44, 52, 7, 12, 8, 56, 31, 18, 51, 58, 50]
+    w2 = [10, 43, 50, 46, 59, 14, 4, 53, 22, 39, 48]
+    rows = [r for r in range(11) for _ in range(w1[r])]
+    rows += [r for r in range(11) for _ in range(w2[r])]
+    samples = CAL.views(rows)
+    scored = CAL.choose(samples)
+    winner = scored[0][1]
+
+    pooled_best = min(
+        ((CAL.spread(rows, f)[1], f) for _, f, _ in scored), key=lambda t: (t[0], t[1])
+    )
+    worst_of_pooled = next(w for w, f, _ in scored if f == pooled_best[1])
+
+    # The fixture must actually separate the two rules, or the test is vacuous.
+    check(
+        "the case really separates pooled from minimax",
+        pooled_best[1] != winner
+        and pooled_best[0] < CAL.spread(rows, winner)[1]
+        and worst_of_pooled > CAL.SPREAD_LIMIT,
+        f"pooled-best {list(pooled_best[1])} @ {pooled_best[0]:.3f}, "
+        f"minimax {list(winner)}",
+    )
+    check(
+        "the pooled-best candidate is refused because a view fails",
+        winner != pooled_best[1],
+        f"picked {list(winner)}, the pooled favourite",
+    )
+    check(
+        "the chosen set passes the spread check on every view",
+        all(r <= CAL.SPREAD_LIMIT for r in scored[0][2].values()),
+        str({k: round(v, 3) for k, v in scored[0][2].items()}),
+    )
+    check(
+        "choose() is deterministic",
+        [f for _, f, _ in CAL.choose(samples)] == [f for _, f, _ in scored],
+    )
+    # An empty tier is not a difficulty level: a candidate that leaves one
+    # unpopulated must never be offered, however balanced the rest looks.
+    counts, ratio = CAL.spread([10] * 50, (9, 8, 7, 5))
+    check(
+        "a candidate with an empty level scores as unusable",
+        ratio == float("inf"),
+        f"{dict(counts)} scored {ratio}",
+    )
+
+
 def main():
     print("assemble_pack invariants\n")
     for t in (
@@ -250,6 +394,9 @@ def main():
         test_answer_never_longest,
         test_band_holds,
         test_pack_shape,
+        test_us_default,
+        test_calibrator_models_the_shipped_mapping,
+        test_calibration_is_minimax,
     ):
         t()
     print(f"\n{len(FAILED)} failed")


### PR DESCRIPTION
Mario's call: **US-centric trivia must not show up in the pack.** Not deleted from the data, and reversible when a toggle gets written.

## What changed

`assemble_pack.py` drops `us_centric` by default and takes `--keep-us` to put them back. The filter is at the pack build and **nowhere upstream of it**: `enrich_pack.py` still writes `us` as a field, all 5,905 flagged rows keep their ratings, and the inclusive pack rebuilds from identical inputs. When the toggle is written, nothing needs re-rating.

## The consequence, fixed rather than absorbed

Dropping them broke `test_pack.py`'s difficulty spread (20/21). The reason is real, not a bug: **for an international table the US-centric questions genuinely are the hard ones.** Mean `r` is 1.30 for them against 6.36 for the rest, and under the old floors 86% of them sat in level 5. Take them out and level 5 goes 5,926 -> 845 (a 4.2% tier).

So the old floors `(9,7,5,3)` were calibrated against a population that no longer ships. New floors `(9,8,7,5)` are the _same fixed-constant scheme_ measured on the international-only population, so a level now means "hard for an international table" -- which is what the ratings measure.

| level | r band        | before (US kept) | US kicked, old floors | after     |
| ----- | ------------- | ---------------- | --------------------- | --------- |
| 1     | 9-10          | 3,772            | 3,754                 | 3,754     |
| 2     | 8             | 6,883            | 6,871                 | 3,849     |
| 3     | 7             | 5,165            | 5,101                 | 3,022     |
| 4     | 5-6           | 4,222            | 3,492                 | 5,101     |
| 5     | 0-4           | 5,926            | **845**               | 4,337     |
|       | **test_pack** | 21/21            | **20/21 FAIL**        | **21/21** |

Still absolute, not quantiles: level 1 is "9 or 10 groups in 10 get it", level 5 is "at most 4 do". The spread check was not weakened or touched -- `test_pack.py` has no diff.

## Re-derivable, because these numbers are provisional

Chosen at 25,977 rated rows of a run that will finish near 50,000. `calibrate_levels.py` makes the choice reproducible in one command rather than leaving a hand-tuned constant nobody can re-derive:

```bash
python3 tools_local/trivia/calibrate_levels.py \
    --corpus .rate/corpus_repaired.jsonl --enriched .rate/enriched.jsonl
```

It prints how the shipped constants stand today and what it would choose instead. It **prints rather than edits**, deliberately: constants a build step rewrites are quantiles with extra steps.

It scores by the **worst** spread ratio across three views (all rows, the half rated first, the half rated last), not the pooled best, because `enriched.jsonl` mixes rows rated under different shot configurations and its halves genuinely disagree -- `r=5` was 20.1% of the first half and 7.7% of the second. `(9,8,7,5)` was the only candidate passing all three views (worst 1.98); the runner-up failed at 2.70.

It reads its population from `assemble_pack.survivors()`, split out of `assemble()` for the purpose, so a calibration cannot silently measure a different filter than the one that builds the pack.

## Verification

- `check.sh --tests --committed`: all green (84 suites).
- `test_pack.py` 21/21 on a pack actually built from the current snapshot (20,063 questions), and the `.dat` round-trips to the same distribution.
- `audit_options.py`: answer-is-longest 0.0%, twins 0.0%.
- Every new test was watched failing first. Five mutations: undoing the default, consuming the flag instead of reading it, scoring pooled instead of minimax, modelling a different `r->d` mapping, allowing an empty tier.

## What I could NOT verify

- **Nothing on hardware.** No device flashed, no panel looked at. Whether levels 1 and 5 now _feel_ different -- the complaint that started this work -- is a question only a person playing it can settle. The distribution is the evidence I have.
- **The thresholds are provisional.** Chosen on 41.7% of the worklist. The final population may move them; that is what the calibrator is for, and the docs say to re-run it at the end.
- **The `us` flag is the rater's judgment, not ground truth.** I spot-checked it, did not audit it. It looks semantic rather than keyword-driven -- questions that _mention_ the US but have an international answer ("this country ranked 2nd to the U.S.", answer Canada/Brazil/Japan) are correctly left unflagged. But in a sample of 10 unflagged questions carrying strong US markers, ~2 were arguably US-centric (Benedict Arnold, Thomas Wolfe). So a small residue almost certainly still ships. Tightening that is a rater-prompt question, not a pack-build one.
- **`export_enriched.py`'s diff is mostly the repo formatter**, which had not run on that file before. My actual edit there is the docstring, explaining why its `--kick-us` stays opt-in while the pack build's is now a default.

## Merged #19, and corrected two facts it carries

#19 (`app/triviadiff`) landed while this was open and touched the same doc region. The conflict was additive -- its blind-panel and state-file sections are kept in full. But two numbers it wrote down stop being true once US-centric questions stop shipping, so they are corrected rather than left to rot:

- **"the finished pack will miss by a handful, not by thousands."** That described a pack of ~49,98x against a 50,000-entry state file. With `us_centric` dropped the pack lands near **38,600**, so the stale-state gap is now over eleven thousand -- easier for the length check to catch, not harder, but the paragraph reasoned from a number that moved.
- **The panel table's "36/50 = 72%."** `panel_score.py` scores through `assemble_pack.level()`, so recalibrating `LEVELS` moved it to **35/50 = 70%**.

### The cost of the recalibration, measured

Attributed on one snapshot with **only** the thresholds changed, so it is the cut and not the data:

| floors | panel agreement | tied pairs |
| --- | --- | --- |
| old `(9,7,5,3)` | 36/50 | 5 |
| new `(9,8,7,5)` | 35/50 | **10** |
| raw `r`, no cut | 38/50 | 2 |

The single-pair drop is noise on n=50. **The doubled ties are not.** Level 5 must span `r` 0-4 to be populated at all once the US-centric questions are gone, and a band that wide stops separating pairs the old cut told apart at the hard end. No candidate that kept the hard end sharper also passed the spread check on every view, so this trade was **forced, not chosen**. It is recorded in the docs in both directions and flagged for revisiting against a fresh panel when the run finishes.

## One trap found in passing (not fixed here)

`check.sh --tests --committed` **silently runs a working-tree check.** `--committed` is only honoured as `$1`, and inside that branch only `${2:-}` is forwarded to the inner run. The wrong order prints the ordinary "verifying your working tree" banner and still ends in `all green`; the `verifying HEAD (<sha>)` line just never appears, and a missing line is not something a reader notices. The correct form is `--committed --tests`, which is what the green above came from. Left alone deliberately -- check.sh is shared infrastructure being run by many trees right now, and changing its argument parsing does not belong in a trivia PR. Filed as separate work.

## Note on the live rating run

Untouched throughout. `rate_status.py` said ADVANCING at 25,972 rows when I started and ADVANCING at 26,425 when I finished. I copied the snapshot into my own tree and read it there; nothing was written inside `wt/localrate/.rate/` and the local model was never called.
