### PR TITLE
site: do not deploy when the site did not change

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -7,6 +7,31 @@ One exception, and it is deliberate: `api/firmware.js`, a single Vercel
 function that exists so the Install button can work at all. See **The Install
 button** below before touching it.
 
+## When it deploys, and when it does not
+
+`vercel.json` carries `"ignoreCommand": "git diff --quiet HEAD^ HEAD ./"`.
+Vercel runs it from this directory: **exit 0 skips the build, non-zero builds**.
+`git diff --quiet` exits 0 when nothing here changed, so a commit that does not
+touch `site/` never deploys.
+
+This is not tidiness. On 2026-09-04 the account hit its deployment rate limit
+and every pull request in the fork went red on a Vercel check, including ones
+whose diff was a word list or a shell script. Of the 305 commits on `xteink`
+that day, **57 touched `site/`** -- so four deploys in five built nothing new
+and the fifth could not run.
+
+Two properties worth keeping if you edit it:
+
+- **It fails towards building.** If the command errors -- a shallow clone with
+  no `HEAD^`, a git that is not there -- it exits non-zero and the deploy
+  proceeds. Never skip when unsure.
+- **`./` means this directory, not the repository root**, because the Vercel
+  project root is `site/`. Changing the project root without changing this
+  path silently stops every deploy.
+
+The emulator rebuild CI commits after a firmware merge DOES touch `site/`, so
+it still deploys. That is correct: the page really did change.
+
 ## Before it deploys
 
 Two steps, both of which fail silently if skipped:

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
The Vercel account hit its **deployment rate limit** today. Every pull request in the fork went red on a Vercel check — including ones whose diff was a Forehead word list or a worktree script — and the failure link read `?upgradeToPro=build-rate-limit`, which looks like a code failure and is not.

## The measurement

Of the **305 commits** on `xteink` today, **57 touched `site/`**.

Four deploys in five built nothing new, and the fifth could not run because the first four had spent the quota.

## The fix

`vercel.json` now carries Vercel's ignore-build hook:

```json
"ignoreCommand": "git diff --quiet HEAD^ HEAD ./"
```

Vercel runs it from the project root, which is `site/`. **Exit 0 skips the build, non-zero builds.** `git diff --quiet` exits 0 when nothing here changed, so a commit that does not touch the site never deploys.

Verified against the last eight commits on `xteink`:

```
3afe7487  Merge #67 gatearg                      SKIP
dea169f1  chore: emulator rebuilt for ba66d354   BUILD
ba66d354  Merge #19 triviadiff                   SKIP
c885f8ed  fix(check): --committed any position   SKIP
a5d0b37a  chore: crossplay 1.12.19               SKIP
936fd124  trivia: pack size in comments          SKIP
6232b658  trivia: app docs                       SKIP
bc4e2aeb  trivia: read a pack.dat back           SKIP
```

Seven skip; the one that builds is the emulator rebuild, which genuinely changed the page.

## Two properties worth keeping

- **It fails towards building.** If the command errors — a shallow clone with no `HEAD^`, a git that is not there — it exits non-zero and the deploy proceeds. Never skip when unsure.
- **`./` means `site/`, not the repository root**, because that is the Vercel project root. Moving the project root without changing this path would silently stop every deploy. Documented in `site/README.md`, since JSON cannot hold comments.

**This is the free fix.** Upgrading the plan is the other one and was not needed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)