### PR TITLE
The GitHub sweep is a command in the tick, not a claim in a heading

### DIFF
--- a/docs/workflow/orchestrator.md
+++ b/docs/workflow/orchestrator.md
@@ -8,7 +8,9 @@ a compaction or a restart it reads both and continues.
 
 Every tick (a `/loop`, twenty to thirty minutes), in this order:
 
-1. **Read.** `board list --open`. For each card with a bound branch, `board
+1. **Read.** `board list --open`, then `board issues` (or `board tick`, which
+   is both). Nothing else fetches a GitHub issue: it is pulled by that
+   command or it never arrives. For each card with a bound branch, `board
 show <id>` derives what git and GitHub say (commits ahead, dirty files, PR
    state). Move states from facts: a PR open is `review`, merged is `merged`,
    a tag containing the merge is `released`.
@@ -47,14 +49,14 @@ integrator --session <your id>`) only while you resolve a conflict or
    outlives its card. Once a tick, `./scripts/wt.sh prune`: it drops every
    tree that is merged, clean and idle, and nothing else; a tree it keeps
    has work in it, and that work has a card or needs one.
-7. **Cards that arrive by themselves.** Three kinds need no dispatcher:
-   `source: error` (an error event opened it; the count on the card's
-   fingerprint says how often; treat it as a bug owned by the service it
-   names), `source: github` (from `board issues`, run every tick; when its
-   card is released, `board issues --close-released` closes the issue with
-   a comment), and `source: site` (a stranger's report; triage it like an
-   internal one, and if it needs a reply the reporter's email is on the
-   card for Mario, never for you).
+7. **Cards nobody dispatched.** Two arrive by themselves; GitHub is a command
+   you run. Pushed: `source: error` (an error event opened it; the count on
+   the card's fingerprint says how often; treat it as a bug owned by the
+   service it names) and `source: site` (a stranger's report; triage it like
+   an internal one, and if it needs a reply the reporter's email is on the
+   card for Mario, never for you). Pulled: `source: github` exists only
+   because you typed `board issues` in step 1, and closing is manual too,
+   `board issues --close-released` once a card is released.
 8. **Upstream.** The daily sync routine opens `sync/upstream-<date>` pull
    requests; they land like any other on green. A sync that stopped on a
    conflict of intent leaves a pushed branch and a card: yours to resolve

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -174,6 +174,47 @@ board issues --from-json "$WORK/issues.json" | grep -q "2 new card" && ok "open 
 board issues --from-json "$WORK/issues.json" | grep -q "0 new card" && ok "a second sweep makes no duplicates" || bad "issues sweep duplicated cards"
 board list | grep -q "reader .*Slow Reader" && ok "an issue about page turns lands on the reader" || bad "reader issue not routed to reader"
 board list | grep -q "sudoku .*Sudoku loses my puzzle" && ok "an issue names its app from the owners" || bad "sudoku issue not routed to sudoku"
+
+# Every assertion above hands the sweep a file, so the branch that actually
+# runs in production -- shelling out to `gh` -- had never been executed by a
+# test. A stub `gh` on PATH exercises it and records what it was asked.
+echo "the github sweep, through gh itself"
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/gh" <<'SH'
+#!/bin/bash
+printf '%s\n' "$*" >> "$GH_LOG"
+[ "$2" = "list" ] && cat "$GH_ISSUES" || echo "closed"
+SH
+chmod +x "$WORK/bin/gh"
+export GH_LOG="$WORK/gh.log" GH_ISSUES="$WORK/live.json"
+# A subshell, not a `PATH=... board ...` prefix: bash 3.2 (which is /bin/bash
+# here) leaves an assignment made in front of a *function* call set afterwards,
+# and the stub gh would then serve the rest of the suite.
+ghboard() { ( PATH="$WORK/bin:$PATH"; python3 "$BOARD" "$@" ); }
+cat > "$WORK/live.json" <<'JSON'
+[{"number":31,"title":"Checkers drops the ninth capture in a chain","body":"uint8_t[3]","labels":[{"name":"bug"}],"url":"https://github.com/ma-r-s/crossplay/issues/31","author":{"login":"stranger"}}]
+JSON
+SWEEP=$(ghboard issues)
+grep -q "issue #31" <<< "$SWEEP" && ok "a sweep with no --from-json shells out to gh" || bad "the live gh path made no card: $SWEEP"
+GID=$(sed -n 's/^#\([0-9]*\) <- issue #31.*/\1/p' <<< "$SWEEP")
+grep -q -- "--state open" "$GH_LOG" && ok "it asks gh for open issues only" || bad "gh was not asked for open issues: $(cat "$GH_LOG")"
+ghboard issues | grep -q "0 new card" && ok "the live path dedupes on a second sweep" || bad "the live path duplicated a card"
+ghboard tick | grep -q "0 new card" && ok "tick sweeps and then lists" || bad "tick did not sweep"
+ghboard tick | grep -q "#$GID " && ok "tick prints the open board after the sweep" || bad "tick printed no board"
+
+# --close-released had no test at all: the half of the flow that reaches out
+# and changes something on GitHub was the untested half.
+echo "a released card closes its issue"
+board state "$GID" released >/dev/null
+: > "$GH_LOG"
+ghboard issues --close-released | grep -q "1 issue(s) closed" && ok "a released card closes its GitHub issue" || bad "close-released closed nothing"
+grep -q "issue close 31 " "$GH_LOG" && ok "it closes the issue its card came from" || bad "close-released named the wrong issue: $(cat "$GH_LOG")"
+grep -q -- "--comment" "$GH_LOG" && ok "the close carries a comment" || bad "the issue was closed silently"
+board show "$GID" | grep -q "closed GitHub issue #31" && ok "the close is recorded on the card" || bad "the close left no history"
+: > "$GH_LOG"
+ghboard tick | grep -q "close 31" && bad "tick closed an issue" || ok "tick never closes anything"
+board state "$GID" triaged >/dev/null
+
 PID=$(board new "Analytics everywhere" --from tooling | sed 's/^#\([0-9]*\).*/\1/')
 KID=$(board new "Firmware heartbeat" --from firmware --parent "$PID" | sed 's/^#\([0-9]*\).*/\1/')
 board parent "$CID" --of "$PID" >/dev/null

