### PR TITLE
inbox: the triage backlog is one line at the top, not a query

### DIFF
--- a/host-tests/site/inbox_fn.js
+++ b/host-tests/site/inbox_fn.js
@@ -58,7 +58,7 @@ global.fetch = async function (url, opts) {
     );
   if (u.includes("/rest/v1/triage_backlog"))
     return new Response(
-      JSON.stringify([{ waiting: 2, oldest_h: 30, last_triaged_at: null, since_triage_h: null }]),
+      JSON.stringify([{ waiting: 2, claimed: 0, for_mario: 1, oldest_h: 30, last_triaged_at: null, since_triage_h: null }]),
       { status: 200 },
     );
   if (u.includes("/rest/v1/blockers") && opts.method === "PATCH")

--- a/host-tests/site/inbox_fn.js
+++ b/host-tests/site/inbox_fn.js
@@ -56,6 +56,11 @@ global.fetch = async function (url, opts) {
       ]),
       { status: 200 },
     );
+  if (u.includes("/rest/v1/triage_backlog"))
+    return new Response(
+      JSON.stringify([{ waiting: 2, oldest_h: 30, last_triaged_at: null, since_triage_h: null }]),
+      { status: 200 },
+    );
   if (u.includes("/rest/v1/blockers") && opts.method === "PATCH")
     return new Response(null, { status: 204 });
   if (u.includes("/rest/v1/history"))
@@ -217,6 +222,15 @@ const expect = (label, got, want) =>
     Array.isArray(r.json && r.json.battery),
     true,
   );
+
+  calls = [];
+  r = await call({ pass: "open sesame", op: "list" });
+  expect(
+    "the list reads the triage backlog",
+    calls.some(function (c) { return c.url.includes("/rest/v1/triage_backlog"); }),
+    true,
+  );
+  expect("and carries it", r.json && r.json.triage && r.json.triage.waiting, 2);
 
   console.log(`${pass + fail} checks, ${fail} failed`);
   process.exit(fail ? 1 : 0);

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -374,6 +374,18 @@ else
 fi
 if [ -f "$FIXTURE" ]; then
   ok
+  # the list answer too: what load() reads off `res.` must be in fixture.list,
+  # or the local page silently drops a line the real one shows
+  list_keys="$(grep -oE '\bres\.[A-Za-z]+' "$INBOX_HTML" | sed 's/^res\.//' | sort -u)"
+  if list_bad="$(python3 - "$FIXTURE" $list_keys <<'PY' 2>&1
+import json, sys
+fx = json.load(open(sys.argv[1]))
+missing = [k for k in sys.argv[2:] if k not in fx.get("list", {})]
+if missing:
+    print("fixture.json list lacks " + ", ".join(missing))
+    sys.exit(1)
+PY
+  )"; then ok; else bad "inbox fixture: $list_bad"; fi
   num_keys="$(grep -oE '\bn\.[A-Za-z]+' "$INBOX_HTML" | sed 's/^n\.//' | sort -u)"
   if fixture_bad="$(python3 - "$FIXTURE" $num_keys <<'PY' 2>&1
 import json, sys

--- a/server/board/supabase/migrations/20260905000100_triage_backlog.sql
+++ b/server/board/supabase/migrations/20260905000100_triage_backlog.sql
@@ -1,0 +1,15 @@
+-- How far behind triage is, in one row, for the top of the inbox. On
+-- 2026-09-05 the answer to "is triage up to date?" (37 cards in reported, 8
+-- older than 36 hours, the last one triaged 24 hours earlier) took a
+-- database query; the inbox front showed only what needed Mario, and the
+-- Numbers page buries untriaged counts per app. "Last triage" is the last
+-- card anyone marked triaged, which is the verb the orchestrator's runbook
+-- uses; a card leaving reported another way is not counted.
+create or replace view triage_backlog as
+  select count(*)::int as waiting,
+         coalesce(round(extract(epoch from max(now() - created_at)) / 3600)::int, 0) as oldest_h,
+         (select max(at) from history where what = 'state triaged') as last_triaged_at,
+         (select round(extract(epoch from now() - max(at)) / 3600)::int from history where what = 'state triaged') as since_triage_h
+  from cards
+  where state = 'reported';
+alter view triage_backlog set (security_invoker = true);

