### PR TITLE
fix: reserve the murdle refusal band so the grid never moves

### DIFF
--- a/docs/apps/murdle.md
+++ b/docs/apps/murdle.md
@@ -354,6 +354,16 @@ CLEAR THEM TO TICK HERE.` Changing your mind costs two more taps than it did --
 clear the old lock, then rule the new square out and lock it in -- and every one
 of them is the player's own.
 
+**The refusal has a band of its own, reserved whether it says anything or not.**
+It used to appear above the grid only when there was something to say, which
+pushed the board down the moment a tap was refused and pulled it back up on the
+next tap. On a panel that takes a second to answer, that is the one surface
+being read by position moving under the reader's finger. The band is two lines
+of the tile cut, which is the worst case `blockedLine` can produce measured
+against the real face over the whole cross product of the cast tables
+(`host-tests/murdle`); the grid is width-bound at every tier, so it pays for the
+band out of the slack the key was spreading into and loses no cell size.
+
 It used to overrule instead, and that is the worst bug this game has had. From a
 finished, correct board a cold tester tapped one false square and watched three
 squares they had never touched change: the two locks that had crossed that

--- a/host-tests/murdle/run.sh
+++ b/host-tests/murdle/run.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Builds and runs the Murdle puzzle tests. No device and no PlatformIO:
-# MurdleCore is freestanding C++17.
+# MurdleCore is freestanding C++17, and so are EpdFont and the generated cuts,
+# which is what lets the refusal notice be measured in the real face here.
 #
 #   host-tests/murdle/run.sh
 set -e
@@ -8,6 +9,14 @@ cd "$(dirname "$0")"
 BUILD_DIR="${TMPDIR:-/tmp}/$(basename "${CXX:-c++}")-murdle-tests-$(cd ../.. && pwd | cksum | cut -d" " -f1)"
 mkdir -p "$BUILD_DIR"
 SRC=../../src/apps_local/murdle
-"${CXX:-c++}" -std=c++17 -Wall -Wextra -Werror -O2 $SRC/MurdleCore.cpp $SRC/MurdleCast.cpp $SRC/MurdleText.cpp \
+# The real tile cut and the real EpdFont lookup, so the notice-band check
+# measures the face the device draws with rather than a character count. Both
+# are freestanding C++17 (host-tests/typefold compiles them the same way);
+# -Wno-missing-field-initializers is for the GENERATED font header, whose
+# aggregate stops at the last field fontconvert.py had a value for.
+"${CXX:-c++}" -std=c++17 -Wall -Wextra -Werror -Wno-missing-field-initializers -O2 \
+  -I../../lib/Utf8 -I../../lib/EpdFont -I../../src/apps_local/ui \
+  ../../lib/Utf8/Utf8.cpp ../../lib/EpdFont/EpdFont.cpp \
+  $SRC/MurdleCore.cpp $SRC/MurdleCast.cpp $SRC/MurdleText.cpp \
   test_murdle.cpp -o "$BUILD_DIR/test_murdle"
 "$BUILD_DIR/test_murdle" "$@"

--- a/host-tests/murdle/test_murdle.cpp
+++ b/host-tests/murdle/test_murdle.cpp
@@ -19,6 +19,8 @@
 // without trial and error, and a puzzle carrying four redundant clues is
 // unique, solvable, and boring.
 
+#include <EpdFont.h>
+
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -27,6 +29,7 @@
 #include "../../src/apps_local/murdle/MurdleCast.h"
 #include "../../src/apps_local/murdle/MurdleCore.h"
 #include "../../src/apps_local/murdle/MurdleText.h"
+#include "../../src/apps_local/ui/fonts/toybox_10.h"
 
 namespace {
 
@@ -988,6 +991,138 @@ void testDenialNamesTheRuledOutItem() {
 }
 
 // ---------------------------------------------------------------------------
+// The refusal notice has to fit the band the grid reserves for it
+
+// The greedy wrap MurdleScreens.cpp::paragraph() performs, restated. It is
+// restated rather than shared because that function needs FreeInkUI and a draw
+// target, and this suite deliberately has neither -- what it has instead is the
+// real font, which is the half that matters here. Two rules, and they are the
+// whole of it: words are split on spaces, and a line is kept while the
+// ASSEMBLED string (spaces included) measures no wider than the box.
+int noticeLines(const EpdFont& face, const char* text, const int boxWidth) {
+  const auto width = [&face](const char* s) {
+    int w = 0, h = 0;
+    face.getTextDimensions(s, &w, &h);
+    return w;
+  };
+  int lines = 0;
+  // The same buffer paragraph() assembles into, so a line long enough to be cut
+  // short is cut short at the same place.
+  char line[128] = {};
+  int fill = 0;
+  const char* at = text;
+  while (true) {
+    while (*at == ' ') ++at;
+    if (*at == '\0') break;
+    int n = 0;
+    while (at[n] != '\0' && at[n] != ' ') ++n;
+    const int kept = fill;
+    if (fill != 0 && fill + 1 < static_cast<int>(sizeof(line))) line[fill++] = ' ';
+    for (int i = 0; i < n && fill + 1 < static_cast<int>(sizeof(line)); ++i) line[fill++] = at[i];
+    line[fill] = '\0';
+    if (kept != 0 && width(line) > boxWidth) {
+      line[kept] = '\0';
+      ++lines;
+      fill = 0;
+      for (int i = 0; i < n && fill + 1 < static_cast<int>(sizeof(line)); ++i) line[fill++] = at[i];
+      line[fill] = '\0';
+    }
+    at += n;
+  }
+  if (fill != 0) ++lines;
+  return lines;
+}
+
+// The grid face reserves a band of exactly this many lines whether there is a
+// notice or not, so that a refused tap does not move the board. A notice that
+// needed a third line would push the grid back down, which is the bug the band
+// exists to close -- so the band is only honest while this holds.
+//
+// The measurement is over the WHOLE cross product of the cast tables rather
+// than a sample or a hand-picked longest pair, because "widest name" is a
+// pixel question and greedy wrapping is not monotone in character count. It
+// runs against the real toybox_10 cut, so a regenerated cut moves this too.
+constexpr int kNoticeLines = 2;
+// The face's body width, which is what paragraph() wraps against. Asserted
+// against the real layout by testMurdleRefusalDoesNotMoveTheGrid in
+// host-tests/ui, which reads it off a drawn run rather than restating it.
+constexpr int kNoticeBoxWidth = 448;
+
+void testEveryRefusalFitsTheReservedBand() {
+  static const EpdFont tile(&toybox_10);
+  static Scratch scratch;
+  Puzzle puzzle;
+  CHECK(makeCase(Tier::Impossible, 99u, scratch, puzzle));
+
+  // A cell is always two DIFFERENT categories, and blockedLine names one item
+  // of each on both sides of its two pairs. Driving it through `puzzle.cast`
+  // uses the real tables and the real format string, so a new fixture or a
+  // reworded message is measured without anybody editing this test.
+  murdle::TapResult refused;
+  refused.changed = false;
+  refused.sameRow = 0;
+  refused.sameCol = 1;
+
+  int worst = 0;
+  int worstOneSided = 0;
+  char line[96];
+  char longest[96] = {};
+  for (int catA = 0; catA < kMaxCats; ++catA) {
+    for (int catB = 0; catB < kMaxCats; ++catB) {
+      if (catA == catB) continue;
+      for (int a0 = 0; a0 < castSize(catA); ++a0) {
+        for (int b0 = 0; b0 < castSize(catB); ++b0) {
+          for (int a1 = 0; a1 < castSize(catA); ++a1) {
+            for (int b1 = 0; b1 < castSize(catB); ++b1) {
+              // itemA/sameCol pick the two catA names, itemB/sameRow the two
+              // catB ones. Items 0 and 1 of each category carry them.
+              puzzle.cast[catA][0] = static_cast<uint8_t>(a0);
+              puzzle.cast[catA][1] = static_cast<uint8_t>(a1);
+              puzzle.cast[catB][0] = static_cast<uint8_t>(b0);
+              puzzle.cast[catB][1] = static_cast<uint8_t>(b1);
+              murdletext::blockedLine(puzzle, catA, 0, catB, 1, refused, line, sizeof(line));
+              const int lines = noticeLines(tile, line, kNoticeBoxWidth);
+              if (lines > worst) {
+                worst = lines;
+                std::snprintf(longest, sizeof(longest), "%s", line);
+              }
+            }
+          }
+          // And the one-blocker wording, which is shorter but wraps by its own
+          // arithmetic and so is not covered by the two-blocker worst case.
+          murdle::TapResult oneSided;
+          oneSided.changed = false;
+          oneSided.sameRow = 1;
+          puzzle.cast[catA][0] = static_cast<uint8_t>(a0);
+          puzzle.cast[catB][1] = static_cast<uint8_t>(b0);
+          murdletext::blockedLine(puzzle, catA, 0, catB, 0, oneSided, line, sizeof(line));
+          const int lines = noticeLines(tile, line, kNoticeBoxWidth);
+          if (lines > worstOneSided) worstOneSided = lines;
+        }
+      }
+    }
+  }
+
+  if (worst > kNoticeLines) std::printf("  a notice needing %d lines: %s\n", worst, longest);
+  CHECK(worst > 0);
+  CHECK(worst <= kNoticeLines);
+  CHECK(worstOneSided > 0);
+  CHECK(worstOneSided <= kNoticeLines);
+
+  // And the check can fail: one line narrower than the real box and the same
+  // sweep must find something that needs a third. Without this the assertion
+  // above would also pass on a box nothing could overflow.
+  int over = 0;
+  for (int entry = 0; entry < castSize(static_cast<int>(Cat::Weapon)); ++entry) {
+    puzzle.cast[static_cast<int>(Cat::Weapon)][0] = static_cast<uint8_t>(entry);
+    murdletext::blockedLine(puzzle, static_cast<int>(Cat::Weapon), 0, static_cast<int>(Cat::Suspect), 1, refused, line,
+                            sizeof(line));
+    if (noticeLines(tile, line, kNoticeBoxWidth / 2) > kNoticeLines) ++over;
+  }
+  CHECK(over > 0);
+}
+
+// ---------------------------------------------------------------------------
 // Mutation check
 //
 // A suite that passes more easily than expected is a suite that cannot fail.
@@ -1522,6 +1657,7 @@ int runTests() {
   testStatementsDoNotGiveTheCaseAway();
   testComparativeHeightMasks();
   testDossierBiasNeverStarvesGeneration();
+  testEveryRefusalFitsTheReservedBand();
   testTheChecksCanFail();
 
   const int seedsPerTier = 400;

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -4092,6 +4092,78 @@ void testMurdleGridEdgesAreLive() {
   CHECK(!murdleui::cellAt(grid, grid.originX, grid.originY - 1, outside));
 }
 
+void testMurdleRefusalDoesNotMoveTheGrid() {
+  // Mario, 2026-09-04: the refusal line "moves the whole board which is bad
+  // UX". It did, twice over -- the band was taken out of the top of the body
+  // only when there was something to put in it, so the grid's origin dropped
+  // AND its cell was re-measured against a shorter area. On this panel that is
+  // a full refresh of the one surface being read by position.
+  //
+  // Every tier, because the cell size is the min of a width fit and a height
+  // fit and only the height fit moves: a tier that happened to be height-bound
+  // would shrink where the others do not.
+  for (const murdle::Tier tier :
+       {murdle::Tier::Elementary, murdle::Tier::Nosy, murdle::Tier::HardBoiled, murdle::Tier::Impossible}) {
+    murdle::Puzzle puzzle = murdleCase(tier, 4242u);
+    murdle::Marks marks;
+    marks.reset(puzzle.shape);
+
+    murdleui::CaseModel quiet;
+    quiet.puzzle = &puzzle;
+    quiet.marks = &marks;
+    quiet.face = murdleui::Face::Grid;
+
+    murdleui::CaseModel refused = quiet;
+    // The longest thing blockedLine can produce; see the reserved band in
+    // buildCase and the measurement in host-tests/murdle.
+    refused.notice = "ALREADY TICKED: HAMMER/REVENGE AND HAMMER/REVENGE. CLEAR THEM TO TICK HERE.";
+
+    Rendered without;
+    Rendered with;
+    const murdleui::GridLayout before = buildMurdleCase(without, quiet);
+    const murdleui::GridLayout after = buildMurdleCase(with, refused);
+
+    CHECK(before.valid && after.valid);
+    CHECK(after.originX == before.originX);
+    CHECK(after.originY == before.originY);
+    CHECK(after.cell == before.cell);
+    CHECK(after.gutter == before.gutter);
+    CHECK(after.headerH == before.headerH);
+
+    // The notice really drew, or every check above is satisfied by a screen
+    // that simply threw the message away.
+    const fui::Rect grid = fui::makeRect(after.originX, static_cast<int16_t>(after.originY - after.headerH), 1, 1);
+    int noticeRuns = 0;
+    for (const auto& run : with.target.texts) {
+      if (run.text.find("ALREADY TICKED") == std::string::npos && run.text.find("CLEAR THEM") == std::string::npos) {
+        continue;
+      }
+      ++noticeRuns;
+      // And it drew ABOVE the grid rather than over the column labels, which is
+      // the way a reserved band goes wrong that a moved origin does not.
+      CHECK(run.rect.y + run.rect.height <= grid.y);
+      // The box the wrap sees, tied to the number host-tests/murdle measures
+      // the worst-case notice against rather than written down twice. This IS
+      // the body width: paragraph() draws each line into the rect it was given.
+      CHECK(run.rect.width == 448);
+    }
+    CHECK(noticeRuns > 0);
+
+    // The quiet render says nothing in the band it reserved.
+    for (const auto& run : without.target.texts) {
+      CHECK(run.text.find("ALREADY TICKED") == std::string::npos);
+    }
+
+    // The key still gets room under the grid. The band is paid for out of that
+    // slack, so this is the check that the payment did not empty it.
+    int legendRows = 0;
+    for (const auto& run : without.target.texts) {
+      if (run.text.find('=') != std::string::npos) ++legendRows;
+    }
+    CHECK(legendRows >= puzzle.shape.cats * puzzle.shape.items);
+  }
+}
+
 void testMurdleGridDrawsMarksItIsGiven() {
   murdle::Puzzle puzzle = murdleCase(murdle::Tier::Elementary, 5u);
   murdle::Marks marks;
@@ -8727,6 +8799,7 @@ int main() {
   testTheSudokuFrontDoorNeverSharesInkBetweenTwoLines();
   testMurdleGridResolvesEveryCellItDrew();
   testMurdleGridEdgesAreLive();
+  testMurdleRefusalDoesNotMoveTheGrid();
   testMurdleGridDrawsMarksItIsGiven();
   testMurdleClueFaceIsPagedAndNeverOverflows();
   testMurdleSettingsPicksAnAbsoluteTier();

--- a/src/apps_local/murdle/MurdleScreens.cpp
+++ b/src/apps_local/murdle/MurdleScreens.cpp
@@ -664,17 +664,38 @@ CaseReport buildCase(toybox::Screen& screen, const CaseModel& model) {
   fui::Rect body = screen.body();
 
   if (model.face == Face::Grid) {
-    // The notice comes out of the grid's own room rather than the key's. The
-    // key is what the message's names have to be looked up in, so squeezing it
-    // to make space for the message would take away the thing the message
-    // sends you to -- and the grid is width-bound at three categories, so at
-    // this tier it does not shrink at all.
+    // The notice band is reserved on EVERY render of this face, empty or not,
+    // for the same reason the pager strip below is. Taking it only when there
+    // is something to say moved the grid down the moment a tap was refused and
+    // back up when the next tap cleared it, which on this panel is a full
+    // refresh of the one surface the player is reading by position. It also
+    // re-measured the cell against a shorter area, which every tier survived
+    // only because every tier is width-bound today.
+    //
+    // The band comes out of the grid's own room rather than the key's. The key
+    // is what the message's names have to be looked up in, so squeezing it to
+    // make space for the message would take away the thing the message sends
+    // you to -- and the grid is width-bound at every tier, so it loses no cell
+    // size to this, only the slack the key was spreading into.
+    //
+    // TWO LINES, measured rather than chosen. blockedLine's longest form is
+    // "ALREADY TICKED: <A>/<B> AND <A>/<B>. CLEAR THEM TO TICK HERE." with
+    // every name out of the MurdleCast tables; taken to the real tile cut at
+    // this face's 448px body the widest of those is 710px, which the greedy
+    // wrap in paragraph() breaks into two lines and never three.
+    // host-tests/murdle measures the whole cross product against the font
+    // itself, so a longer fixture name fails a suite rather than quietly
+    // pushing the grid down again.
+    constexpr int kNoticeLines = 2;
+    const int16_t noticeH = static_cast<int16_t>(screen.target().lineHeight(toybox::kTileFont) * kNoticeLines + 8);
+    // Top of the band, not centred in it: a one-line refusal and a two-line one
+    // then start on the same row, which is the same rule one level down.
     if (model.notice != nullptr && model.notice[0] != '\0') {
-      const int16_t used =
-          paragraph(screen, styled(toybox::kTileFont, fui::TextAlign::Center), model.notice, body, true);
-      body = fui::makeRect(body.x, static_cast<int16_t>(body.y + used + 8), body.width,
-                           static_cast<int16_t>(body.height - used - 8));
+      paragraph(screen, styled(toybox::kTileFont, fui::TextAlign::Center), model.notice,
+                fui::makeRect(body.x, body.y, body.width, noticeH), true);
     }
+    body = fui::makeRect(body.x, static_cast<int16_t>(body.y + noticeH), body.width,
+                         static_cast<int16_t>(body.height - noticeH));
     layout = layoutGrid(screen, puzzle, body);
     drawGrid(screen, puzzle, *model.marks, layout);
     screen.frame().hit(fui::makeRect(static_cast<int16_t>(layout.originX - layout.gutter),

--- a/src/apps_local/murdle/MurdleScreens.h
+++ b/src/apps_local/murdle/MurdleScreens.h
@@ -113,10 +113,11 @@ struct CaseModel {
   uint32_t struck = 0;  // one bit per clue, a reading aid only
   int caseNumber = 1;
   bool solved = false;
-  // One line above the grid, or null. The only thing that puts one there is a
-  // tap this board refused, and it has to say so: on a panel that takes a
-  // second to answer, a tap that changes nothing and says nothing is
-  // indistinguishable from a tap that was missed.
+  // What to say in the band above the grid, or null. The only thing that puts
+  // something there is a tap this board refused, and it has to say so: on a
+  // panel that takes a second to answer, a tap that changes nothing and says
+  // nothing is indistinguishable from a tap that was missed. The band itself is
+  // reserved whether this is set or not, so the grid never moves; see buildCase.
   const char* notice = nullptr;
 };
 


### PR DESCRIPTION
Mario: the Murdle refusal line *"moves the whole board which is bad UX"*.

It did. On the grid face the notice band was taken out of the top of the body
**only when there was something to put in it**, so a refused tap dropped the
grid, its labels, the key and everything under them by one wrapped paragraph,
and the next tap put them all back. On a panel that takes about a second to
answer, that is a full refresh of the one surface a player reads by position.

## The evidence, as numbers

Simulator A/B, the same case with the same marks, compared row by row (images
are 2x logical):

| | first differing row | first differing row at or below the grid (image y=324) |
|---|---|---|
| **before** | 225 | **325** — and it keeps diverging to the bottom of the panel |
| **after** | 231 | **none** — byte-identical from row 324 down |

So before the fix the grid, its labels, the key and the ACCUSE button all move.
After it, the two frames differ *only inside the band*. That is the whole claim
and it is checkable: `qa-artifacts/before-quiet.png` / `before-notice.png` and
`after-quiet.png` / `after-notice-oneline.png`.

## The fix

The band is reserved on **every** render of the grid face, empty or not. That is
the rule the pager strip on the clue face already states and explains, applied
one face across: a few pixels of honest waste beats the board jumping.

It is taken from the top of the body **before** `layoutGrid` measures, so the
origin and the cell come out the same either way. The notice draws at the top of
the band rather than centred in it, so a one-line refusal and a two-line one
start on the same row.

## 50px, and where the number comes from

The height is `lineHeight(kTileFont) * 2 + 8`, **computed at runtime from the
bound font rather than hardcoded** — 50px on device today, and it follows the
cut if the cut ever moves. A layout that reserves a constant number of pixels
for wrapped text is correct at one metric and wrong at every other.

The **two lines** is measured, not chosen. `blockedLine`'s longest form is
`ALREADY TICKED: <A>/<B> AND <A>/<B>. CLEAR THEM TO TICK HERE.` with every name
out of the `MurdleCast` tables. `host-tests/murdle` now compiles the real
`toybox_10` cut and the real `EpdFont` lookup (freestanding, the way
`host-tests/typefold` already does) and drives the real `blockedLine` over the
**whole cross product of the real cast tables** through `puzzle.cast`.

**The worst case actually measured is `HAMMER/REVENGE` twice over, at 710px
against a 448px body** — which the greedy wrap in `paragraph()` breaks into two
lines and never three. Because the sweep reads the tables rather than a copy of
them, a longer fixture name in some future case **fails that suite** instead of
silently reflowing the board again. The 448 is not written down twice:
`host-tests/ui` reads it off a drawn run and asserts it.

## Considered and rejected

- **Below the grid.** Honestly the better geometry: the grid would not move at
  all, and the key pays the same 50px either way. Rejected on where hands go —
  the bottom of the panel is where the tapping hand and ACCUSE are, and a
  message drawn there is the most likely thing on the screen to be under a
  thumb. The strip under the header is the one place a hand never is. It is also
  a second change Mario did not ask for.
- **Over the grid.** E-ink has no transient overlay, and it would cover the very
  squares the message names.
- **Blank when quiet, deliberately.** Putting something permanent in the band to
  fill it would be inventing a feature to justify a gap.

## Cost, stated plainly

The key loses 50px of the ~160px of slack it was spreading into: rows go from
33px to 25px at four categories, where the icon is 24. It still clears its
minimum and a test asserts every entry still draws.

The empty reserved band is **permanent and clearly visible** as a gap under the
header when there is nothing to say. It reads as breathing room rather than as a
fault, but it is the honest price of the grid never moving, and it is the part
of this change most worth reversing if it looks wrong on a device.

## Verification

- `host-tests/ui`: `testMurdleRefusalDoesNotMoveTheGrid` asserts origin, cell,
  gutter and header height are identical with and without a notice at all four
  tiers, that the notice drew, that it drew above the grid, and that the key
  still draws every entry. **Watched go red** with the fix reverted (`originY`,
  four tiers), and the revert confirmed to have changed the file first — a no-op
  revert reads exactly like a pass.
- `host-tests/murdle`: `testEveryRefusalFitsTheReservedBand`, **watched go red**
  at `kNoticeLines = 1`. It carries its own mutation check, so a box nothing
  could overflow cannot pass it.
- `./scripts_local/check.sh --committed --tests` → `verifying HEAD (53ceb8b0)`,
  verdict `all green`. It also warns that `site/emulator/` is stale, which CI
  rebuilds after merge.

## Not verified

**Nothing here has been on hardware.** The four-category key at its new 25px row
pitch has been seen in the simulator only (`qa-artifacts/hb-grid.png`): four
rows, icons distinct, letters clear, no collision with the grid above or ACCUSE
below.
