### PR TITLE
site: a cancelled port picker is not a bug card

### DIFF
--- a/host-tests/site/install_fn.js
+++ b/host-tests/site/install_fn.js
@@ -1,0 +1,41 @@
+// install.js decides which failed installs are the person's own (a closed
+// port picker, a device that would not answer on the cable) and posts those
+// as info, not error, so they are counted and not carded. The page is a
+// browser IIFE, so the decision function is lifted out of the source text
+// and run here on its own.
+//
+//   node host-tests/site/install_fn.js <repo root>
+const fs = require("fs");
+const path = require("path");
+const root = process.argv[2];
+const src = fs.readFileSync(path.join(root, "site/assets/install.js"), "utf8");
+
+const m = src.match(/function userSide\(err\) \{[\s\S]*?\n  \}\n/);
+if (!m) {
+  console.log("  FAIL install.js has no userSide(err); every failed install would be a bug card again");
+  process.exit(1);
+}
+const userSide = new Function(m[0] + "\nreturn userSide;")();
+
+let failed = 0;
+function check(label, got, want) {
+  if (got === want) console.log("  ok   " + label);
+  else { failed++; console.log("  FAIL " + label + " (got " + got + ", wanted " + want + ")"); }
+}
+function dom(name, message) { const e = new Error(message); e.name = name; return e; }
+
+check("a closed port picker is the person's own", userSide(dom("NotFoundError", "Failed to execute 'requestPort' on 'Serial': No port selected by the user.")), true);
+check("a declined permission prompt is the person's own", userSide(dom("NotAllowedError", "Permission denied")), true);
+check("no sync on the cable is the person's own", userSide(new Error("Failed to connect with the device")), true);
+check("a port another tab holds is the person's own", userSide(new Error("Failed to open serial port.")), true);
+check("a thrown string is read too", userSide("No port selected by the user"), true);
+check("a flasher exception is still an error", userSide(new TypeError("Cannot read properties of undefined (reading 'length')")), false);
+check("a download failure is still an error", userSide(new Error("HTTP 502 fetching firmware.bin")), false);
+check("a checksum mismatch is still an error", userSide(new Error("Image verification failed")), false);
+check("nothing at all is still an error", userSide(undefined), false);
+
+// And the catch actually uses it: the level is the decision, not a constant.
+check("the install's catch posts by that decision",
+  /tellBoard\(userSide\(err\) \? "info" : "error"/.test(src), true);
+
+process.exit(0);

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -327,6 +327,18 @@ for field in url anonKey; do
     && ok || bad "install.js and board-config.js disagree on the field '$field'"
 done
 
+# A failed install is a card only when the failure is the page's, not the
+# person's (cards 153 and 157 were a closed port picker and a silent cable).
+# The decision function is lifted from install.js and run under node.
+if install_out="$(node "$HERE/install_fn.js" "$ROOT" 2>&1)"; then
+  ok
+  n_fail="$(printf '%s\n' "$install_out" | grep -c '^  FAIL' || true)"
+  [ "$n_fail" -eq 0 ] && ok || { while IFS= read -r line; do bad "install_fn: $line"; done < <(printf '%s\n' "$install_out" | grep '^  FAIL'); }
+else
+  bad "install_fn.js could not run, so install.js's error levels went unchecked:"
+  while IFS= read -r line; do echo "      $line"; done <<< "$install_out"
+fi
+
 # under node with the board stubbed; the wrong passphrase must read nothing.
 if inbox_out="$(node "$HERE/inbox_fn.js" "$ROOT" 2>&1)"; then
   ok

--- a/site/assets/install.js
+++ b/site/assets/install.js
@@ -411,7 +411,7 @@
         say(friendly(err), "bad");
         note("error: " + ((err && err.message) || String(err)));
         setBusy(false);
-        tellBoard("error", (err && err.message) || String(err));
+        tellBoard(userSide(err) ? "info" : "error", (err && err.message) || String(err));
       });
   }
 
@@ -419,9 +419,25 @@
 
   // One site/install event per attempt, so the Numbers page can say how many
   // installs the button did and how many failed on what. A failed install
-  // posts an error, which opens a card by the board's own rule; the message
-  // is the flasher's, with nothing about the person. Best effort throughout:
-  // no board, no key, no network, and the install itself is unaffected.
+  // posts an error, which opens a card by the board's own rule, unless the
+  // failure is the person's own: a port picker they closed, a device that
+  // would not answer on the cable. Those are info with the message, counted
+  // and not carded (cards 153 and 157 were two of them). The message is the
+  // flasher's, with nothing about the person. Best effort throughout: no
+  // board, no key, no network, and the install itself is unaffected.
+  function userSide(err) {
+    var name = (err && err.name) || "";
+    var msg = String((err && err.message) || err || "");
+    return (
+      name === "NotFoundError" || // "No port selected by the user"
+      name === "NotAllowedError" || // the browser's permission prompt, declined
+      name === "SecurityError" || // not a secure context, or a policy
+      name === "AbortError" ||
+      /No port selected/i.test(msg) ||
+      /Failed to connect with the device/i.test(msg) || // esptool-js: no sync on the cable
+      /The port is already open|Failed to open serial port/i.test(msg)
+    );
+  }
   function tellBoard(level, message) {
     if (typeof fetch !== "function") return;
     fetch("/api/board-config")


### PR DESCRIPTION
`install.js` posted every caught error of the install flow as an `error` event, and an error event is a bug card. Two of today's cards were the person's own doing: card #153, "No port selected by the user" (the port picker was closed), and card #157, "Failed to connect with the device" (no cable, wrong port, not in the boot mode). Those are outcomes worth counting, not bugs to fix: they now post as `info` with the message, and `error` stays for the exceptions the page did not expect (the flasher throwing, a download failing, an image that does not verify).

Card #200; #153 and #157 close once this is live on the site.

**Verified**: `host-tests/site` lifts `userSide()` out of the page and runs it under node on nine shapes (four user-side, four page-side, one empty) and asserts the catch posts by that decision. Against the `install.js` on `xteink` today the check fails (no `userSide`). Site suite 145 checks green.

**Not verified**: the exact `name`/`message` esptool-js and Chrome produce for each user-side case beyond the two seen in the cards; the list is the observed two plus the Web Serial errors the spec names (NotAllowedError, SecurityError, AbortError) and the open-port message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)