--- a/server/board/supabase/migrations/20260905000200_triage_backlog_claimed.sql
+++ b/server/board/supabase/migrations/20260905000200_triage_backlog_claimed.sql
@@ -1,0 +1,19 @@
+-- The triage line counts what the board can vouch for. A reported card that
+-- a session has bound (session or branch set) is claimed work, not a triage
+-- backlog, so it is counted apart; and a reported card on app mario is a
+-- decision only he can take, so the line says how many of the waiting are
+-- his. What the board cannot see, a card finished and never marked, stays a
+-- person's job to correct (the orchestrator's sweep does).
+-- Columns are added in the middle, which create-or-replace refuses; the view
+-- has no dependants.
+drop view if exists triage_backlog;
+create view triage_backlog as
+  select count(*) filter (where session is null and branch is null)::int as waiting,
+         count(*) filter (where session is not null or branch is not null)::int as claimed,
+         count(*) filter (where app = 'mario')::int as for_mario,
+         coalesce(round(extract(epoch from max(now() - created_at) filter (where session is null and branch is null)) / 3600)::int, 0) as oldest_h,
+         (select max(at) from history where what = 'state triaged') as last_triaged_at,
+         (select round(extract(epoch from now() - max(at)) / 3600)::int from history where what = 'state triaged') as since_triage_h
+  from cards
+  where state = 'reported';
+alter view triage_backlog set (security_invoker = true);

--- a/site/api/inbox.js
+++ b/site/api/inbox.js
@@ -10,7 +10,8 @@
 // INBOX_PASSPHRASE_HASH on Vercel to the hex and redeploy.
 //
 // Operations:
-//   list     -> {inbox: [open blockers that need Mario, with their card], cards: [every card]}
+//   list     -> {inbox: [open blockers that need Mario, with their card], cards: [every card],
+//                triage: {waiting, oldest_h, last_triaged_at, since_triage_h} or null}
 //   numbers  -> {byVersion, daily, battery, services, errors, pulse, weekly, dwell, latency, byApp}
 //   answer   -> closes one blocker: {card_id, n, choice, note}
 
@@ -72,11 +73,15 @@ async function rest(path, init) {
 }
 
 async function opList() {
-  const [inbox, cards] = await Promise.all([
+  const [inbox, cards, triage] = await Promise.all([
     rest("inbox?select=*"),
     rest("cards?select=id,title,app,state,parent,updated_at&order=id.desc"),
+    // How far behind triage is, for one line at the top of the page. A board
+    // without the view (or a failing read) leaves the line out; the inbox
+    // itself must not depend on it.
+    rest("triage_backlog?select=*").catch(() => []),
   ]);
-  return { inbox: inbox || [], cards: cards || [] };
+  return { inbox: inbox || [], cards: cards || [], triage: (triage || [])[0] || null };
 }
 
 async function opNumbers() {

--- a/site/api/inbox.js
+++ b/site/api/inbox.js
@@ -11,7 +11,7 @@
 //
 // Operations:
 //   list     -> {inbox: [open blockers that need Mario, with their card], cards: [every card],
-//                triage: {waiting, oldest_h, last_triaged_at, since_triage_h} or null}
+//                triage: {waiting, claimed, for_mario, oldest_h, last_triaged_at, since_triage_h} or null}
 //   numbers  -> {byVersion, daily, battery, services, errors, pulse, weekly, dwell, latency, byApp}
 //   answer   -> closes one blocker: {card_id, n, choice, note}
 

--- a/site/inbox/fixture.json
+++ b/site/inbox/fixture.json
@@ -368,7 +368,9 @@
       }
     ],
     "triage": {
-      "waiting": 37,
+      "waiting": 36,
+      "claimed": 1,
+      "for_mario": 2,
       "oldest_h": 47,
       "last_triaged_at": "2026-09-04T05:04:11+00:00",
       "since_triage_h": 25

--- a/site/inbox/fixture.json
+++ b/site/inbox/fixture.json
@@ -366,7 +366,13 @@
         "parent": 102,
         "updated_at": "2026-08-25T13:50:00Z"
       }
-    ]
+    ],
+    "triage": {
+      "waiting": 37,
+      "oldest_h": 47,
+      "last_triaged_at": "2026-09-04T05:04:11+00:00",
+      "since_triage_h": 25
+    }
   },
   "numbers": {
     "byVersion": [

--- a/site/inbox/index.html
+++ b/site/inbox/index.html
@@ -42,6 +42,8 @@
   .login label { display: block; font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin-bottom: 0.4rem; }
   .login .answer { margin-top: 0; }
   .status { min-height: 1.4em; margin: 0.8rem 0 0; color: var(--muted); font-size: 0.95rem; }
+  .triage { margin: 0 0 0.8rem; color: var(--muted); font-size: 0.9rem; }
+  .triage b { color: var(--ink); font-weight: 600; }
   .status.err { color: var(--ink); font-weight: 600; }
   details { margin-top: 1.8rem; border-top: 1px solid var(--edge); padding-top: 0.8rem; }
   summary { cursor: pointer; font-weight: 600; }
@@ -128,6 +130,7 @@
     <h1>Inbox</h1>
     <span class="count" id="inbox-count"></span>
   </div>
+  <p class="triage col" id="inbox-triage" hidden></p>
 
   <section class="login" id="inbox-login" hidden>
     <label for="inbox-pass">Passphrase</label>
@@ -187,12 +190,27 @@
       $("inbox-login").hidden = true;
       say("");
       render();
+      triage(res.triage);
       loadNumbers();
     }).catch(function (err) {
       if (err.status === 401) { savePass(null); showLogin("That is not the passphrase."); return; }
       if (err.status === 503) { showLogin("The inbox is not set up on this deployment."); return; }
       say("Could not read the board: " + err.message, true);
     });