--- a/tools_local/board/board.py
+++ b/tools_local/board/board.py
@@ -30,6 +30,7 @@ file store so the hooks never need the network.
     board state <id> reported|triaged|working|review|merged|released|done|parked
     board owner <app> [--session <sid>] [--tree wt/x]  who owns an app (lookup with no flags)
     board route <id>                                   which session a card goes to
+    board tick                                         the issue sweep, then the open board
     board show <id> | board list [--open] | board inbox | board import <file.md>
     board sync                                         copy the file store into Supabase, once
 
@@ -1063,6 +1064,17 @@ def cmd_issues(st, a):
     print(f"board: {made} new card(s) from issues, {closed} issue(s) closed")
 
 
+def cmd_tick(st, a):
+    """A tick's read in one command: sweep GitHub for new issues, then the open board.
+
+    Never closes an issue. Closing stays a command typed on purpose.
+    """
+    ns = argparse.Namespace(repo=a.repo, from_json=a.from_json, close_released=False)
+    cmd_issues(st, ns)
+    print()
+    cmd_list(st, argparse.Namespace(open=True))
+
+
 def cmd_sync(st, a):
     """Copy the file store into Supabase, keeping ids. Run once, then the file store is only a mirror."""
     if not isinstance(st, SupaStore):
@@ -1205,6 +1217,10 @@ def main(argv=None):
     s.add_argument("--from-json")
     s.add_argument("--close-released", action="store_true")
     s.set_defaults(fn=cmd_issues)
+    s = sub.add_parser("tick", help="the issue sweep, then the open board")
+    s.add_argument("--repo", default="ma-r-s/crossplay")
+    s.add_argument("--from-json")
+    s.set_defaults(fn=cmd_tick)
 
     a = p.parse_args(argv)
     st = open_store(find_root())


### PR DESCRIPTION
`board issues` was invoked nowhere. Two greps hit it: prose in
`docs/workflow/orchestrator.md`, and `host-tests/bugflow/run.sh`, which always
passes `--from-json`. It ran once, on 2026-09-03, printed "0 new card(s) from
issues, 0 issue(s) closed", and has not run since.

The code was never the problem. A read-only dry run against the live store and
live `gh` fetched the one open issue, correctly skipped #7 as already on card
#13, and would have created nothing.

**The cause is the heading.** Step 7 read *"Cards that arrive by themselves.
Three kinds need no dispatcher"* and listed `error`, `github` and `site`
together. Two of those really are push (a Postgres BEFORE INSERT trigger, and
`site/api/report.js`). `github` is the only pull, and it sat in a parenthetical
under a heading that told the reader nothing was required of them.

## What changed

- **The sweep moves into the numbered tick list**, next to step 1's
  `board list --open`, so it rides the pass that already happens.
- **Step 7 stops claiming all three are automatic.** Pushed and Pulled are now
  separate sentences, and closing is named as manual.
- **`board tick`** runs the sweep and then the open board, 16 lines. It
  hardcodes `close_released=False`, so it can never close an issue.

No cron, no scheduled task, no workflow. Issue #7 stays open, and closing stays
a command typed on purpose (`board issues --close-released`).

## Two paths that had never been executed by a test

- **The subprocess branch.** Every existing assertion hands the sweep a JSON
  file, so the branch that runs in production had no coverage. A stub `gh` on
  PATH now exercises it and records what it was asked for.
- **`--close-released`,** which had no test at all. The half of the flow that
  reaches out and changes something on GitHub was the untested half.

Each was watched go red, and each mutant confirmed to have changed its file:

| break | result |
| --- | --- |
| `issues = []` in place of the gh stdout parse | 6 failures, led by "the live gh path made no card" |
| `--state open` -> `--state all` in the gh argv | 1 failure, "gh was not asked for open issues" |
| close filter `("released", "done")` -> `("shipped",)` | 4 failures, led by "close-released closed nothing"; the sweep assertions stayed green |

The last one is the point: the two halves fail independently.

The stub is reached through a `ghboard()` subshell, not a `PATH=... board`
prefix. `/bin/bash` here is 3.2, where an assignment in front of a *function*
call stays set afterwards, and the stub `gh` would have served the rest of the
suite.

## Verification

`./scripts_local/check.sh --committed` from `wt/issuesweep`:

> HOST GREEN, DEVICE BUILDS SKIPPED (gh_release_x4pro gh_release_sticky) --
> nothing in this diff reaches a device image, so none was built.

`bugflow.log`: 100 checks, 0 failed (89 before this branch).

**Not verified:** no real `gh` call was made and no GitHub issue was touched.
The live path is asserted through a stub only; the one production run of this
code was the read-only dry run described above. Card #59.