### PR TITLE
fix(tests): the postgres readiness probe answers for the wrong server

### DIFF
--- a/host-tests/boardmigrate/run.sh
+++ b/host-tests/boardmigrate/run.sh
@@ -32,8 +32,27 @@ CID="$(docker run --rm -d -e POSTGRES_PASSWORD=x -e POSTGRES_DB=board "$IMAGE" -
 trap 'docker rm -f "$CID" >/dev/null 2>&1; rm -rf "$WORK"' EXIT
 # Two minutes: a GitHub runner took more than the 30 seconds this first
 # allowed (relwatch allows 60), and the failure said only "never came up".
-for _ in $(seq 1 120); do docker exec "$CID" pg_isready -U postgres -d board >/dev/null 2>&1 && break; sleep 1; done
-if ! docker exec "$CID" pg_isready -U postgres -d board >/dev/null 2>&1; then
+# -h 127.0.0.1, and that one flag is the whole fix.
+#
+# postgres's docker-entrypoint runs initdb against a TEMPORARY server before
+# restarting the real one, and it starts that server with `listen_addresses=''`
+# (docker-entrypoint.sh:297) -- Unix socket only, no TCP, by construction. A
+# bare `pg_isready` talks to that socket, so it answers YES to the init server,
+# the loop below breaks after a second or two, and the identical check behind
+# it then runs inside the restart window and fails. The container log in every
+# such failure is the same three lines: `database "board" does not exist`, then
+# `CREATE DATABASE`, then `waiting for server to shut down`.
+#
+# Probing TCP cannot see the init server at all, so the loop breaks only when
+# the real server is up. Confirmed in the image: the init server logs one
+# `listening on` line (Unix socket); the real one logs three (IPv4, IPv6,
+# socket).
+#
+# This is not the timeout being too short. The failure that prompted the fix
+# printed "never came up in 120s" 4.9 seconds after the previous suite's last
+# line -- a 120-iteration loop with `sleep 1` had not run.
+for _ in $(seq 1 120); do docker exec "$CID" pg_isready -h 127.0.0.1 -U postgres -d board >/dev/null 2>&1 && break; sleep 1; done
+if ! docker exec "$CID" pg_isready -h 127.0.0.1 -U postgres -d board >/dev/null 2>&1; then
   echo "FAIL boardmigrate  postgres never came up in 120s; its last lines:"
   docker logs --tail 15 "$CID" 2>&1 | sed 's/^/  /'
   exit 1

--- a/host-tests/relwatch/run.sh
+++ b/host-tests/relwatch/run.sh
@@ -62,10 +62,29 @@ psql() { docker exec -i "$CID" psql -U postgres -d board -v ON_ERROR_STOP=1 -qtA
 # red build on a pull request whose diff cannot touch a database, which is
 # what this has already done twice.
 for _ in $(seq 1 420); do
-  docker exec "$CID" pg_isready -U postgres -d board >/dev/null 2>&1 && break
+# -h 127.0.0.1, and that one flag is the whole fix.
+#
+# postgres's docker-entrypoint runs initdb against a TEMPORARY server before
+# restarting the real one, and it starts that server with `listen_addresses=''`
+# (docker-entrypoint.sh:297) -- Unix socket only, no TCP, by construction. A
+# bare `pg_isready` talks to that socket, so it answers YES to the init server,
+# the loop below breaks after a second or two, and the identical check behind
+# it then runs inside the restart window and fails. The container log in every
+# such failure is the same three lines: `database "board" does not exist`, then
+# `CREATE DATABASE`, then `waiting for server to shut down`.
+#
+# Probing TCP cannot see the init server at all, so the loop breaks only when
+# the real server is up. Confirmed in the image: the init server logs one
+# `listening on` line (Unix socket); the real one logs three (IPv4, IPv6,
+# socket).
+#
+# This is not the timeout being too short. The failure that prompted the fix
+# printed "never came up in 120s" 4.9 seconds after the previous suite's last
+# line -- a 120-iteration loop with `sleep 1` had not run.
+  docker exec "$CID" pg_isready -h 127.0.0.1 -U postgres -d board >/dev/null 2>&1 && break
   sleep 1
 done
-if ! docker exec "$CID" pg_isready -U postgres -d board >/dev/null 2>&1; then
+if ! docker exec "$CID" pg_isready -h 127.0.0.1 -U postgres -d board >/dev/null 2>&1; then
   # Say WHY. "never came up" names no cause, and the next person to read it is
   # looking at a red build on an unrelated diff with nothing to go on.
   echo "FAIL relwatch  postgres never came up within 420s; its own log follows"


### PR DESCRIPTION
`host-tests/relwatch` and `host-tests/boardmigrate` fail intermittently in CI on
diffs that cannot touch a database. Both blocked PR #74: `boardmigrate` on one
run, `relwatch` on the next, same signature. Board card #203.

## The message misdirects

    FAIL boardmigrate  postgres never came up in 120s

printed **4.9 seconds** after the previous suite's last line. A
`for _ in $(seq 1 120)` loop with `sleep 1` had not run. It did not time out --
it broke early, and the check behind it failed.

## The race

postgres's `docker-entrypoint.sh` runs `initdb` against a **temporary** server
before restarting the real one, and starts it with `listen_addresses=''`
(`docker-entrypoint.sh:297`) -- Unix socket only, **no TCP, by construction**.

A bare `pg_isready` talks to that socket, so it answers YES to the init server.
The loop breaks after a second or two, and the identical check on the next line
runs inside the restart window. Every failure logs the same three lines:

    FATAL: database "board" does not exist    <- probe hit the init server
    CREATE DATABASE
    waiting for server to shut down...        <- the restart it fell into

## The fix

`-h 127.0.0.1` on both probes. TCP cannot reach the init server at all, so the
loop breaks only once the real server is listening.

## Demonstrated, not inferred

Sampling could not reproduce it -- this machine finishes init before the first
`docker exec` returns -- so the window was widened with a sleeping
`/docker-entrypoint-initdb.d` script. Inside it:

```
bare pg_isready         : /var/run/postgresql:5432 - accepting connections   <- the bug
pg_isready -h 127.0.0.1 : 127.0.0.1:5432 - no response                       <- the fix waits
"listening on" lines    : 1   (socket only)
```

After the real server starts, both say accepting and there are 4 `listening on`
lines (IPv4, IPv6, socket).

## A repair placed where it could not run

`boardmigrate` had already diagnosed this in a comment -- *"the image answers
pg_isready during its first-run initialisation, then restarts the server once;
the first real connection can land in that gap"* -- and put its mitigation, a
`select 1` loop, **after** the check the race breaks. It stays as
belt-and-braces now that the gate itself is sound.

## What this does not do

Neither timeout is touched. 420s and 120s were both raised while chasing this,
and neither was ever reached. Both suites pass locally with the fix
(`boardmigrate` 16/16, `relwatch` 64/64).

Closes #203.