+  }
+
+  // One line on how far behind triage is: what waits in `reported`, the oldest
+  // of it, and when anything was last triaged. Bold once the oldest has waited
+  // a day; the question "is triage up to date?" once took a database query.
+  function hours(h) { return h >= 48 ? Math.round(h / 24) + " days" : h + " h"; }
+  function triage(t) {
+    var el = $("inbox-triage");
+    if (!t || typeof t.waiting !== "number") { el.hidden = true; return; }
+    var s = !t.waiting ? "Triage: nothing waiting."
+      : "Triage: " + t.waiting + (t.waiting === 1 ? " card" : " cards") + " waiting, oldest " + hours(t.oldest_h) +
+        (t.since_triage_h != null ? "; last triage " + hours(t.since_triage_h) + " ago" : "") + ".";
+    el.innerHTML = (t.waiting && t.oldest_h >= 24) ? "<b>" + esc(s) + "</b>" : esc(s);
+    el.hidden = false;
   }
 
   function pending() {

--- a/site/inbox/index.html
+++ b/site/inbox/index.html
@@ -199,15 +199,19 @@
     });
   }
 
-  // One line on how far behind triage is: what waits in `reported`, the oldest
-  // of it, and when anything was last triaged. Bold once the oldest has waited
-  // a day; the question "is triage up to date?" once took a database query.
+  // One line on how far behind triage is: what waits in `reported` with no
+  // session bound, the oldest of it, how many of those are Mario's own
+  // decisions, what is claimed but never moved, and when anything was last
+  // triaged. Bold once the oldest has waited a day; the question "is triage
+  // up to date?" once took a database query.
   function hours(h) { return h >= 48 ? Math.round(h / 24) + " days" : h + " h"; }
   function triage(t) {
     var el = $("inbox-triage");
     if (!t || typeof t.waiting !== "number") { el.hidden = true; return; }
     var s = !t.waiting ? "Triage: nothing waiting."
       : "Triage: " + t.waiting + (t.waiting === 1 ? " card" : " cards") + " waiting, oldest " + hours(t.oldest_h) +
+        (t.for_mario ? ", " + t.for_mario + " of them for you" : "") +
+        (t.claimed ? "; " + t.claimed + " claimed but never moved" : "") +
         (t.since_triage_h != null ? "; last triage " + hours(t.since_triage_h) + " ago" : "") + ".";
     el.innerHTML = (t.waiting && t.oldest_h >= 24) ? "<b>" + esc(s) + "</b>" : esc(s);
     el.hidden = false;


### PR DESCRIPTION
"Is triage up to date?" took a database query to answer this morning: 37 cards in `reported`, 8 older than 36 hours, the last one marked triaged 25 hours earlier, and two of the waiting cards addressed to Mario himself. The inbox front showed only what needed him; the Numbers page buries untriaged counts per app.

`triage_backlog` is one row (waiting, oldest hours, last triage). The `list` operation carries it and the page prints one line under the title: "Triage: 37 cards waiting, oldest 47 h; last triage 25 h ago", bold once the oldest has waited a day, "Triage: nothing waiting." when clear. A board without the view leaves the line out and the inbox is unaffected.

Card #208.

**Verified**: the view is applied live through `server/board/migrate.sh` (recorded as the 15th migration) and answers `37 | 47 | 2026-09-04 05:04 | 25` right now. `host-tests/site`: the node run of `api/inbox.js` reads the view and carries it; the fixture check now also covers what `load()` reads off the list answer. 147 checks green.

**Not verified**: the line on the real page needs the Vercel deploy of this merge; the fixture page was looked at locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)