### PR TITLE
fix: count a link match, and show the board that ended it (#35, #36)

### DIFF
--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -564,6 +564,7 @@ class MyActivity final : public linkplay::LinkActivity {
   void onRematch() override;                      // both said yes
   void onLinkEnded() override;                    // back to solo
   bool matchGameOver() const override;
+  void onMatchEnded() override;                   // count it, and show it
   void gameLoop() override;                       // what loop() used to be
   void gameRender() override;                     // what render() used to be
 
@@ -573,6 +574,20 @@ class MyActivity final : public linkplay::LinkActivity {
 
 `enterLink(GameId::MyGame)` when the player taps PLAY NEARBY, and that is the
 whole integration.
+
+#### `onMatchEnded()` is where a link game is recorded
+
+Record the result there and go to whatever screen shows the finished game. Do
+**not** record it in `gameLoop()`: the moment the match ends, the link layer
+stops giving your game the pass, so anything at the end of `gameLoop()` is
+unreachable in multiplayer. Five games were written that way and none of them
+ever counted a single link match -- no crash, no log, just a tally that stayed
+at zero -- which is why the hook is pure virtual rather than defaulted.
+
+The layer then keeps your final screen on the panel for a couple of seconds
+before it offers another game, so the player who just lost sees the move that
+beat them. You get that for free; you only have to put something worth looking
+at on the screen. See `src/apps_local/link/LinkEndgame.h`.
 
 The row is called **PLAY NEARBY** in every game, and it carries the mark below.
 Do not invent another wording: "click where it says multiplayer" only works if

--- a/host-tests/link/run.sh
+++ b/host-tests/link/run.sh
@@ -61,3 +61,10 @@ SRC=../../src/apps_local/link
   ../../src/apps_local/toybattle/ToyBattleCore.cpp ../../src/apps_local/toybattle/ToyBattleBrain.cpp \
   test_toybattlelink.cpp -o "$BUILD_DIR/test_toybattlelink"
 "$BUILD_DIR/test_toybattlelink"
+
+# The end of a match: the record that was never written and the final board the
+# loser was never shown. Real link, real Connect Four rules, real Endgame; see
+# test_endgame.cpp for what it does and does not cover.
+"${CXX:-c++}" -std=c++17 -Wall -Wextra -Werror -O2 $SRC/LinkProtocol.cpp $SRC/LinkSession.cpp \
+  $SRC/LinkRadio.cpp $SRC/LinkPlay.cpp test_endgame.cpp -o "$BUILD_DIR/test_endgame"
+"$BUILD_DIR/test_endgame"

--- a/host-tests/link/test_endgame.cpp
+++ b/host-tests/link/test_endgame.cpp
@@ -164,6 +164,8 @@ struct Seat {
   }
 
   void render(const uint32_t nowMs) {
+    // Read before the frame is built, exactly as LinkActivity::render() does.
+    const Endgame::Stage stageAtBuild = endgame.stage();
     if (linkOwnsScreen()) {
       if (c4::over(game)) {
         framesOfOfferScreen++;
@@ -176,7 +178,7 @@ struct Seat {
       framesOfFinalBoard++;
       if (firstFinalPaintMs == 0) firstFinalPaintMs = nowMs;
     }
-    endgame.notePainted(nowMs);
+    endgame.notePainted(stageAtBuild, nowMs);
   }
 };
 
@@ -322,7 +324,7 @@ void aSoloGameIsNeverCountedByTheLayer() {
   CHECK(c4::over(a.game));
   for (uint32_t now = 0; now < 20000; now += 10) {
     a.endgame.update(a, a.inMatch(), now);
-    a.endgame.notePainted(now);
+    a.endgame.notePainted(a.endgame.stage(), now);
   }
   CHECK(a.recordCalls == 0);
   CHECK(!a.endgame.showingFinal());
@@ -347,7 +349,7 @@ void aPaintFromBeforeTheEndDoesNotCountAsTheFinalBoard() {
   // 1000ms of a live game, painting all the way.
   for (uint32_t now = 0; now < 1000; now += 10) {
     endgame.update(host, true, now);
-    endgame.notePainted(now);
+    endgame.notePainted(endgame.stage(), now);
   }
   CHECK(host.ended == 0);
   // It ends at 1000, and nothing is painted after that.
@@ -362,6 +364,39 @@ void aPaintFromBeforeTheEndDoesNotCountAsTheFinalBoard() {
   endgame.update(host, true, 1000 + Endgame::kUnpaintedHoldMs);
   CHECK(endgame.offering());
   (void)a;
+}
+
+// A repaint of the old board can already be in flight when the match ends.
+// Reporting it as the final board would start the hold from a frame that never
+// showed the winning move -- the original bug, wearing a timer.
+void aRepaintInFlightWhenTheMatchEndsIsNotTheFinalBoard() {
+  struct Host {
+    bool over = false;
+    int ended = 0;
+    bool matchGameOver() const { return over; }
+    void onMatchEnded() { ended++; }
+    void onEndgameChanged() {}
+  } host;
+  Endgame endgame;
+  // A frame starts being drawn at 900, while the game is still running.
+  const Endgame::Stage stageAtBuild = endgame.stage();
+  CHECK(stageAtBuild == Endgame::Stage::Live);
+  // The match ends at 1000, before that frame reaches the panel.
+  host.over = true;
+  endgame.update(host, true, 1000);
+  CHECK(endgame.showingFinal());
+  // Now it lands. It is not the final board, so it starts nothing.
+  endgame.notePainted(stageAtBuild, 1100);
+  endgame.update(host, true, 1110);
+  endgame.update(host, true, 1100 + Endgame::kHoldMs);
+  CHECK(endgame.showingFinal());
+  // The real final board lands at 2000 and gets its full hold from there.
+  endgame.notePainted(Endgame::Stage::Final, 2000);
+  endgame.update(host, true, 2010);
+  endgame.update(host, true, 2000 + Endgame::kHoldMs - 10);
+  CHECK(endgame.showingFinal());
+  endgame.update(host, true, 2000 + Endgame::kHoldMs);
+  CHECK(endgame.offering());
 }
 
 // A rematch is a different end of a game, so the next one is counted too.
@@ -379,7 +414,7 @@ void aRematchIsCountedAgain() {
   host.over = true;
   endgame.update(host, true, 100);
   CHECK(host.ended == 1);
-  endgame.notePainted(200);
+  endgame.notePainted(Endgame::Stage::Final, 200);
   endgame.update(host, true, 210);
   endgame.update(host, true, 200 + Endgame::kHoldMs);
   CHECK(endgame.offering());
@@ -419,7 +454,7 @@ void theHoldSurvivesAMillisRollover() {
   const uint32_t justBeforeWrap = 0xFFFFFFFFu - 1000;
   endgame.update(host, true, justBeforeWrap);
   CHECK(host.ended == 1);
-  endgame.notePainted(justBeforeWrap);
+  endgame.notePainted(Endgame::Stage::Final, justBeforeWrap);
   endgame.update(host, true, justBeforeWrap + 10);
   CHECK(endgame.showingFinal());
   // Past the wrap but inside the hold.
@@ -459,6 +494,7 @@ int main() {
   askingForAnotherGameSkipsTheHold();
   aSoloGameIsNeverCountedByTheLayer();
   aPaintFromBeforeTheEndDoesNotCountAsTheFinalBoard();
+  aRepaintInFlightWhenTheMatchEndsIsNotTheFinalBoard();
   aRematchIsCountedAgain();
   theHoldSurvivesAMillisRollover();
   leavingDuringTheHoldResets();

--- a/host-tests/link/test_endgame.cpp
+++ b/host-tests/link/test_endgame.cpp
@@ -1,0 +1,468 @@
+// The end of a match, played out between two devices over the hostile link.
+//
+// Two bugs lived at the same instant and this file is about both of them.
+//
+//   The loser saw zero frames of the final board. The winning state was applied
+//   and the rematch screen went up in the same pass, and the repaint that would
+//   have shown the board never happened, so the move that ended the game was
+//   never on the panel.
+//
+//   And no link match was ever counted. Five games recorded their result in a
+//   part of gameLoop() that multiplayer returns before reaching, so the tally
+//   simply stayed at zero. Nothing crashed and nothing logged.
+//
+// Both are Endgame's now (src/apps_local/link/LinkEndgame.h), which is why they
+// can be tested here at all: the state machine is freestanding, the link
+// underneath it is the real one, and the game on top is the real Connect Four
+// rules. What the seats below reproduce from LinkActivity is only its ORDERING
+// -- take delivery, drive the endgame, then either the link screen or the game
+// -- because everything with a decision in it was deliberately put inside
+// Endgame::update() rather than left in the caller for a test to re-derive.
+//
+// The assertions that matter are the two the bugs were:
+//
+//   recordCalls == 1 and the tally is no longer zero, on BOTH devices, after a
+//   finished MATCH -- the record exists, rather than a code path having run.
+//
+//   the LOSER painted the final board, and it stayed on the panel for at least
+//   the hold before anything replaced it.
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "../../src/apps_local/connectfour/ConnectFourCore.h"
+#include "../../src/apps_local/link/LinkEndgame.h"
+#include "../../src/apps_local/link/LinkPlay.h"
+#include "FakeLink.h"
+
+namespace {
+
+int checksRun = 0;
+int checksFailed = 0;
+
+void check(const bool condition, const char* what, const int line) {
+  checksRun++;
+  if (condition) return;
+  checksFailed++;
+  std::printf("FAIL test_endgame.cpp:%d  %s\n", line, what);
+}
+
+#define CHECK(expr) check((expr), #expr, __LINE__)
+
+using namespace linkplay;
+using namespace linktest;
+namespace c4 = connectfour;
+using Phase = PlayBase::Phase;
+
+// One device: the real link, the real rules, the real Endgame, and the parts of
+// LinkActivity a game cannot be tested without.
+struct Seat {
+  Seat(Medium& medium, const uint8_t last) : transport(medium, addressOf(last)), play(&transport) {}
+
+  FakeTransport transport;
+  Play<c4::Game> play;
+  c4::Game game{};
+  Endgame endgame;
+  uint8_t seat = c4::kLight;
+  bool requested = false;
+  bool rematch = false;
+  // Set by the test to make a player tap ANOTHER GAME while the board is still
+  // up, which is the one thing allowed to cut the hold short.
+  bool tapsPlayAgain = false;
+
+  // --- the record, which is the whole of card #35 -------------------------
+  // ConnectFourActivity keeps exactly these and writes them to the SD card.
+  // After a finished MATCH they must not all still be zero.
+  int wins = 0;
+  int losses = 0;
+  int draws = 0;
+  bool hasHistory = false;
+  int recordCalls = 0;
+
+  // --- what was actually on the panel, which is the whole of card #36 -----
+  enum class Screen { Board, Result };
+  Screen screen = Screen::Board;
+  int framesOfFinalBoard = 0;
+  // Only the link screen that REPLACES a finished game. The searching screen is
+  // the link screen too, and counting it made the first version of this test
+  // compare the end of the match against a frame from before it started.
+  int framesOfOfferScreen = 0;
+  uint32_t firstFinalPaintMs = 0;
+  uint32_t offerScreenAtMs = 0;
+
+  bool start() { return play.start(GameId::ConnectFour, "TEST"); }
+
+  Phase phase() const { return play.phase(); }
+  bool inMatch() const { return requested && phase() != Phase::Off && phase() != Phase::Searching; }
+  bool linkYourTurn() const { return phase() == Phase::YourTurn; }
+
+  // --- what Endgame asks of its host --------------------------------------
+
+  bool matchGameOver() const { return c4::over(game); }
+
+  void onMatchEnded() {
+    recordCalls++;
+    // ConnectFourActivity::recordResult() in miniature: which way the outcome
+    // fell, read from this device's own seat.
+    const bool won = (seat == c4::kLight && game.outcome == c4::Outcome::LightWins) ||
+                     (seat == c4::kDark && game.outcome == c4::Outcome::DarkWins);
+    if (game.outcome == c4::Outcome::Draw)
+      draws++;
+    else if (won)
+      wins++;
+    else
+      losses++;
+    hasHistory = true;
+    // And the screen the solo game ends on, which in a match was unreachable.
+    screen = Screen::Result;
+  }
+
+  void onEndgameChanged() {}
+
+  // --- LinkActivity's ordering ---------------------------------------------
+
+  bool linkOwnsScreen() const {
+    if (!requested) return false;
+    if (endgame.showingFinal()) return false;
+    return phase() == Phase::Searching || phase() == Phase::Over || rematch;
+  }
+
+  void onMatchStart(const bool goesFirst) {
+    seat = goesFirst ? c4::kLight : c4::kDark;
+    c4::start(game);
+    screen = Screen::Board;
+  }
+
+  void pump(const uint32_t nowMs) {
+    play.update(nowMs);
+    if (play.takeMatchStart()) onMatchStart(play.goesFirst());
+    play.takeOpponent(game);
+
+    endgame.update(*this, inMatch(), nowMs);
+    if (endgame.offering() && !rematch) rematch = true;
+
+    if (linkOwnsScreen()) return;  // driveLink() returns false; gameLoop() is skipped
+    gameLoop();
+  }
+
+  void gameLoop() {
+    if (tapsPlayAgain && endgame.showingFinal()) {
+      // proposeRematch(): the player has seen enough.
+      endgame.skip();
+      rematch = true;
+      return;
+    }
+    if (!inMatch() || !linkYourTurn() || c4::over(game)) return;
+    // Light stacks column 0 and dark stacks column 1, so light wins on its
+    // fourth drop -- the seventh move of the game. Deterministic on purpose:
+    // the move that ends it is the last one either device sends, which is
+    // exactly the frame the loser was never shown.
+    const int column = seat == c4::kLight ? 0 : 1;
+    if (!c4::drop(game, column)) return;
+    play.play(game);
+  }
+
+  void render(const uint32_t nowMs) {
+    if (linkOwnsScreen()) {
+      if (c4::over(game)) {
+        framesOfOfferScreen++;
+        if (offerScreenAtMs == 0) offerScreenAtMs = nowMs;
+      }
+      return;
+    }
+    // gameRender(): whatever screen the game is on reaches the panel here.
+    if (screen == Screen::Result && c4::over(game)) {
+      framesOfFinalBoard++;
+      if (firstFinalPaintMs == 0) firstFinalPaintMs = nowMs;
+    }
+    endgame.notePainted(nowMs);
+  }
+};
+
+// `paintEveryMs` is the panel. Zero means it never paints at all, which is the
+// case the ceiling exists for.
+void run(Medium& medium, std::vector<Seat*>& seats, const uint32_t durationMs, const uint32_t paintEveryMs) {
+  const uint32_t until = medium.nowMs + durationMs;
+  while (medium.nowMs < until) {
+    for (Seat* seat : seats) seat->pump(medium.nowMs);
+    if (paintEveryMs != 0 && medium.nowMs % paintEveryMs == 0) {
+      for (Seat* seat : seats) seat->render(medium.nowMs);
+    }
+    medium.collect();
+    medium.nowMs += 10;
+  }
+}
+
+Seat* winnerOf(Seat& a, Seat& b) { return a.seat == c4::kLight ? &a : &b; }
+Seat* loserOf(Seat& a, Seat& b) { return a.seat == c4::kLight ? &b : &a; }
+
+// ---------------------------------------------------------------------------
+
+// The whole of both cards, on a panel that repaints every 200ms.
+void aFinishedMatchIsCountedAndSeen() {
+  Medium medium;
+  medium.lossPercent = 10;
+  medium.duplicatePercent = 10;
+  medium.maxJitterMs = 30;
+  Seat a(medium, 0x11);
+  Seat b(medium, 0x22);
+  CHECK(a.start());
+  CHECK(b.start());
+  a.requested = true;
+  b.requested = true;
+  std::vector<Seat*> seats{&a, &b};
+  run(medium, seats, 20000, 200);
+
+  // The game actually finished, or nothing below means anything.
+  CHECK(c4::over(a.game));
+  CHECK(c4::over(b.game));
+  CHECK(a.game.outcome == b.game.outcome);
+  CHECK(a.game.outcome == c4::Outcome::LightWins);
+
+  // Card #35. The record EXISTS, on both devices, exactly once.
+  CHECK(a.recordCalls == 1);
+  CHECK(b.recordCalls == 1);
+  CHECK(a.hasHistory);
+  CHECK(b.hasHistory);
+  CHECK(a.wins + a.losses + a.draws == 1);
+  CHECK(b.wins + b.losses + b.draws == 1);
+  Seat* winner = winnerOf(a, b);
+  Seat* loser = loserOf(a, b);
+  CHECK(winner->wins == 1);
+  CHECK(winner->losses == 0);
+  CHECK(loser->losses == 1);
+  CHECK(loser->wins == 0);
+
+  // Card #36. The loser saw the board that beat them, and it stayed up.
+  CHECK(loser->framesOfFinalBoard > 0);
+  CHECK(winner->framesOfFinalBoard > 0);
+  CHECK(loser->firstFinalPaintMs != 0);
+  CHECK(loser->offerScreenAtMs > loser->firstFinalPaintMs);
+  CHECK(loser->offerScreenAtMs - loser->firstFinalPaintMs >= Endgame::kHoldMs);
+  CHECK(winner->offerScreenAtMs - winner->firstFinalPaintMs >= Endgame::kHoldMs);
+
+  // And the offer does arrive: a hold that never ends is the worse bug.
+  CHECK(loser->framesOfOfferScreen > 0);
+  CHECK(winner->framesOfOfferScreen > 0);
+  CHECK(loser->rematch);
+  CHECK(winner->rematch);
+}
+
+// The hold is counted from the paint, not from the move. A panel this slow
+// would have spent the entire hold repainting under a timer started earlier.
+void theHoldIsCountedFromThePaint() {
+  Medium medium;
+  Seat a(medium, 0x31);
+  Seat b(medium, 0x32);
+  CHECK(a.start());
+  CHECK(b.start());
+  a.requested = true;
+  b.requested = true;
+  std::vector<Seat*> seats{&a, &b};
+  run(medium, seats, 20000, 1500);
+
+  Seat* loser = loserOf(a, b);
+  CHECK(loser->framesOfFinalBoard > 0);
+  CHECK(loser->offerScreenAtMs - loser->firstFinalPaintMs >= Endgame::kHoldMs);
+}
+
+// A panel that never reports a paint must still reach the offer, or the player
+// is stuck on a finished board with no way to ask for another game.
+void anUnpaintedHoldStillEnds() {
+  Medium medium;
+  Seat a(medium, 0x41);
+  Seat b(medium, 0x42);
+  CHECK(a.start());
+  CHECK(b.start());
+  a.requested = true;
+  b.requested = true;
+  std::vector<Seat*> seats{&a, &b};
+  run(medium, seats, 20000, 0);
+
+  CHECK(a.recordCalls == 1);
+  CHECK(b.recordCalls == 1);
+  CHECK(a.endgame.offering());
+  CHECK(b.endgame.offering());
+  CHECK(a.rematch);
+  CHECK(b.rematch);
+}
+
+// Tapping ANOTHER GAME while the board is up ends the hold rather than being
+// swallowed by it.
+void askingForAnotherGameSkipsTheHold() {
+  Medium medium;
+  Seat a(medium, 0x51);
+  Seat b(medium, 0x52);
+  CHECK(a.start());
+  CHECK(b.start());
+  a.requested = true;
+  b.requested = true;
+  a.tapsPlayAgain = true;
+  std::vector<Seat*> seats{&a, &b};
+  run(medium, seats, 20000, 100);
+
+  // Still counted -- skipping the look does not skip the record.
+  CHECK(a.recordCalls == 1);
+  CHECK(a.rematch);
+  CHECK(!a.endgame.showingFinal());
+  // The other device did not tap anything, so it got its full look.
+  CHECK(b.offerScreenAtMs - b.firstFinalPaintMs >= Endgame::kHoldMs);
+}
+
+// A finished SOLO game is not the link layer's business, and must not be
+// counted twice: the game records that one itself.
+void aSoloGameIsNeverCountedByTheLayer() {
+  Medium medium;
+  Seat a(medium, 0x61);
+  a.seat = c4::kLight;
+  c4::start(a.game);
+  // Play it out with no link at all.
+  for (int i = 0; i < 7 && !c4::over(a.game); ++i) c4::drop(a.game, i % 2);
+  CHECK(c4::over(a.game));
+  for (uint32_t now = 0; now < 20000; now += 10) {
+    a.endgame.update(a, a.inMatch(), now);
+    a.endgame.notePainted(now);
+  }
+  CHECK(a.recordCalls == 0);
+  CHECK(!a.endgame.showingFinal());
+  CHECK(!a.endgame.offering());
+}
+
+// A frame that reached the panel while the game was still running is not the
+// final board. Left pending it would be picked up by the transition and cut the
+// hold to nothing, which is the original bug wearing a timer.
+void aPaintFromBeforeTheEndDoesNotCountAsTheFinalBoard() {
+  Medium medium;
+  Seat a(medium, 0x71);
+  // Straight to the state machine: no link, no rules, just the ordering.
+  struct Host {
+    bool over = false;
+    int ended = 0;
+    bool matchGameOver() const { return over; }
+    void onMatchEnded() { ended++; }
+    void onEndgameChanged() {}
+  } host;
+  Endgame endgame;
+  // 1000ms of a live game, painting all the way.
+  for (uint32_t now = 0; now < 1000; now += 10) {
+    endgame.update(host, true, now);
+    endgame.notePainted(now);
+  }
+  CHECK(host.ended == 0);
+  // It ends at 1000, and nothing is painted after that.
+  host.over = true;
+  endgame.update(host, true, 1000);
+  CHECK(host.ended == 1);
+  CHECK(endgame.showingFinal());
+  // The stale 990ms paint must not have started a hold that is already over.
+  endgame.update(host, true, 1010 + Endgame::kHoldMs);
+  CHECK(endgame.showingFinal());
+  // Only the ceiling releases it.
+  endgame.update(host, true, 1000 + Endgame::kUnpaintedHoldMs);
+  CHECK(endgame.offering());
+  (void)a;
+}
+
+// A rematch is a different end of a game, so the next one is counted too.
+void aRematchIsCountedAgain() {
+  Medium medium;
+  Seat a(medium, 0x81);
+  struct Host {
+    bool over = false;
+    int ended = 0;
+    bool matchGameOver() const { return over; }
+    void onMatchEnded() { ended++; }
+    void onEndgameChanged() {}
+  } host;
+  Endgame endgame;
+  host.over = true;
+  endgame.update(host, true, 100);
+  CHECK(host.ended == 1);
+  endgame.notePainted(200);
+  endgame.update(host, true, 210);
+  endgame.update(host, true, 200 + Endgame::kHoldMs);
+  CHECK(endgame.offering());
+
+  // Both said yes: LinkActivity::startRematch() resets, and the game restarts.
+  endgame.reset();
+  host.over = false;
+  endgame.update(host, true, 5000);
+  CHECK(!endgame.showingFinal());
+  CHECK(host.ended == 1);
+
+  host.over = true;
+  endgame.update(host, true, 6000);
+  CHECK(host.ended == 2);
+  CHECK(endgame.showingFinal());
+
+  // And a rematch that reset nothing is still a new game.
+  host.over = false;
+  endgame.update(host, true, 6010);
+  CHECK(!endgame.showingFinal());
+  host.over = true;
+  endgame.update(host, true, 6020);
+  CHECK(host.ended == 3);
+  (void)a;
+}
+
+// millis() rolls over about every 49 days and a match can straddle it.
+void theHoldSurvivesAMillisRollover() {
+  struct Host {
+    bool over = true;
+    int ended = 0;
+    bool matchGameOver() const { return over; }
+    void onMatchEnded() { ended++; }
+    void onEndgameChanged() {}
+  } host;
+  Endgame endgame;
+  const uint32_t justBeforeWrap = 0xFFFFFFFFu - 1000;
+  endgame.update(host, true, justBeforeWrap);
+  CHECK(host.ended == 1);
+  endgame.notePainted(justBeforeWrap);
+  endgame.update(host, true, justBeforeWrap + 10);
+  CHECK(endgame.showingFinal());
+  // Past the wrap but inside the hold.
+  endgame.update(host, true, static_cast<uint32_t>(justBeforeWrap + 1500));
+  CHECK(endgame.showingFinal());
+  endgame.update(host, true, static_cast<uint32_t>(justBeforeWrap + Endgame::kHoldMs));
+  CHECK(endgame.offering());
+}
+
+// Leaving mid-hold puts the machine back where a fresh match expects it.
+void leavingDuringTheHoldResets() {
+  struct Host {
+    bool over = true;
+    int ended = 0;
+    bool matchGameOver() const { return over; }
+    void onMatchEnded() { ended++; }
+    void onEndgameChanged() {}
+  } host;
+  Endgame endgame;
+  endgame.update(host, true, 100);
+  CHECK(endgame.showingFinal());
+  // requested_ goes false, so inMatch() does.
+  endgame.update(host, false, 110);
+  CHECK(!endgame.showingFinal());
+  CHECK(!endgame.offering());
+  // And the next match counts its own end.
+  endgame.update(host, true, 120);
+  CHECK(host.ended == 2);
+}
+
+}  // namespace
+
+int main() {
+  aFinishedMatchIsCountedAndSeen();
+  theHoldIsCountedFromThePaint();
+  anUnpaintedHoldStillEnds();
+  askingForAnotherGameSkipsTheHold();
+  aSoloGameIsNeverCountedByTheLayer();
+  aPaintFromBeforeTheEndDoesNotCountAsTheFinalBoard();
+  aRematchIsCountedAgain();
+  theHoldSurvivesAMillisRollover();
+  leavingDuringTheHoldResets();
+
+  std::printf("test_endgame: %d checks, %d failed\n", checksRun, checksFailed);
+  return checksFailed == 0 ? 0 : 1;
+}

--- a/src/apps_local/battleship/BattleshipActivity.h
+++ b/src/apps_local/battleship/BattleshipActivity.h
@@ -41,6 +41,12 @@ class BattleshipActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override { return gameOver(); }
+  // Battleship is the one game that already counted its matches: finishGame()
+  // runs from fireAtAimed() when your shot sinks the last ship and from
+  // takeOpponentState() when theirs does, and both of those run inside a match.
+  // Calling it again here would double-count, because it has no once-only
+  // guard. So this is deliberately empty. See link/LinkEndgame.h.
+  void onMatchEnded() override {}
   void onLinkPhaseChanged() override { sendFleetIfReady(); }
   void drawLinkArt(const Rect& slot) override { drawMiniGrid(slot); }
   void gameLoop() override;

--- a/src/apps_local/checkers/CheckersActivity.cpp
+++ b/src/apps_local/checkers/CheckersActivity.cpp
@@ -357,6 +357,14 @@ void CheckersActivity::gameLoop() {
       return;
 
     case checkui::ActionDone:
+      // DONE on a finished MATCH means done with the match, not just with the
+      // screen: the radio is still up and the link screen would slam over the
+      // menu the moment the hold ended. leaveLink() is what puts the app back
+      // on its own menu, and it tells the other device on the way out.
+      if (inMatch()) {
+        leaveLink();
+        return;
+      }
       goTo(ck::Screen::Menu);
       return;
 

--- a/src/apps_local/checkers/CheckersActivity.cpp
+++ b/src/apps_local/checkers/CheckersActivity.cpp
@@ -209,6 +209,14 @@ uint32_t CheckersActivity::surfaceMeaning() const {
   return paintclock::mixMeaning(withSeat, live ? 1u : 0u);
 }
 
+void CheckersActivity::onMatchEnded() {
+  recordResult();
+  // The same screen the solo game ends on. In a match it used to be
+  // unreachable, so the finished board went straight to ANOTHER GAME? and the
+  // loser saw nothing at all of the move that beat them.
+  goTo(ck::Screen::Result);
+}
+
 void CheckersActivity::gameLoop() {
   namespace fui = freeink::ui;
 

--- a/src/apps_local/checkers/CheckersActivity.h
+++ b/src/apps_local/checkers/CheckersActivity.h
@@ -32,6 +32,11 @@ class CheckersActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override { return checkers::over(game); }
+  // Counted here and nowhere else in a match. It used to be counted in an
+  // else-if arm of gameLoop() that multiplayer returns before reaching, so no
+  // link game was ever recorded and no final board was ever shown. See
+  // link/LinkEndgame.h.
+  void onMatchEnded() override;
   void gameLoop() override;
   void gameRender() override;
 

--- a/src/apps_local/chess/ChessActivity.h
+++ b/src/apps_local/chess/ChessActivity.h
@@ -43,6 +43,11 @@ class ChessActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override { return gameOver; }
+  // Chess keeps no W/L tally to write, so the only half of this that applies is
+  // the screen -- and the board it is already on IS the final position, with
+  // the mating move on it. Verified 2026-09-04: ChessActivity has kSettingsPath
+  // and kSavePath and no played/won counter anywhere. See link/LinkEndgame.h.
+  void onMatchEnded() override {}
   void onLinkPhaseChanged() override { refreshTurnLabel(); }
   void drawLinkArt(const Rect& slot) override { drawMiniBoard(slot); }
   void gameLoop() override;

--- a/src/apps_local/connectfour/ConnectFourActivity.cpp
+++ b/src/apps_local/connectfour/ConnectFourActivity.cpp
@@ -195,6 +195,14 @@ void ConnectFourActivity::onLinkEnded() {
   goTo(c4::Screen::Menu);
 }
 
+void ConnectFourActivity::onMatchEnded() {
+  recordResult();
+  // The same screen the solo game ends on. In a match it used to be
+  // unreachable, so the finished board went straight to ANOTHER GAME? and the
+  // loser saw nothing at all of the move that beat them.
+  goTo(c4::Screen::Result);
+}
+
 void ConnectFourActivity::gameLoop() {
   namespace fui = freeink::ui;
 

--- a/src/apps_local/connectfour/ConnectFourActivity.cpp
+++ b/src/apps_local/connectfour/ConnectFourActivity.cpp
@@ -315,6 +315,14 @@ void ConnectFourActivity::gameLoop() {
       return;
 
     case c4ui::ActionDone:
+      // DONE on a finished MATCH means done with the match, not just with the
+      // screen: the radio is still up and the link screen would slam over the
+      // menu the moment the hold ended. leaveLink() is what puts the app back
+      // on its own menu, and it tells the other device on the way out.
+      if (inMatch()) {
+        leaveLink();
+        return;
+      }
       goTo(c4::Screen::Menu);
       return;
 

--- a/src/apps_local/connectfour/ConnectFourActivity.h
+++ b/src/apps_local/connectfour/ConnectFourActivity.h
@@ -32,6 +32,11 @@ class ConnectFourActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override { return connectfour::over(game); }
+  // Counted here and nowhere else in a match. It used to be counted in an
+  // else-if arm of gameLoop() that multiplayer returns before reaching, so no
+  // link game was ever recorded and no final board was ever shown. See
+  // link/LinkEndgame.h.
+  void onMatchEnded() override;
   void gameLoop() override;
   void gameRender() override;
 

--- a/src/apps_local/jaipur/JaipurActivity.cpp
+++ b/src/apps_local/jaipur/JaipurActivity.cpp
@@ -247,10 +247,11 @@ const char* JaipurActivity::linkHeadline() const {
 
 void JaipurActivity::onMatchStart(const bool goesFirst) {
   seat = goesFirst ? 0 : 1;
-  if (goesFirst) {
-    game.newGame(nextSeed(), 0);
-    link.play(game);
-  }
+  // Both sides clear the table; only the dealer's deal travels. The follower
+  // used to keep the previous game, so a match begun after a finished one
+  // opened on the old scoreline until the first packet landed.
+  game.newGame(nextSeed(), 0);
+  if (goesFirst) link.play(game);
   clearSelection();
   view = View::Board;
   requestUpdate();
@@ -1417,9 +1418,17 @@ void JaipurActivity::routeRoundOver() {
     if (inMatch()) link.play(game);
     if (opponentIsBrain() && game.currentPhase() == jaipur::Phase::Playing && !myTurn()) opponentPending = true;
     requestUpdate();
-  } else if (action == jaipurui::ActionPlayAgain && !inMatch()) {
-    // Never in a match: a rematch is asked and answered through the link's own
-    // screen, which is what both devices are looking at by then.
+  } else if (action == jaipurui::ActionPlayAgain) {
+    // It used to be true that both devices were already looking at the link
+    // screen by the time this could be tapped, so the match case was excluded
+    // and the button was never drawn. The finished board now stays up for a
+    // couple of seconds first, and the button is drawn live on it -- a tap that
+    // did nothing would read exactly like a crash. Asking is the same question
+    // the link screen is about to ask, only sooner.
+    if (inMatch()) {
+      proposeRematch();
+      return;
+    }
     startNewGame();
   }
 }

--- a/src/apps_local/jaipur/JaipurActivity.h
+++ b/src/apps_local/jaipur/JaipurActivity.h
@@ -49,6 +49,11 @@ class JaipurActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override { return game.currentPhase() == jaipur::Phase::GameOver; }
+  // Nothing to record: Jaipur keeps no played/won counter (its menu draws one,
+  // and it has never been anything but zero -- filed separately). The screen
+  // half applies though: viewForPhase() puts View::RoundOver up at GameOver,
+  // and until now nobody ever saw it in a match. See link/LinkEndgame.h.
+  void onMatchEnded() override {}
   // The link screen's ornament, and after a match its result: it takes the
   // screen the moment the game ends, so this is where the final position is
   // reported.

--- a/src/apps_local/knucklebones/KnucklebonesActivity.cpp
+++ b/src/apps_local/knucklebones/KnucklebonesActivity.cpp
@@ -174,6 +174,14 @@ void KnucklebonesActivity::onLinkEnded() {
   goTo(kb::Screen::Menu);
 }
 
+void KnucklebonesActivity::onMatchEnded() {
+  recordResult();
+  // The same screen the solo game ends on. In a match it used to be
+  // unreachable, so the finished board went straight to ANOTHER GAME? and the
+  // loser saw nothing at all of the move that beat them.
+  goTo(kb::Screen::Result);
+}
+
 void KnucklebonesActivity::gameLoop() {
   namespace fui = freeink::ui;
 

--- a/src/apps_local/knucklebones/KnucklebonesActivity.cpp
+++ b/src/apps_local/knucklebones/KnucklebonesActivity.cpp
@@ -279,6 +279,14 @@ void KnucklebonesActivity::gameLoop() {
       return;
 
     case knuckleui::ActionDone:
+      // DONE on a finished MATCH means done with the match, not just with the
+      // screen: the radio is still up and the link screen would slam over the
+      // menu the moment the hold ended. leaveLink() is what puts the app back
+      // on its own menu, and it tells the other device on the way out.
+      if (inMatch()) {
+        leaveLink();
+        return;
+      }
       goTo(kb::Screen::Menu);
       return;
 

--- a/src/apps_local/knucklebones/KnucklebonesActivity.h
+++ b/src/apps_local/knucklebones/KnucklebonesActivity.h
@@ -42,6 +42,11 @@ class KnucklebonesActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override { return knucklebones::over(game); }
+  // Counted here and nowhere else in a match. It used to be counted in an
+  // else-if arm of gameLoop() that multiplayer returns before reaching, so no
+  // link game was ever recorded and no final board was ever shown. See
+  // link/LinkEndgame.h.
+  void onMatchEnded() override;
   void gameLoop() override;
   void gameRender() override;
 

--- a/src/apps_local/link/LinkActivity.cpp
+++ b/src/apps_local/link/LinkActivity.cpp
@@ -34,6 +34,7 @@ void LinkActivity::enterLink(const GameId gameId) {
   gameId_ = gameId;
   requested_ = true;
   rematch_ = false;
+  endgame_.reset();
   lastPhase_ = Phase::Off;
   you_ = linkui::SeatState::Ready;
   them_ = linkui::SeatState::Looking;
@@ -49,12 +50,19 @@ void LinkActivity::leaveLink() {
   linkState().stop();
   requested_ = false;
   rematch_ = false;
+  endgame_.reset();
   lastPhase_ = Phase::Off;
   onLinkEnded();
 }
 
 bool LinkActivity::linkOwnsScreen() const {
-  return requested_ && (linkPhase() == Phase::Searching || linkPhase() == Phase::Over || rematch_);
+  if (!requested_) return false;
+  // The final board outranks everything the link layer would otherwise put on
+  // the panel, including the opponent walking away in the same second. A player
+  // who has just lost must see the move that beat them; being told THEY LEFT
+  // instead is the same bug wearing a different screen.
+  if (endgame_.showingFinal()) return false;
+  return linkPhase() == Phase::Searching || linkPhase() == Phase::Over || rematch_;
 }
 
 bool LinkActivity::driveLink() {
@@ -105,9 +113,22 @@ bool LinkActivity::driveLink() {
 
   if (takeOpponentState()) requestUpdate();
 
-  // A finished game is a question, so it goes to the same screen the rematch
-  // uses rather than leaving a dead board with an inert capsule on it.
-  if (matchGameOver() && !rematch_ && inMatch()) {
+  // A finished game is a question, but not yet. The board that ended it goes up
+  // first and stays there long enough to read, and the match is counted on the
+  // same pass -- both of those are Endgame's, and this is the only place either
+  // happens. See LinkEndgame.h.
+  //
+  // A local class in a member function has that member's access, which is how
+  // the game's protected hooks reach a helper that knows nothing about
+  // Activity. No vtable and no allocation: Endgame::update is a template.
+  struct EndgameHost {
+    LinkActivity& self;
+    bool matchGameOver() const { return self.matchGameOver(); }
+    void onMatchEnded() const { self.onMatchEnded(); }
+    void onEndgameChanged() const { self.requestUpdate(); }
+  } endgameHost{*this};
+  endgame_.update(endgameHost, inMatch(), millis());
+  if (endgame_.offering() && !rematch_) {
     rematch_ = true;
     you_ = linkui::SeatState::Deciding;
     them_ = linkui::SeatState::Deciding;
@@ -153,6 +174,9 @@ void LinkActivity::proposeRematch() {
   // asking: the seats had been left on Ready by the match handshake, so the
   // proposal saw agreement that had never been given.
   const bool theyAlreadyAgreed = rematch_ && them_ == linkui::SeatState::Ready;
+  // Asked for while the final board was still up: they have seen what the hold
+  // exists to show them, so it stops holding rather than swallowing the tap.
+  endgame_.skip();
   you_ = linkui::SeatState::Ready;
   linkState().say(kNotePlayAgain);
   if (theyAlreadyAgreed) {
@@ -167,6 +191,7 @@ void LinkActivity::proposeRematch() {
 }
 
 void LinkActivity::startRematch() {
+  endgame_.reset();
   rematch_ = false;
   you_ = linkui::SeatState::Deciding;
   them_ = linkui::SeatState::Deciding;
@@ -260,6 +285,11 @@ void LinkActivity::render(RenderLock&&) {
     return;
   }
   gameRender();
+  // Stamped after gameRender() rather than before, because gameRender() ends in
+  // displayBuffer(): this is the moment the frame is actually on the panel, and
+  // drawn is not seen until it is. Endgame decides whether this was the final
+  // board; it is stamped on every frame so that decision has one home.
+  endgame_.notePainted(millis());
 }
 
 }  // namespace linkplay

--- a/src/apps_local/link/LinkActivity.cpp
+++ b/src/apps_local/link/LinkActivity.cpp
@@ -295,12 +295,16 @@ void LinkActivity::render(RenderLock&&) {
     renderer.displayBuffer();
     return;
   }
+  // Read BEFORE the frame is built and reported after: a repaint of the old
+  // board can already be in flight when the match ends, and a hold started from
+  // that frame is a hold the player never saw.
+  const Endgame::Stage stageAtBuild = endgame_.stage();
   gameRender();
-  // Stamped after gameRender() rather than before, because gameRender() ends in
-  // displayBuffer(): this is the moment the frame is actually on the panel, and
-  // drawn is not seen until it is. Endgame decides whether this was the final
-  // board; it is stamped on every frame so that decision has one home.
-  endgame_.notePainted(millis());
+  // Reported after gameRender() rather than before, because gameRender() ends
+  // in displayBuffer(): this is the moment the frame is actually on the panel,
+  // and drawn is not seen until it is. Endgame decides whether this was the
+  // final board; every frame is reported so that decision has one home.
+  endgame_.notePainted(stageAtBuild, millis());
 }
 
 }  // namespace linkplay

--- a/src/apps_local/link/LinkActivity.cpp
+++ b/src/apps_local/link/LinkActivity.cpp
@@ -35,6 +35,7 @@ void LinkActivity::enterLink(const GameId gameId) {
   requested_ = true;
   rematch_ = false;
   endgame_.reset();
+  lastEndgameStage_ = Endgame::Stage::Live;
   lastPhase_ = Phase::Off;
   you_ = linkui::SeatState::Ready;
   them_ = linkui::SeatState::Looking;
@@ -51,6 +52,7 @@ void LinkActivity::leaveLink() {
   requested_ = false;
   rematch_ = false;
   endgame_.reset();
+  lastEndgameStage_ = Endgame::Stage::Live;
   lastPhase_ = Phase::Off;
   onLinkEnded();
 }
@@ -160,6 +162,14 @@ bool LinkActivity::driveLink() {
     interactionsReady = false;
     ownedScreen_ = owns;
   }
+  // Same invariant, second handover: onMatchEnded() sends the game to its own
+  // final screen mid-pass with nobody having touched the panel, and the table
+  // on the panel still describes the board. Without this the first tap after a
+  // game ends is routed against the screen it just left.
+  if (endgame_.stage() != lastEndgameStage_) {
+    interactionsReady = false;
+    lastEndgameStage_ = endgame_.stage();
+  }
 
   if (owns) {
     routeLinkScreen();
@@ -192,6 +202,7 @@ void LinkActivity::proposeRematch() {
 
 void LinkActivity::startRematch() {
   endgame_.reset();
+  lastEndgameStage_ = Endgame::Stage::Live;
   rematch_ = false;
   you_ = linkui::SeatState::Deciding;
   them_ = linkui::SeatState::Deciding;

--- a/src/apps_local/link/LinkActivity.h
+++ b/src/apps_local/link/LinkActivity.h
@@ -24,6 +24,7 @@
 //   onRematch()        both sides said yes
 //   onLinkEnded()      back to solo: restore what was saved
 //   matchGameOver()    whether the game has finished
+//   onMatchEnded()     it just finished: count it and put the final board up
 //   gameLoop() / gameRender()   what loop() and render() used to be
 //
 // What it must NOT write: the searching screen, the disconnect screen, the
@@ -38,6 +39,7 @@
 #include "../../activities/Activity.h"
 #include "../../components/UITheme.h"  // Rect
 #include "../ui/ToyboxScreen.h"
+#include "LinkEndgame.h"
 #include "LinkPlay.h"
 #include "LinkScreens.h"
 
@@ -87,6 +89,17 @@ class LinkActivity : public Activity {
   // The match is over and the app is solo again: put the saved game back.
   virtual void onLinkEnded() = 0;
   virtual bool matchGameOver() const = 0;
+  // The match has just ended, on the pass it ended, on BOTH devices. Two jobs,
+  // and they are one moment: record the result, and go to whatever screen shows
+  // the finished game. The layer then keeps that screen on the panel for a
+  // couple of seconds before it offers another game -- see LinkEndgame.h.
+  //
+  // Pure rather than defaulted, and that is the whole point of it. Every game
+  // recorded its result in an else-if arm of gameLoop() that multiplayer
+  // returns before reaching, so no link match was ever counted in any of them.
+  // A hook with a default body would have been forgotten in exactly the same
+  // silence; this one makes the compiler ask each game the question.
+  virtual void onMatchEnded() = 0;
   virtual void gameLoop() = 0;
   virtual void gameRender() = 0;
 
@@ -141,10 +154,13 @@ class LinkActivity : public Activity {
   // Which side of the screen handover we were on last pass, so the shared hit
   // table can be invalidated exactly when the screen changes hands.
   bool ownedScreen_ = false;
-  // The rematch screen is up. Reached by a finished game, or by either player
-  // asking for a new one -- which is the same question either way, so it is the
-  // same screen.
+  // The rematch screen is up. Reached by a finished game once its final board
+  // has had its couple of seconds, or by either player asking for a new one --
+  // which is the same question either way, so it is the same screen.
   bool rematch_ = false;
+  // The seconds between the last move and ANOTHER GAME?, and the one place a
+  // link match is counted. See LinkEndgame.h.
+  Endgame endgame_;
   linkui::SeatState you_ = linkui::SeatState::Ready;
   linkui::SeatState them_ = linkui::SeatState::Looking;
 

--- a/src/apps_local/link/LinkActivity.h
+++ b/src/apps_local/link/LinkActivity.h
@@ -154,6 +154,10 @@ class LinkActivity : public Activity {
   // Which side of the screen handover we were on last pass, so the shared hit
   // table can be invalidated exactly when the screen changes hands.
   bool ownedScreen_ = false;
+  // The endgame moves the game to its own final screen with nobody having
+  // tapped anything, so that handover invalidates the table for the same reason
+  // the one above does.
+  Endgame::Stage lastEndgameStage_ = Endgame::Stage::Live;
   // The rematch screen is up. Reached by a finished game once its final board
   // has had its couple of seconds, or by either player asking for a new one --
   // which is the same question either way, so it is the same screen.

--- a/src/apps_local/link/LinkEndgame.h
+++ b/src/apps_local/link/LinkEndgame.h
@@ -34,6 +34,12 @@
 //                                per finished match, and it is the only place
 //                                a link match is ever recorded
 //   void onEndgameChanged()      repaint
+//
+// On tasks: update(), reset() and skip() belong to the LOOP task, notePainted()
+// to the RENDER task, and only the timestamp crosses between them, atomically.
+// The stage byte is written by the loop and read by the render task through
+// showingFinal(), the same way requested_ and rematch_ already are in
+// LinkActivity: a single byte, and a stale read costs one frame.
 
 #include <atomic>
 #include <cstdint>
@@ -119,7 +125,17 @@ class Endgame {
   // not the task that runs update(), so the stamp is atomic and everything that
   // reads it happens on the next pass of the loop. Zero means nothing pending,
   // so a millis() of 0 -- the first millisecond after boot -- is stamped as 1.
-  void notePainted(const uint32_t now) { pendingPaintMs_.store(now == 0 ? 1 : now); }
+  //
+  // `stageAtBuild` is the stage as it was when this frame STARTED being drawn,
+  // and it is the whole reason this takes an argument. requestUpdate() only
+  // notifies the render task, so a repaint of the old board can already be in
+  // flight when the match ends; reporting that one would start the hold from a
+  // frame that never showed the final position. A frame that began before the
+  // end is not the final board, however it ends up on the panel.
+  void notePainted(const Stage stageAtBuild, const uint32_t now) {
+    if (stageAtBuild != Stage::Final) return;
+    pendingPaintMs_.store(now == 0 ? 1 : now);
+  }
 
   // The player has asked for another game while the board was still up. They
   // have seen everything the hold exists to show them, so stop holding.

--- a/src/apps_local/link/LinkEndgame.h
+++ b/src/apps_local/link/LinkEndgame.h
@@ -1,0 +1,143 @@
+#pragma once
+
+// The end of a match: what happens between the last move and ANOTHER GAME?
+//
+// Two things went wrong at that instant, and it is the same instant, which is
+// why they are one file.
+//
+// The loser never saw the move that beat them. driveLink() applied the winning
+// state and put the rematch screen up in the same pass, and a repaint is
+// deferred to the end of the loop, so the board carrying the win was never on
+// the panel at all. Losing without seeing how is the worst version of losing.
+//
+// And a link match was never counted. Five of the nine games recorded their
+// result inside gameLoop() -- checkers, connect four, knucklebones and yahtzee
+// in an else-if arm after a guard that returns first in multiplayer, toy battle
+// in a block gameLoop() simply stops reaching -- so the tally, the final board
+// and the whole W/L/D record only ever existed for solo games. Nothing crashed
+// and nothing logged: the record was simply never written.
+//
+// Ask what a Nintendo DS would do. It shows the winning move, lets it sit long
+// enough to read, and only then offers another game -- and it counts the match
+// while it is doing that. So both live here, driven by the layer, rather than
+// in nine games that would each get it slightly differently.
+//
+// Freestanding on purpose -- <atomic> and <cstdint> and nothing else -- so
+// host-tests/link can drive the whole sequence with no renderer, no device and
+// no radio. Everything that has an ORDER to get wrong is inside update(),
+// rather than spread across the caller where a test would have to reproduce it
+// and could reproduce it wrongly. The host is a template parameter rather than
+// a base class for the same reason a vtable is not free here; it must supply:
+//
+//   bool matchGameOver() const   has the game finished
+//   void onMatchEnded()          count it, and show it: called exactly ONCE
+//                                per finished match, and it is the only place
+//                                a link match is ever recorded
+//   void onEndgameChanged()      repaint
+
+#include <atomic>
+#include <cstdint>
+
+namespace linkplay {
+
+class Endgame {
+ public:
+  // Long enough to read a board and see what happened. Counted from the paint
+  // rather than from the move, because a repaint on this panel takes the better
+  // part of a second and a hold measured from the move is mostly the repaint.
+  static constexpr uint32_t kHoldMs = 2500;
+  // And a ceiling, from the move, in case the paint is never reported. A player
+  // stuck forever on a finished board with no way to ask for another game is a
+  // worse bug than the one this file exists to fix.
+  static constexpr uint32_t kUnpaintedHoldMs = 6000;
+
+  enum class Stage : uint8_t {
+    // Playing, or not in a match at all.
+    Live,
+    // The game has finished and its own final screen is up. The link layer
+    // keeps its hands off the panel for the length of the hold.
+    Final,
+    // ANOTHER GAME?
+    Offer,
+  };
+
+  Stage stage() const { return stage_; }
+  // The game still owns the screen. Ask this before putting anything over it.
+  bool showingFinal() const { return stage_ == Stage::Final; }
+  bool offering() const { return stage_ == Stage::Offer; }
+
+  // A fresh match, a rematch, leaving: anything after which the next end of a
+  // game is a different end of a game.
+  void reset() {
+    stage_ = Stage::Live;
+    painted_ = false;
+    holdUntil_ = 0;
+    pendingPaintMs_.store(0);
+  }
+
+  // One pass. `inMatch` is the link layer's own idea of being in a match, so a
+  // finished SOLO game never reaches any of this.
+  template <class Host>
+  void update(Host& host, const bool inMatch, const uint32_t now) {
+    // Consumed FIRST, and consumed whatever the stage is. A frame that reached
+    // the panel while the game was still running is not the final board, and if
+    // it were left pending it would be picked up by the transition below and
+    // cut the hold to nothing -- which is the original bug wearing a timer.
+    const uint32_t painted = pendingPaintMs_.exchange(0);
+    if (painted != 0 && stage_ == Stage::Final && !painted_) {
+      painted_ = true;
+      holdUntil_ = painted + kHoldMs;
+    }
+
+    if (!inMatch) {
+      if (stage_ != Stage::Live) reset();
+      return;
+    }
+    if (!host.matchGameOver()) {
+      // A rematch that began without anybody calling reset() is still a new
+      // game, and the next end of it must be announced again.
+      if (stage_ != Stage::Live) reset();
+      return;
+    }
+    if (stage_ == Stage::Live) {
+      stage_ = Stage::Final;
+      painted_ = false;
+      holdUntil_ = now + kUnpaintedHoldMs;
+      // Counted here and nowhere else. This runs on both devices, on the pass
+      // the game ends, whoever played the last move.
+      host.onMatchEnded();
+      host.onEndgameChanged();
+      return;
+    }
+    if (stage_ == Stage::Final && expired(now)) {
+      stage_ = Stage::Offer;
+      host.onEndgameChanged();
+    }
+  }
+
+  // A frame reached the panel at `now`. Called from the RENDER task, which is
+  // not the task that runs update(), so the stamp is atomic and everything that
+  // reads it happens on the next pass of the loop. Zero means nothing pending,
+  // so a millis() of 0 -- the first millisecond after boot -- is stamped as 1.
+  void notePainted(const uint32_t now) { pendingPaintMs_.store(now == 0 ? 1 : now); }
+
+  // The player has asked for another game while the board was still up. They
+  // have seen everything the hold exists to show them, so stop holding.
+  void skip() {
+    if (stage_ == Stage::Final) stage_ = Stage::Offer;
+  }
+
+ private:
+  // Wrap-safe: millis() rolls over about every 49 days, and a difference
+  // compared as signed survives it where `now >= holdUntil_` does not.
+  bool expired(const uint32_t now) const { return static_cast<int32_t>(now - holdUntil_) >= 0; }
+
+  Stage stage_ = Stage::Live;
+  // The final board has been seen, so the hold is counted from that rather than
+  // from the move.
+  bool painted_ = false;
+  uint32_t holdUntil_ = 0;
+  std::atomic<uint32_t> pendingPaintMs_{0};
+};
+
+}  // namespace linkplay

--- a/src/apps_local/seasalt/SeaSaltActivity.cpp
+++ b/src/apps_local/seasalt/SeaSaltActivity.cpp
@@ -81,10 +81,13 @@ void SeaSaltActivity::onMatchStart(const bool goesFirst) {
   // The dealer deals and sends; the other device adopts the state whole, so
   // both play the same shuffle without a seed ever crossing on its own.
   seat = goesFirst ? 0 : 1;
-  if (goesFirst) {
-    game.newGame(nextSeed(), 0);
-    link.play(game);
-  }
+  // BOTH sides clear the table; only the dealer's deal is the one that counts,
+  // and it arrives in the first packet. The follower used to keep whatever it
+  // was holding, so a match begun after a finished game started with
+  // matchGameOver() already true -- which counted that old game a second time
+  // and put its score screen up as the new match's opening view.
+  game.newGame(nextSeed(), 0);
+  if (goesFirst) link.play(game);
   statsCounted = false;
   clearSelection();
   report[0] = '\0';
@@ -964,6 +967,13 @@ void SeaSaltActivity::routeCall() {
 
 void SeaSaltActivity::routeRoundOver() {
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+    // The same guard routeBoard() has twenty lines up. Without it Back here
+    // walks to the front door with the radio still up and the opponent never
+    // told, and the link screen arrives over the menu a moment later.
+    if (linkRequested()) {
+      leaveLink();
+      return;
+    }
     goToMenu();
     return;
   }
@@ -1001,6 +1011,13 @@ void SeaSaltActivity::routeRoundOver() {
     return;
   }
   if (event.action == seasaltui::ActionPlayAgain) {
+    // In a match this button is drawn live and reachable, and startNewGame()
+    // would deal a fresh local game over a link the opponent is still on --
+    // they would never see it. A rematch is asked, the same as everywhere else.
+    if (inMatch()) {
+      proposeRematch();
+      return;
+    }
     startNewGame();
   }
 }

--- a/src/apps_local/seasalt/SeaSaltActivity.h
+++ b/src/apps_local/seasalt/SeaSaltActivity.h
@@ -45,6 +45,11 @@ class SeaSaltActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override { return game.currentPhase() == seasalt::Phase::GameOver; }
+  // Sea Salt already counts a match from both takeOpponentState() and
+  // afterHumanAction(), so this is insurance rather than the fix -- and free
+  // insurance, because countMatchEnd() is guarded by statsCounted and a second
+  // call does nothing. See link/LinkEndgame.h.
+  void onMatchEnded() override { countMatchEnd(); }
   void drawLinkArt(const Rect& slot) override;
   void gameLoop() override;
   void gameRender() override;

--- a/src/apps_local/toybattle/ToyBattleActivity.cpp
+++ b/src/apps_local/toybattle/ToyBattleActivity.cpp
@@ -220,6 +220,14 @@ void ToyBattleActivity::gameLoop() {
       return;
     }
     if (screen == tb::Screen::Board) {
+      // In a match, Back is leaving the match. Every other game on the link
+      // layer says so; this one walked to its own menu with the radio up and
+      // the opponent never told, and the link screen arrived over the menu a
+      // moment later. saveGame() is a no-op in a match anyway.
+      if (inMatch()) {
+        leaveLink();
+        return;
+      }
       // Leaving the board writes it, the same as leaving the app does. onExit
       // is the call that matters because sleep makes it when the player does
       // nothing, but a board abandoned by Back and then never slept would

--- a/src/apps_local/toybattle/ToyBattleActivity.cpp
+++ b/src/apps_local/toybattle/ToyBattleActivity.cpp
@@ -185,6 +185,22 @@ const char* ToyBattleActivity::promptText() const {
   return "";
 }
 
+void ToyBattleActivity::recordResult() {
+  if (recorded) return;
+  recorded = true;
+  ++played;
+  if (game.winner == seat) ++won;
+  hasSave = false;
+  if (Storage.exists(kSavePath)) Storage.remove(kSavePath);
+  requestUpdate();
+}
+
+// In a match this is the ONLY caller: gameLoop() stops running the moment the
+// link layer notices the battle is over, so the block above never reaches a
+// finished match. The board itself is already the right thing to look at -- it
+// stays up by design -- so there is no screen to change, only a result to count.
+void ToyBattleActivity::onMatchEnded() { recordResult(); }
+
 void ToyBattleActivity::gameLoop() {
   namespace fui = freeink::ui;
 
@@ -236,14 +252,7 @@ void ToyBattleActivity::gameLoop() {
     //
     // Still the one place a result is recorded and the save is cleared: a
     // finished game must not be offered as one to continue.
-    if (!recorded) {
-      recorded = true;
-      ++played;
-      if (game.winner == seat) ++won;
-      hasSave = false;
-      if (Storage.exists(kSavePath)) Storage.remove(kSavePath);
-      requestUpdate();
-    }
+    recordResult();
     return;
   }
 

--- a/src/apps_local/toybattle/ToyBattleActivity.cpp
+++ b/src/apps_local/toybattle/ToyBattleActivity.cpp
@@ -195,10 +195,12 @@ void ToyBattleActivity::recordResult() {
   requestUpdate();
 }
 
-// In a match this is the ONLY caller: gameLoop() stops running the moment the
-// link layer notices the battle is over, so the block above never reaches a
-// finished match. The board itself is already the right thing to look at -- it
-// stays up by design -- so there is no screen to change, only a result to count.
+// The first caller in a match, and for a long time there was no other: the link
+// layer used to stop giving gameLoop() the pass the moment the battle ended, so
+// the block below never ran and no link battle was ever counted. It runs again
+// now, during the couple of seconds the finished board stays up, which is
+// harmless because `recorded` latches. No screen to change either -- this game's
+// board stays put by design, and that is already the thing worth looking at.
 void ToyBattleActivity::onMatchEnded() { recordResult(); }
 
 void ToyBattleActivity::gameLoop() {

--- a/src/apps_local/toybattle/ToyBattleActivity.h
+++ b/src/apps_local/toybattle/ToyBattleActivity.h
@@ -39,6 +39,10 @@ class ToyBattleActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override;
+  // Counted here and nowhere else in a match. It used to be counted only inside
+  // gameLoop(), which multiplayer stops running the moment the game ends, so no
+  // link battle was ever recorded. See link/LinkEndgame.h.
+  void onMatchEnded() override;
   void gameLoop() override;
   void gameRender() override;
   void drawLinkArt(const Rect& area) override;
@@ -50,6 +54,7 @@ class ToyBattleActivity final : public linkplay::LinkActivity {
   void cycleSetupRow(tbui::SetupRow row);
   void refreshSaveLine();
   void takeOpponentTurn();
+  void recordResult();
   void goTo(toybattle::Screen next);
   const char* promptText() const;
 

--- a/src/apps_local/yahtzee/YahtzeeActivity.cpp
+++ b/src/apps_local/yahtzee/YahtzeeActivity.cpp
@@ -293,6 +293,14 @@ void YahtzeeActivity::gameLoop() {
       return;
 
     case yzui::ActionDone:
+      // DONE on a finished MATCH means done with the match, not just with the
+      // screen: the radio is still up and the link screen would slam over the
+      // menu the moment the hold ended. leaveLink() is what puts the app back
+      // on its own menu, and it tells the other device on the way out.
+      if (inMatch()) {
+        leaveLink();
+        return;
+      }
       goTo(yz::Screen::Menu);
       return;
 

--- a/src/apps_local/yahtzee/YahtzeeActivity.cpp
+++ b/src/apps_local/yahtzee/YahtzeeActivity.cpp
@@ -137,10 +137,12 @@ void YahtzeeActivity::onMatchStart(const bool goesFirst) {
   // The follower waits for the leader's first state to arrive, which it will,
   // because the whole game travels on every move.
   //
-  // Starting on a zeroed Game here is safe in a way it was not in Checkers: an
-  // empty Yahtzee card is not a finished game, so over() is false and nothing
-  // announces a winner before the first roll.
-  if (goesFirst) yz::start(game, toybox::seed());
+  // BOTH sides start a card; only the leader's dice are the ones that count,
+  // and they arrive in its first state. The follower used to keep whatever it
+  // was holding, and a kept card is a FULL card -- kUnscored is -1, so a game
+  // left over from before is over() and the new match opened on the old score
+  // sheet with the old result counted a second time.
+  yz::start(game, toybox::seed());
   goTo(yz::Screen::Card);
 }
 

--- a/src/apps_local/yahtzee/YahtzeeActivity.cpp
+++ b/src/apps_local/yahtzee/YahtzeeActivity.cpp
@@ -153,6 +153,14 @@ void YahtzeeActivity::onLinkEnded() {
   goTo(yz::Screen::Menu);
 }
 
+void YahtzeeActivity::onMatchEnded() {
+  recordResult();
+  // The same screen the solo game ends on. In a match it used to be
+  // unreachable, so the finished board went straight to ANOTHER GAME? and the
+  // loser saw nothing at all of the move that beat them.
+  goTo(yz::Screen::Result);
+}
+
 void YahtzeeActivity::gameLoop() {
   namespace fui = freeink::ui;
 

--- a/src/apps_local/yahtzee/YahtzeeActivity.h
+++ b/src/apps_local/yahtzee/YahtzeeActivity.h
@@ -32,6 +32,11 @@ class YahtzeeActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override { return yahtzee::over(game); }
+  // Counted here and nowhere else in a match. It used to be counted in an
+  // else-if arm of gameLoop() that multiplayer returns before reaching, so no
+  // link game was ever recorded and no final board was ever shown. See
+  // link/LinkEndgame.h.
+  void onMatchEnded() override;
   void gameLoop() override;
   void gameRender() override;
 


### PR DESCRIPTION
Closes board cards **#35** and **#36**. They are one instant in the code, so they are one change.

## What was wrong

**#35 -- a link match was never recorded.** `recordResult()` sat in an `else if` arm after `if (inMatch())`, which returns first in multiplayer:

```cpp
if (screen == c4::Screen::Board) {
  if (inMatch()) {
    if (!linkYourTurn()) { ...; return; }      // multiplayer stops here
  } else if (!c4::over(game) && game.turn != seat) {
    takeOpponentTurn(); return;
  } else if (c4::over(game)) {
    recordResult();                             // solo only
    goTo(c4::Screen::Result);
    return;
  }
}
```

Nothing crashed and nothing logged. The tally, the W/L/D record and the last-board ornament simply never existed for a game played against another device.

**#36 -- the loser saw zero frames of the final board.** `driveLink()` applied the winning state and set `rematch_` in the same pass; `linkOwnsScreen()` then became true and `render()` drew the rematch screen. The repaint that would have shown the winning move is deferred to the end of the loop, so it never happened. The board jumped from "their turn" straight to ANOTHER GAME?.

## The sweep, per game

`recordResult()` after a guard that can return first is a **shape**, not a typo. I audited all nine games on the link layer. The shape is confined to link games: `inMatch()` appears in exactly those nine `src/apps_local/*` directories, and the solo games with a tally (minesweeper, sudoku, solitaire) record from an unconditional `if` with no link guard in front of it.

| game             | recorded a link match before? | why                                                                                                                       |
| ---------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
| **connectfour**  | **NO**                        | `recordResult()` at `ConnectFourActivity.cpp:238`, else-if after `inMatch()`                                              |
| **checkers**     | **NO**                        | same shape, `CheckersActivity.cpp:252`                                                                                    |
| **knucklebones** | **NO**                        | same shape, `KnucklebonesActivity.cpp:208`                                                                                |
| **yahtzee**      | **NO**                        | same shape, `YahtzeeActivity.cpp:196`                                                                                     |
| **toybattle**    | **NO**                        | different shape, same cause: its record block is in `gameLoop()`, which the layer stops calling the moment the match ends |
| battleship       | yes                           | `finishGame()` runs from `fireAtAimed()` and from `takeOpponentState()`, both inside a match                              |
| seasalt          | yes                           | `countMatchEnd()` from `takeOpponentState()` and `afterHumanAction()`                                                     |
| chess            | n/a                           | keeps no tally (only `chess.cfg` settings and `chess.sav` position)                                                       |
| jaipur           | n/a                           | keeps no tally                                                                                                            |

So Connect Four was **not** the only one: four games share it exactly and a fifth shares its cause.

#36 affects **all nine**, because it is entirely in `LinkActivity`.

## The fix

New `src/apps_local/link/LinkEndgame.h`: a freestanding `Live -> Final -> Offer` state machine that the layer drives.

- On the pass a match ends it calls a new **pure virtual `onMatchEnded()`** exactly once, on both devices. That is now the only place a link match is recorded.
- It then holds the game's own final screen for 2.5s, **counted from the paint rather than from the move** -- a repaint on this panel takes the better part of a second, so a hold started at the move is mostly the repaint. `notePainted()` is reported by the render task and consumed on the next loop pass, guarded at both ends: the render task reports the stage the frame was BUILT under, and `update()` consumes any pending stamp before the Live->Final transition can pick it up. A frame from before the game ended can never be mistaken for the final board.
- A ceiling of 6s releases the offer even if no paint is ever reported. A player stuck on a finished board with no way to ask for another game would be a worse bug than the one this fixes.
- Tapping ANOTHER GAME during the hold skips it (`Endgame::skip()`), because they have already seen what the hold is for.

Ask what a Nintendo DS would do: show the winning move, let it sit long enough to read, offer a rematch. It counts the match while it does that.

**`onMatchEnded()` is pure virtual on purpose.** A defaulted hook would have been forgotten in exactly the silence that hid this for five games; this one makes the compiler ask all nine. The answers are each documented in the game's header with the reason:

- checkers / connectfour / knucklebones / yahtzee: `recordResult(); goTo(<ns>::Screen::Result);` -- their own Result screen was unreachable in a match, so they lost the tally _and_ the screen in one stroke
- toybattle: `recordResult()` (extracted from `gameLoop()`); its board already stays up by design
- seasalt: `countMatchEnd()`, idempotent, insurance rather than a fix
- battleship: deliberately empty -- `finishGame()` already covers both sides and has no once-only guard, so calling it again would double-count
- chess, jaipur: empty, no tally exists

## What a cold critic found, and what it cost

I ran a fresh agent over all nine games against the change. It was worth it: the layer was sound, but **five games' routing was written on the assumption that a finished match never gets another pass**, and it now gets 2.5 seconds of them. All of the following are fixed in `abe1a429` and `0d745b2f`:

| game | what the hold exposed | fix |
|---|---|---|
| connectfour, checkers, knucklebones, yahtzee | the Result screen's **DONE** row became reachable in a match. It called `goTo(Screen::Menu)`, leaving the radio up and `requested_` true, so the link screen would have slammed over the app's own menu when the hold ended | `leaveLink()` in a match |
| seasalt | **PLAY AGAIN** is drawn live on the round-over screen and called `startNewGame()` -- a fresh LOCAL deal over a live radio the opponent would never see | `proposeRematch()` |
| seasalt | **Back** on that screen went to the front door with the radio up and the opponent never told. `routeBoard()` twenty lines above already had the guard | `leaveLink()` |
| seasalt, yahtzee, jaipur | `onMatchStart()` reset the game **only on the dealer**. A follower entering a match after a finished game held a finished game, so `matchGameOver()` was true on pass one: the new hook counted the OLD result and put its score screen up as the new match's opening view | both sides clear the table; only the dealer's deal travels |
| jaipur | a **PLAY AGAIN** button the hold now paints live, whose handler excluded `inMatch()`. A tap that does nothing reads exactly like a crash | `proposeRematch()` |
| toybattle | **Back** on the board went to its own menu with the radio up | `leaveLink()` |

Yahtzee's is worth naming on its own. Its `onMatchStart()` carried this comment:

> Starting on a zeroed Game here is safe in a way it was not in Checkers: an empty Yahtzee card is not a finished game, so `over()` is false

and the code never zeroed anything. `kUnscored` is `-1`, so a *kept* card is a full card and `over()` was true. `goesFirst()` is fixed for a session, so the same device would have miscounted on every rematch.

Two more in the layer itself:

- `interactionsReady` is now invalidated on the endgame stage change, the same way it already is on the link-screen handover. The layer moves the game to its own final screen with nobody having tapped anything, and the table on the panel still described the board it left. Not exploitable in the four games today (their board tables are `NO_ACTION` or route through an `over(game)` guard), but the invariant the comment documents no longer held.
- `notePainted()` now takes the stage as it was when the frame **started** being drawn. `requestUpdate()` only notifies the render task, so a repaint of the old board can be in flight when the match ends, and reporting that frame started the hold from one that never showed the winning move.

## Tests

`host-tests/link/test_endgame.cpp` -- 69 checks. Two seats play a **real** Connect Four match over the **real** hostile link (10% loss, 10% duplication, 30ms jitter) with the **real** `Endgame`. Everything with an ordering decision in it was deliberately put inside `Endgame::update()` rather than left in the caller, so the test drives the shipped logic instead of re-deriving it.

The two assertions that are the two cards:

```
CHECK(a.recordCalls == 1);  CHECK(b.recordCalls == 1);
CHECK(winner->wins == 1);   CHECK(loser->losses == 1);      // the record EXISTS
CHECK(loser->framesOfFinalBoard > 0);                        // the loser saw it
CHECK(loser->offerScreenAtMs - loser->firstFinalPaintMs >= Endgame::kHoldMs);
```

Plus: the hold measured from a 1500ms-per-frame panel, the unpainted ceiling, skip-on-tap, a finished **solo** game never being counted by the layer, a pre-end paint not shortening the hold, an in-flight repaint at the moment of the end not being mistaken for the final board, a rematch being counted again, a `millis()` rollover mid-hold, and leaving mid-hold.

**Both halves watched go red**, each by reverting the fix in `LinkEndgame.h` and confirming with `diff` that the revert actually changed the file:

- deleting the `host.onMatchEnded()` call: **22 checks fail**, including `winner->wins == 1` and `loser->losses == 1`
- replacing `stage_ = Stage::Final` with `stage_ = Stage::Offer` (the old behaviour exactly): **14 checks fail**, including `loser->framesOfFinalBoard > 0`
- dropping the in-flight-repaint guard in `notePainted()`: **2 checks fail**, the hold expiring early

**What the suite does not cover, said plainly.** It models one game through a `Seat` struct that reproduces `driveLink()`'s ordering; it instantiates no real Activity, and it does not touch the other eight games' routing. **None of the critic's findings above would have gone red in it.** They were found by reading, not by testing, and the reading is the evidence for them.

## What I could NOT verify

- **Nothing on hardware.** This is two-device behaviour and I had no two devices. Everything below is a claim about code, not about a panel.
- **The 2.5s hold has never been looked at by a person.** The number is reasoned (long enough to read a board, short enough not to annoy), not measured. It may want tuning once somebody plays a match.
- **The five games' final screens have not been rendered** during the hold. Four of them now show their own Result screen, which is the same screen the solo game has always ended on, so it is drawn code -- but drawn in a state (`inMatch()` true) it has never been drawn in. Toy battle keeps its board, sea salt its round-over view, jaipur its round-over view, chess and battleship their boards.
- The simulator cannot help here: it does not compile `lib/hal` or run the real `InputManager`, and a link match needs two of them.

## Filed separately, found during the sweep

- **#195** Toy Battle's `PLAYED`/`WON` line is always zero: the counters are plain members, never written to `toybattle.sav`, so they reset on every entry to the app even in solo.
- **#196** Jaipur's front door draws a record line that is permanently `0 PLAYED   0 WON`: `StartModel::played`/`won` are never assigned anywhere in the tree.
- **#197** Toy Battle's `HOW IT ENDED` button on a finished board has never been tappable -- `gameLoop()` returns before tap routing on that state. Pre-existing in solo too; it matters more now that the finished board sits there for 2.5s with Back as the only live input.
- **#198** Chess says `BLACK WINS` rather than `YOU LOST` during the hold. Nothing is lost, only delayed until the link screen, but the hold exists precisely so the loser understands what happened.
