### PR TITLE
docs: make the front door true for this fork, and testable

### DIFF
--- a/.github/workflows/crossplay-ci.yml
+++ b/.github/workflows/crossplay-ci.yml
@@ -154,6 +154,21 @@ jobs:
       # repo already got burned by. A forgiven suite that no longer fails is a
       # door held open for the next regression.
       #
+      # host-tests/docsclaims asks who wrote each file in docs/ by comparing it
+      # against upstream, and actions/checkout gives the runner only `origin`.
+      # Without this the whole ownership half of that suite SKIPPED here while
+      # docs/README.md told readers it was enforced -- most of its checks
+      # running nowhere that blocks a merge. A shallow fetch is enough: the
+      # suite only reads blobs at the tip. Deliberately not `|| true`; a silent
+      # skip is the exact failure being fixed, and docsclaims fails outright in
+      # CI when the ref is missing.
+      - name: Fetch upstream's tip, for the docs ownership checks
+        run: |
+          git fetch --no-tags --depth=1 \
+            https://github.com/crosspoint-reader/crosspoint-reader.git \
+            develop:refs/remotes/crosspoint/develop
+          git rev-parse --verify crosspoint/develop
+
       # host-tests/ci/run.sh executes this step's actual text (extracted from
       # this yaml, not copied) and asserts the no-forgiveness shape, so drift
       # here fails a suite there.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -780,9 +780,13 @@ upstream    https://github.com/crosspoint-reader/crosspoint-reader.git (fetch/pu
 
 ### Git Operation Rules
 
-1. Integration branches and PR comparisons target `develop`, not `master` or the remote's symbolic HEAD.
+1. Integration branches and PR comparisons target **`xteink`**, this fork's
+   default branch, and the remote is `origin` (`ma-r-s/crossplay`). `develop`
+   is upstream's branch, not this one's, and the example remotes above are
+   upstream's too: here `origin` is the fork and `crosspoint` is upstream.
 2. Never push to any remote or open/close a PR without explicit user approval. Complete local work and any requested local commit, then stop.
-3. If the user explicitly approves a push, inspect remotes again and use `fork` for the feature branch unless the user specifies otherwise.
+3. If the user explicitly approves a push, inspect remotes again and push the
+   feature branch to `origin` unless the user specifies otherwise.
 4. Never add Claude, Codex, or assistant self-attribution as a commit co-author or generated-by trailer.
 5. When a change supersedes or adapts another person's PR, verify the original human author from Git/GitHub and add that person as `Co-Authored-By`; skip bot authors.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,8 @@ Never invoke or probe `clang-format` directly. The repository wrapper is the onl
 
    - **Verify**: `which pio` (Git Bash) or `where.exe pio` (cmd)
 
-   - **Usage**: `pio run`, `pio run -t upload`, etc.
+   - **Usage**: `pio run -e x4pro`, `pio run -e x4pro -t upload`, etc. Always
+     with an environment; see Build Commands below for why.
 
 **Configuration Files**:
 
@@ -635,8 +636,10 @@ renderer.drawText(FONT_UI_MEDIUM, x, y, "Hello", true);
 
 > **These are upstream's commands and every one of them targets the wrong
 > chip here.** `default`, `gh_release` and a bare `pio run` all set
-> `FREEINK_DEVICE_X4` / `FREEINK_DEVICE_X3`, which are ESP32-C3. This fork's
-> envs are `x4pro`, `sticky` and `simulator_x4_pro`. Go through
+> `FREEINK_DEVICE_X4` / `FREEINK_DEVICE_X3`, which are ESP32-C3. Build
+> `-e x4pro`, `-e sticky` or `-e simulator_x4_pro` instead (upstream ships an
+> `x4pro` and a `sticky` env too; what differs here is the release envs and the
+> default). Go through
 > `./scripts_local/check.sh` from your own worktree rather than running
 > PlatformIO by hand: it takes the workspace build lock, and concurrent builds
 > race the shared `~/.platformio` and fail on framework headers that have

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -633,20 +633,29 @@ renderer.drawText(FONT_UI_MEDIUM, x, y, "Hello", true);
 
 ### Build Commands
 
+> **These are upstream's commands and every one of them targets the wrong
+> chip here.** `default`, `gh_release` and a bare `pio run` all set
+> `FREEINK_DEVICE_X4` / `FREEINK_DEVICE_X3`, which are ESP32-C3. This fork's
+> envs are `x4pro`, `sticky` and `simulator_x4_pro`. Go through
+> `./scripts_local/check.sh` from your own worktree rather than running
+> PlatformIO by hand: it takes the workspace build lock, and concurrent builds
+> race the shared `~/.platformio` and fail on framework headers that have
+> nothing to do with your diff.
+
 **Via CLI**:
 
 ```bash
-# Build firmware (default environment)
-pio run
+# Everything that can be verified without a device (preferred)
+./scripts_local/check.sh
+
+# One environment, when you need just that
+pio run -e x4pro                 # or -e sticky, -e simulator_x4_pro
 
 # Build and upload to device
-pio run -t upload
-
-# Build specific environment
-pio run -e gh_release
+pio run -e x4pro -t upload
 
 # Clean build artifacts
-pio run -t clean
+pio run -e x4pro -t clean
 ```
 
 **Via VS Code**:
@@ -825,7 +834,9 @@ Tested in all 4 orientations with 5MB+ files.
 - Feature is complete and tested on device
 - Bug fix is verified working
 - Refactoring preserves all functionality
-- All tests pass (`pio run` succeeds)
+- All tests pass (`./scripts_local/check.sh --committed` reaches a green verdict
+  on its last line -- it has four verdicts and one non-zero exit code, so `$?`
+  is not the answer)
 
 **DO NOT commit when**:
 
@@ -880,7 +891,7 @@ Tested in all 4 orientations with 5MB+ files.
 **To change HTML pages**:
 
 1. Edit source: `data/html/<pagename>.html`
-2. Build: `pio run` (auto-triggers `scripts/build_html.py`)
+2. Build: `pio run -e x4pro` (auto-triggers `scripts/build_html.py`)
 3. Generated headers update: `src/network/html/<pagename>Html.generated.h`
 4. **Commit ONLY** source HTML, NOT generated `.generated.h` files
 

--- a/LOCAL_SCOPE.md
+++ b/LOCAL_SCOPE.md
@@ -18,9 +18,16 @@ upstream's to own. We do not fork it, improve it, or diverge from it. Anything
 that makes reading better belongs upstream, so send it there.
 
 What we add is **games and small tools that make the device worth carrying
-instead of a phone**. Twenty-one apps are here now: seventeen games, a
-spaced-repetition trainer, a Hacker News reader, an xkcd viewer and a
-catalog browser.
+instead of a phone**: a shelf of games, plus the small apps beside them -- a
+spaced-repetition trainer, readers for Hacker News and xkcd, a catalog browser,
+a read-later queue.
+
+`src/apps_local/Shelf.cpp` is the list of what is here, and it is the only one.
+No total is written down in this file, for the same reason the count of
+upstream files we own is not: a number in prose is a claim nobody re-derives,
+and this sentence sat at "twenty-one apps, seventeen games" while the shelf
+grew past both. The shelf itself never had that problem, because `Folder`
+computes its `count` from its own table rather than being told.
 
 ## The one rule that keeps this sustainable
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,17 @@ Most of the shelf never touches the network. Of the parts that do:
 ## Build it
 
 ```bash
-pio run -e x4pro                 # the firmware
-pio run -e simulator_x4_pro      # a desktop simulator, SDL2 + a FreeRTOS shim
-./scripts_local/check.sh         # host tests and both builds
+git submodule update --init --recursive   # freeink-sdk, and nothing builds without it
+pio run -e x4pro                          # the firmware
+pio run -e simulator_x4_pro               # a desktop simulator, SDL2 + a FreeRTOS shim
+./scripts_local/check.sh                  # host tests and both builds
 ```
+
+Always name an environment. A bare `pio run` builds `[env:default]`, which is
+upstream's ESP32-C3 target: the chip the install warning above says not to
+write an S3 image to. [docs/contributing/](docs/contributing/) is the long
+version of all of this -- prerequisites, the clone, the hooks, what CI checks
+and how a branch lands.
 
 The apps live in `src/apps_local/`, which is what keeps the merge with upstream
 close to conflict-free. Read [LOCAL_SCOPE.md](LOCAL_SCOPE.md) for what the fork

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,13 +2,48 @@
 
 Two owners share this directory, and the split is deliberate.
 
-**Upstream's reference docs stay at the root, untouched and unrenamed**, so
-merges from CrossPoint stay cheap: `activity-manager.md`, `comparison.md`,
-`dictionary.md`, `file-formats.md`, `fix-bricked-xteink.md`,
-`focus-reading.md`, `hyphenation-trie-format.md`, `i18n.md`,
-`sd-card-fonts.md`, `translators.md`, `troubleshooting.md`,
-`webserver*.md`, `contributing/`, `images/`, and `crosspoint-readme.md`
-(upstream's README, preserved when the fork took the filename).
+**Upstream's reference docs keep upstream's filenames**, so merges from
+CrossPoint stay cheap: `activity-manager.md`, `comparison.md`, `dictionary.md`,
+`file-formats.md`, `fix-bricked-xteink.md`, `focus-reading.md`,
+`hyphenation-trie-format.md`, `i18n.md`, `sd-card-fonts.md`, `translators.md`,
+`troubleshooting.md`, `webserver*.md`, `contributing/` and `images/`.
+
+`crosspoint-readme.md` is the exception to the naming rule: it is upstream's
+README, moved here when the fork took the `README.md` filename, and its
+internal links were re-based when it moved.
+
+**A shared filename is not a byline, and this paragraph used to claim it was.**
+It said those files were "untouched", and several are not. The fork has edited
+`activity-manager.md`, `i18n.md`, `translators.md`, `troubleshooting.md`,
+`webserver.md` and `webserver-endpoints.md` at the root, plus most of
+`contributing/`. Keeping upstream's name is a merge decision, not an authorship
+claim. Ask git rather than reading a list that goes stale:
+
+```bash
+# verbatim upstream, upstream's file with fork edits, or ours alone?
+f=docs/i18n.md
+git cat-file -e crosspoint/develop:"$f" 2>/dev/null \
+  && { [ "$(git rev-parse crosspoint/develop:"$f")" = "$(git rev-parse HEAD:"$f")" ] \
+       && echo "upstream, verbatim" || echo "upstream's file, edited here"; } \
+  || echo "this fork's"
+```
+
+`contributing/` is worth naming file by file, because it is the directory a
+newcomer opens on instinct and it is no longer upstream's alone:
+
+| File                         | Who wrote it                                                                                         |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `getting-started.md`         | **rewritten for this fork.** Upstream's version cloned the wrong repository and built the wrong chip |
+| `landing-and-integration.md` | **this fork's.** No upstream counterpart                                                             |
+| `development-workflow.md`    | upstream's, with fork edits (branch, checks, where a PR goes)                                        |
+| `testing-debugging.md`       | upstream's filename, almost entirely fork content now                                                |
+| `README.md`                  | upstream's, index extended                                                                           |
+| `architecture.md`            | upstream's, one link re-pointed                                                                      |
+| `touch-and-ui.md`            | upstream's, verbatim                                                                                 |
+
+`host-tests/docsclaims/` holds that table to the repository: every row is
+checked against `crosspoint/develop`, so a row that stops being true is a test
+failure rather than something the next reader has to notice.
 
 **The fork's cross-cutting docs also live at the root**: how to build an app
 (`building-apps.md`), how it should look (`design-language.md`), what the

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,13 @@ buttons (`buttons.md`), what scale does to games (`games-at-scale.md`), how to
 reflash and inspect a device over Wi-Fi with no cable
 (`developer-mode.md`), and what is knowingly unfinished (`open-items.md`).
 
+Four more are narrower but no less load-bearing, and this paragraph did not
+name any of them until the suite started asking: what the glass hides
+(`bezel-insets.md`), the unbounded build cache that fails builds by filling
+the disk (`build-cache.md`), the pixel budget an unwrapped string has in 32
+languages (`i18n-overflow.md`), and where Trivia's questions come from
+(`trivia-curation.md`).
+
 **Two files, and only one of them is published.** `release-body.md` is what a
 tag publishes, and it is deliberately tiny: one line of links, then this
 release's `### What is new in <version>` block. Nothing else. It describes

--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -57,31 +57,44 @@ if (button == Button::Back && wasBackGesture()) return true;
 ```
 
 and `wasBackGesture()` is a left-to-right swipe anchored near the left edge. So
-every `mappedInput.wasReleased(Button::Back)` in `apps_local` -- all seventeen
-apps -- resolves through the gesture on this device, and every game is
-exitable. The physical half of that call has been dead since the X4 Pro was
-targeted and nothing depended on it.
+every `mappedInput.wasReleased(Button::Back)` in `apps_local` -- every app here
+-- resolves through the gesture on this device, and every game is exitable. The
+physical half of that call has been dead since the X4 Pro was targeted and
+nothing depended on it.
 
 ## 3. What we actually use
 
-Counted across `src/apps_local/`:
+Counted across `src/apps_local/`, excluding the shared modules that are not apps
+(`link`, `player`, `sample`, `ui`, `bridge`). Re-derive it rather than trusting
+the table; `host-tests/docsclaims/` does exactly that and fails when it drifts:
+
+```bash
+grep -rl "Button::Up\|Button::Down" src/apps_local/*/ | cut -d/ -f3 | sort -u
+```
 
 | Button       | Apps that read it | Exists on X4 Pro |
 | ------------ | ----------------- | ---------------- |
-| Back         | 17                | as a swipe       |
-| Confirm      | 3                 | **no**           |
+| Back         | 23                | as a swipe       |
+| Confirm      | 2                 | **no**           |
 | Left / Right | 1                 | **no**           |
-| Up / Down    | 3                 | **yes**          |
+| Up / Down    | 10                | **yes**          |
 
-Thirteen of seventeen apps use Back and nothing else. **The two buttons the
-device actually has are unused by every game we have built.** The only apps that
-touch them are the reader-shaped ones: hackernews, xkcd, and chess.
+Twelve of the twenty-three use Back and nothing else.
 
-That is the whole finding. Not "we should use the buttons more" as a matter of
-taste -- the device ships with two physical keys, they are page keys, and our
-games ignore them.
+> **The finding below was true when it was written, in August 2026, and it is
+> not true any more.** It said the two real keys were unused by every game we
+> had built, and that the only apps touching them were the reader-shaped ones.
+> Ten apps read Up/Down today and seven of them are games: Checkers, Connect
+> Four, Forehead, Sea Salt, Toy Battle, Wavelength and Yahtzee, alongside Hacker
+> News, Instapaper and xkcd. The rule in section 4 is what survived and is still
+> the thing to apply; the census that motivated it has been overtaken, which is
+> the outcome it was arguing for.
 
-### One game since then does not, and it is the exception that proves the rule
+That was the whole finding. Not "we should use the buttons more" as a matter of
+taste -- the device shipped with two physical keys, they were page keys, and our
+games ignored them.
+
+### The first game that did not, and the exception that proved the rule
 
 FOREHEAD (2026-08-28) is the first game here where the two keys are the primary
 input rather than a page turn, and it earns that by satisfying section 4 exactly

--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -65,8 +65,15 @@ nothing depended on it.
 ## 3. What we actually use
 
 Counted across `src/apps_local/`, excluding the shared modules that are not apps
-(`link`, `player`, `sample`, `ui`, `bridge`). Re-derive it rather than trusting
-the table; `host-tests/docsclaims/` does exactly that and fails when it drifts:
+(`link`, `player`, `sample`, `ui`, `bridge`). **That scope is not the shelf.**
+GET BOOKS is on the shelf and its activity is upstream's
+`src/activities/browser/OpdsBookBrowserActivity.cpp`, outside `apps_local`
+entirely; it reads Back, Confirm and Left, so the shelf's real Confirm and
+Left/Right figures are each one higher than the table below. The table counts
+the directories this fork owns, which is the question this section asks.
+
+`host-tests/docsclaims/` walks the same directories and fails when these numbers
+drift. To see it by hand:
 
 ```bash
 grep -rl "Button::Up\|Button::Down" src/apps_local/*/ | cut -d/ -f3 | sort -u
@@ -79,7 +86,7 @@ grep -rl "Button::Up\|Button::Down" src/apps_local/*/ | cut -d/ -f3 | sort -u
 | Left / Right | 1                 | **no**           |
 | Up / Down    | 10                | **yes**          |
 
-Twelve of the twenty-three use Back and nothing else.
+Twelve of the twenty-three directories use Back and nothing else.
 
 > **The finding below was true when it was written, in August 2026, and it is
 > not true any more.** It said the two real keys were unused by every game we

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,12 +1,17 @@
 # Contributing Docs
 
-This section is a lightweight contributor guide for CrossPoint Reader.
-It is written for software developers who may be new to embedded development.
+This section is a lightweight contributor guide, written for software developers
+who may be new to embedded development.
 
 - [Getting Started](./getting-started.md)
 - [Architecture Overview](./architecture.md)
 - [Development Workflow](./development-workflow.md)
 - [Testing and Debugging](./testing-debugging.md)
+- [Landing and Integration](./landing-and-integration.md)
 - [Touch and UI Development](./touch-and-ui.md)
 
-If you are new, start with [Getting Started](./getting-started.md).
+If you are new, start with [Getting Started](./getting-started.md). It is
+written for **CrossPlay**, this fork: the repository to clone, the branch to
+target and the build environments are all different from upstream's, and a
+build that names no environment targets the wrong chip. `architecture.md` and
+`touch-and-ui.md` are upstream's and describe the firmware both projects share.

--- a/docs/contributing/development-workflow.md
+++ b/docs/contributing/development-workflow.md
@@ -8,33 +8,45 @@ This page defines the expected local workflow before opening a pull request.
 - Clone your fork locally and add the upstream repository if needed
 - Enable repo hooks once per clone: `git config core.hooksPath .githooks && chmod +x .githooks/pre-commit`
 
-- Branch from `develop`
+- Branch from `xteink`, this fork's default branch. Upstream's is `develop`;
+  they are not interchangeable.
 - Keep each PR focused on one fix or feature area
 
 ## 2) Implement with scope in mind
 
-- Confirm your idea is in project scope: [SCOPE.md](../../SCOPE.md)
+- Confirm your idea is in this fork's scope: [LOCAL_SCOPE.md](../../LOCAL_SCOPE.md),
+  which overrides upstream's [SCOPE.md](../../SCOPE.md) where the two disagree.
+  Most of what belongs here lives in new files under `src/apps_local/`.
 - Prefer incremental changes over broad refactors
 
 ## 3) Run local checks
 
 ```sh
 ./bin/clang-format-fix
-pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
-pio run
+pio check --fail-on-defect high
+./scripts_local/check.sh --committed
 ```
 
-CI enforces formatting, static analysis, and build checks.
-Use clang-format 21+ locally to match CI.
-If `clang-format` is missing or too old locally, see [Getting Started](./getting-started.md).
+CI enforces formatting, static analysis, the unit tests and the device builds.
+Use clang-format 21 locally to match it; if `clang-format` is missing or the
+wrong version, see [Getting Started](./getting-started.md).
+
+Do not reach for a bare `pio run` instead. It builds `[env:default]`, which is
+upstream's ESP32-C3 target rather than this fork's, and it bypasses the
+workspace build lock that keeps concurrent builds from corrupting each other.
+Name an environment (`-e x4pro`, `-e sticky`, `-e simulator_x4_pro`) when you
+build one directly.
 
 ## 4) Open the PR
 
-- Target `develop` (the repository's default branch)
+- Target `xteink` (this repository's default branch)
 - Use a semantic title (example: `fix: avoid crash when opening malformed epub`)
-- Fill out `.github/PULL_REQUEST_TEMPLATE.md`
 - Describe the problem, approach, and any tradeoffs
+- Say what you did **not** verify. Hardware always counts as not verified.
 - Include reproduction and verification steps for bug fixes
+- [Landing and integration](./landing-and-integration.md) says which gate your
+  branch actually needs, and what to check first when the gate goes red on
+  something that is not your diff
 
 ## 5) Review etiquette
 

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -1,16 +1,46 @@
 # Getting Started
 
-This guide helps you build and run CrossPoint locally.
+This guide builds and runs **CrossPlay** locally. CrossPlay is a fork of
+CrossPoint Reader, so most of what is here also applies upstream, but the
+repository, the branch and the build environments are all different. If you
+came looking for CrossPoint itself, it lives at
+[crosspoint-reader/crosspoint-reader](https://github.com/crosspoint-reader/crosspoint-reader).
+
+## Read this before you build anything
+
+> **Never build or flash without naming an environment.** `platformio.ini` sets
+> `default_envs = default`, and `[env:default]` is upstream's: it defines
+> `FREEINK_DEVICE_X4` and `FREEINK_DEVICE_X3`, which are the **ESP32-C3**
+> devices. CrossPlay is for the **ESP32-S3** Xteink X4 Pro and Seeed reTerminal
+> Sticky, and writing an S3 image to a C3 device used to brick it. Every build
+> and every upload in this guide carries `-e <env>` for that reason.
+
+The environments you will actually use:
+
+| Env                | What it is                                                     |
+| ------------------ | -------------------------------------------------------------- |
+| `x4pro`            | Xteink X4 Pro firmware, debug log level, dev serial bridge on. |
+| `sticky`           | Seeed reTerminal Sticky, same shape.                           |
+| `simulator_x4_pro` | A desktop build: SDL2 plus a FreeRTOS shim. No device needed.  |
+
+`gh_release_x4pro` and `gh_release_sticky` are what a tag builds; CI builds
+them, you do not need to.
 
 ## Prerequisites
 
 - PlatformIO Core (`pio`) or VS Code + PlatformIO IDE
 - Python 3.8+
-- `clang-format` 21+ in your `PATH` (CI uses clang-format 21)
-- USB-C cable
-- Xteink X4 device for hardware testing
+- `clang-format` **21**, on your `PATH` as `clang-format-21`.
+  `bin/clang-format-fix` prefers that exact name and falls back to plain
+  `clang-format`, which on a current machine is 22 -- and 22 reformats 44 files
+  that CI's 21 leaves alone, so the fallback shows churn you did not write.
+- SDL2, for the simulator env only (`brew install sdl2`, or your distribution's
+  `libsdl2-dev`)
+- A USB-C cable and an X4 Pro or a Sticky, **only** for on-device testing. The
+  simulator and the host test suites need no hardware.
 
-If `./bin/clang-format-fix` fails with either of these errors, install clang-format 21:
+If `./bin/clang-format-fix` fails with either of these errors, install
+clang-format 21:
 
 - `clang-format: No such file or directory`
 - `.clang-format: error: unknown key 'AlignFunctionDeclarations'`
@@ -28,8 +58,9 @@ sudo ./llvm.sh 21
 sudo apt-get update
 sudo apt-get install -y clang-format-21
 
-# macOS (Homebrew)
-brew install clang-format
+# macOS (Homebrew): llvm@21 ships clang-format 21, unversioned, keg-only
+brew install llvm@21
+ln -s "$(brew --prefix llvm@21)/bin/clang-format" /opt/homebrew/bin/clang-format-21
 ```
 
 Then verify:
@@ -38,22 +69,23 @@ Then verify:
 clang-format-21 --version
 ```
 
-The reported major version must be 21 or newer.
+The reported major version must be 21.
 
 ## Clone and initialize
 
 ```sh
-git clone --recursive https://github.com/crosspoint-reader/crosspoint-reader
-cd crosspoint-reader
-```
-
-If you already cloned without submodules:
-
-```sh
+git clone https://github.com/ma-r-s/crossplay
+cd crossplay
 git submodule update --init --recursive
 ```
 
-Enable the repository-managed Git hooks (required once per clone):
+**The submodule step is not optional.** `.gitmodules` pins `freeink-sdk`, which
+is the platform layer every build compiles against. Without it the first build
+fails on missing headers rather than on anything you did. `git clone
+--recursive` does the same thing in one step; the two-step form is here because
+it is also the fix for a clone you already made.
+
+Enable the repository-managed Git hooks (once per clone):
 
 ```sh
 git config core.hooksPath .githooks
@@ -63,25 +95,61 @@ chmod +x .githooks/pre-commit
 ## Build
 
 ```sh
-pio run
+./scripts_local/check.sh --tests        # host suites only, no toolchain needed
+./scripts_local/check.sh                # host suites plus the device and simulator builds
+```
+
+`check.sh` is the entry point rather than a convenience wrapper: it takes a
+workspace-wide build lock, and concurrent PlatformIO builds race the shared
+`~/.platformio` and fail on framework headers that have nothing to do with your
+diff. **It has four verdicts and one non-zero exit code, so read its last
+line** rather than `$?` -- "VERDICT WITHHELD" exits 0 and is not a pass.
+
+To build one environment directly:
+
+```sh
+pio run -e x4pro
+pio run -e simulator_x4_pro
 ```
 
 ## Flash
 
 ```sh
-pio run --target upload
+pio run -e x4pro --target upload      # or -e sticky
 ```
 
-## First checks before opening a PR
+Once a device has CrossPlay on it, Developer Mode reflashes it over Wi-Fi with
+no cable at all: [docs/developer-mode.md](../developer-mode.md). Installing
+onto a device for the first time, by browser or by esptool, is
+[docs/install.md](../install.md); if a flash goes wrong,
+[docs/fix-bricked-xteink.md](../fix-bricked-xteink.md) is the way back.
+
+## First checks before opening a pull request
 
 ```sh
 ./bin/clang-format-fix
-pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
-pio run
+pio check --fail-on-defect high
+./scripts_local/check.sh --committed
 ```
+
+`--committed` verifies `HEAD` instead of your working directory. Uncommitted
+work masks a broken commit, which is how three apps once shipped against
+symbols that were never committed while every check ran green.
+
+Pull requests go into **`xteink`**, this fork's default branch, not `develop`.
+CI builds both device environments on a runner, so you do not have to.
+[Landing and integration](./landing-and-integration.md) covers which gate a
+branch actually needs and what to do when integration goes red.
 
 ## What to read next
 
+- [LOCAL_SCOPE.md](../../LOCAL_SCOPE.md) -- what this fork owns and what it
+  turns down. Read it before writing any code.
 - [Architecture Overview](./architecture.md)
 - [Development Workflow](./development-workflow.md)
 - [Testing and Debugging](./testing-debugging.md)
+- [Landing and Integration](./landing-and-integration.md)
+- [Touch and UI Development](./touch-and-ui.md)
+- [docs/building-apps.md](../building-apps.md) and
+  [docs/shelf.md](../shelf.md) -- how an app on this fork is put together, and
+  the contract it has with the shelf.

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -32,8 +32,8 @@ them, you do not need to.
 - Python 3.8+
 - `clang-format` **21**, on your `PATH` as `clang-format-21`.
   `bin/clang-format-fix` prefers that exact name and falls back to plain
-  `clang-format`, which on a current machine is 22 -- and 22 reformats 44 files
-  that CI's 21 leaves alone, so the fallback shows churn you did not write.
+  `clang-format`, which on a current machine is 22. 22 reformats files 21 leaves
+  alone, so the fallback shows churn you did not write and CI then rejects.
 - SDL2, for the simulator env only (`brew install sdl2`, or your distribution's
   `libsdl2-dev`)
 - A USB-C cable and an X4 Pro or a Sticky, **only** for on-device testing. The
@@ -69,7 +69,10 @@ Then verify:
 clang-format-21 --version
 ```
 
-The reported major version must be 21.
+It must report 21. `bin/clang-format-fix` itself only refuses versions **below**
+21, so a newer one runs happily and quietly reformats files CI would leave
+alone; the wrapper cannot tell you that, which is why the version is pinned
+here.
 
 ## Clone and initialize
 
@@ -80,7 +83,9 @@ git submodule update --init --recursive
 ```
 
 **The submodule step is not optional.** `.gitmodules` pins `freeink-sdk`, which
-is the platform layer every build compiles against. Without it the first build
+is the platform layer every build compiles against. It tracks a branch rather
+than upstream's default, so take the commit the superproject records and do not
+update it casually. Without it the first build
 fails on missing headers rather than on anything you did. `git clone
 --recursive` does the same thing in one step; the two-step form is here because
 it is also the fix for a clone you already made.
@@ -137,7 +142,11 @@ work masks a broken commit, which is how three apps once shipped against
 symbols that were never committed while every check ran green.
 
 Pull requests go into **`xteink`**, this fork's default branch, not `develop`.
-CI builds both device environments on a runner, so you do not have to.
+CI compiles `gh_release_x4pro`, `gh_release_sticky` and `simulator_x4_pro` on a
+runner, so you do not have to build for a device to land. Note what that does
+**not** cover: `x4pro` and `sticky`, the dev envs in the table above, carry
+`CROSSPOINT_DEV_SERIAL_BRIDGE` and CI never compiles them. Only your local
+`check.sh` does.
 [Landing and integration](./landing-and-integration.md) covers which gate a
 branch actually needs and what to do when integration goes red.
 

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -60,7 +60,7 @@ sudo apt-get install -y clang-format-21
 
 # macOS (Homebrew): llvm@21 ships clang-format 21, unversioned, keg-only
 brew install llvm@21
-ln -s "$(brew --prefix llvm@21)/bin/clang-format" /opt/homebrew/bin/clang-format-21
+ln -s "$(brew --prefix llvm@21)/bin/clang-format" "$(brew --prefix)/bin/clang-format-21"
 ```
 
 Then verify:
@@ -95,7 +95,7 @@ chmod +x .githooks/pre-commit
 ## Build
 
 ```sh
-./scripts_local/check.sh --tests        # host suites only, no toolchain needed
+./scripts_local/check.sh --tests        # host suites only, no device build (fast)
 ./scripts_local/check.sh                # host suites plus the device and simulator builds
 ```
 

--- a/docs/contributing/testing-debugging.md
+++ b/docs/contributing/testing-debugging.md
@@ -4,22 +4,31 @@ CrossPoint runs on real hardware, so debugging usually combines local build chec
 
 ## Local checks
 
-Make sure `clang-format` 21+ is installed and available in `PATH` before running the formatting step.
+Make sure `clang-format` 21 is installed and on `PATH` as `clang-format-21` before running the formatting step.
 If needed, see [Getting Started](./getting-started.md).
 
 ```sh
 ./bin/clang-format-fix
-pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
-pio run
+pio check --fail-on-defect high
+./scripts_local/check.sh --committed
 ```
+
+`check.sh` runs the host suites and both builds behind the workspace build
+lock. It has four verdicts and one non-zero exit code, so read its **last
+line**, never `$?`.
 
 ## Flash and monitor
 
-Flash firmware:
+Flash firmware -- **always naming an environment**, because a bare `pio run`
+builds `[env:default]`, which is upstream's ESP32-C3 target and not this fork's
+([Getting Started](./getting-started.md) says why that matters):
 
 ```sh
-pio run --target upload
+pio run -e x4pro --target upload      # or -e sticky
 ```
+
+A device already running CrossPlay takes a build over Wi-Fi instead, with no
+cable: [docs/developer-mode.md](../developer-mode.md).
 
 Open serial monitor:
 

--- a/docs/crosspoint-readme.md
+++ b/docs/crosspoint-readme.md
@@ -1,5 +1,13 @@
 # CrossPoint Reader
 
+> **This is upstream's README, kept as a record, not as instructions.** CrossPlay
+> took the `README.md` filename, so upstream's landed here; only its internal
+> links were re-based. Everything below describes **CrossPoint** on the ESP32-C3
+> Xteink X4 and X3, and its `pio run --target upload` flashes a C3 image. This
+> fork builds ESP32-S3 (`-e x4pro`, `-e sticky`). To build or flash CrossPlay,
+> read [contributing/getting-started.md](contributing/getting-started.md); to
+> install it on a device, read [install.md](install.md).
+
 [![Fund contributors](https://img.shields.io/badge/%F0%9F%91%91_Fund_contributors-royalty.dev-BB953A?style=for-the-badge&labelColor=1a1a1a)](https://app.royalty.dev/crosspoint-reader/crosspoint-reader)
 
 CrossPoint is open-source e-reader firmware - community-built, fully hackable, free forever. It's maintained by a growing community of developers and readers who believe your device should do what you want - not what a manufacturer decided for you.
@@ -12,7 +20,7 @@ CrossPoint is open-source e-reader firmware - community-built, fully hackable, f
 
 ## What can CrossPoint do?
 
-- **Reader engine**: EPUB 2/3 rendering with embedded-style option, image handling, hyphenation, kerning, chapter navigation, footnotes, bookmarks, dictionary lookups ([StarDict](dictionary.md)), go-to-percent, auto page turn, orientation control, focus reading, KOReader progress sync and more. 
+- **Reader engine**: EPUB 2/3 rendering with embedded-style option, image handling, hyphenation, kerning, chapter navigation, footnotes, bookmarks, dictionary lookups ([StarDict](dictionary.md)), go-to-percent, auto page turn, orientation control, focus reading, KOReader progress sync and more.
 
 - **Various formats**: native handling for `.epub`, `.xtc/.xtch`, `.txt`, and `.bmp`.
 
@@ -25,7 +33,7 @@ CrossPoint is open-source e-reader firmware - community-built, fully hackable, f
 - **Library workflow**: folder browser, hidden-file toggle, long-press delete, recent books, SD-cache management.
 
 - **Wireless workflows**:
-  
+
   - File transfer web UI
   - EPUB Optimizer
   - Web settings UI/API (edit many device settings from browser)
@@ -63,9 +71,9 @@ https://crosspointreader.com/#unlock-tool before you can flash CrossPoint.
 USB port or browser before assuming the device is locked. Only reach for the unlocker if the device still doesn't appear.
 
 > ### ⚠️ WARNING: READ THIS BEFORE USING THE UNLOCKER ⚠️
-> 
+>
 > **The only officially supported firmwares in the unlock tool are CrossPoint and CrossInk.**
-> 
+>
 > Flashing any other firmware on a USB-locked device may **permanently brick the device** or leave it **permanently
 > stuck on that firmware with no recovery path**. Once USB flashing is re-locked, your only way back is via OTA, and if
 > the firmware you flashed doesn't support OTA, **there is no way out**.
@@ -274,7 +282,7 @@ One of the best things about open source is that anyone can take the code in a d
 
 - ~~[PlusPoint](https://github.com/ngxson/pluspoint-reader) — custom JS apps support.~~ (Unmaintained)
 
-- [crosspoint-reader-papers3](https://github.com/juicecultus/crosspoint-reader-papers3) — Crosspoint port for M5Stack Paper S3. 
+- [crosspoint-reader-papers3](https://github.com/juicecultus/crosspoint-reader-papers3) — Crosspoint port for M5Stack Paper S3.
 
 - [t5s3-reader](https://github.com/ShallowGreen123/t5s3-reader) — Crosspoint port for LilyGo T5 ePaper S3 / T5S3 4.7-inch e-paper device.
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -46,17 +46,17 @@ and any description that omits them has described a folder of minigames.
 **A shape for still activities.** The apps are not ports that happen to run.
 They share a shelf, a header band, a font, a control vocabulary and an
 interaction model, so a person who learns one has learned all of them. That
-shared surface is what turns eleven programs into one device. See
+shared surface is what turns a shelf of separate programs into one device. See
 [`shelf.md`](shelf.md) and [`LOCAL_SCOPE.md`](../LOCAL_SCOPE.md).
 
 **Multiplayer with nothing to configure.** Two devices on a table find each
 other and play. No pairing screen, no room code, no account, no router, no
-internet. It is on the menu of three games as `PLAY NEARBY` and that is the
+internet. On every game that supports it, it is one `PLAY NEARBY` row and that is the
 entire user-facing surface of it. The north star is the DS: you sat down next to
 someone and it worked, and no part of the experience ever mentioned a network.
 The layer itself is `src/apps_local/link/`, described in
 [`building-apps.md`](building-apps.md) and covered by the `link` host-test suite
-(five sub-suites, real UDP on loopback).
+(real UDP on loopback).
 
 ## What the identity is made of
 
@@ -81,8 +81,8 @@ choice. The device is 1-bit because the hardware is; the page is 1-bit because i
 looks like us. Where the web can do something better (real greys for hierarchy,
 selectable text, a font that stays legible at any size), use it.
 
-**The screenshots are the artwork.** We have eleven apps that each spent real
-effort on one still screen. Nothing drawn for a web page will beat a photograph
+**The screenshots are the artwork.** Every app on the shelf spent real effort
+on one still screen. Nothing drawn for a web page will beat a photograph
 of the thing itself, and anything decorative that is not a screenshot is
 competing with them. This is the same rule as ornament on the device: it has to
 be made of the app's own material.

--- a/docs/shelf.md
+++ b/docs/shelf.md
@@ -75,8 +75,8 @@ a finger. A horizontal swipe pages nothing.
 
 This list paged sideways first, and sideways cannot be symmetrical on this
 device. Back is a left-to-right swipe anchored in the left 25% of the panel
-(`EDGE_SWIPE_SIDE_FRAC`, 120px of 480), and it is the only way out of all
-seventeen apps because the X4 Pro has no Back button. So on the horizontal axis
+(`EDGE_SWIPE_SIDE_FRAC`, 120px of 480), and it is the only way out of every app
+here because the X4 Pro has no Back button. So on the horizontal axis
 the backward page turn and the exit are **the same visible gesture separated by
 an invisible line**: past 120px it paged, inside it you were on Home. A gesture
 whose meaning flips on a boundary nothing draws cannot be made discoverable. It

--- a/host-tests/docsclaims/run.sh
+++ b/host-tests/docsclaims/run.sh
@@ -169,24 +169,52 @@ if m:
 # No reader must be able to reach a build or an upload that names no
 # environment. `default_envs = default` is upstream's ESP32-C3 target.
 # ---------------------------------------------------------------------------
+# Every markdown file in the repository, not a chosen few: scoping this to the
+# files that were known to be wrong is how the twin in the next directory
+# survives. One file is exempt, by name and with a reason.
+EXEMPT = {
+    # Upstream's README, preserved as a record when the fork took the README.md
+    # filename. Rewriting its commands would falsify the record, so it carries a
+    # blockquote at the top saying it is upstream's and that its upload flashes
+    # a C3 image. That note is asserted below.
+    "docs/crosspoint-readme.md",
+}
+SKIP_DIRS = {".git", ".pio", "freeink-sdk", "node_modules", "fs_agent",
+             "fs_mario", "qa-artifacts", "emulator", ".cache", "archive"}
 env_less = []
-scan = ["README.md", "AGENTS.md"]
-contrib = os.path.join(root, "docs/contributing")
-scan += [f"docs/contributing/{f}" for f in sorted(os.listdir(contrib)) if f.endswith(".md")]
-for rel in scan:
-    fenced = False
-    for n, line in enumerate(read(rel).splitlines(), 1):
-        if line.lstrip().startswith("```"):
-            fenced = not fenced
+scanned = 0
+for dp, dns, fns in os.walk(root):
+    dns[:] = [d for d in dns if d not in SKIP_DIRS]
+    for fn in sorted(fns):
+        if not fn.endswith(".md"):
             continue
-        if not fenced:
+        rel = os.path.relpath(os.path.join(dp, fn), root)
+        if rel in EXEMPT:
             continue
-        cmd = line.strip().lstrip("$").strip()
-        if cmd.startswith("pio run") and " -e " not in cmd:
-            env_less.append(f"{rel}:{n}  {cmd}")
+        scanned += 1
+        fenced = False
+        for n, line in enumerate(read(rel).splitlines(), 1):
+            if line.lstrip().startswith("```"):
+                fenced = not fenced
+                continue
+            if not fenced:
+                continue
+            cmd = line.strip().lstrip("$").strip()
+            if cmd.startswith("pio run") and " -e " not in cmd:
+                env_less.append(f"{rel}:{n}  {cmd}")
+check(scanned > 50, "the env-less build scan reached almost nothing",
+      f"only {scanned} markdown files; a scan that finds no files reports clean")
 check(not env_less,
       "a firmware build or upload that names no environment builds [env:default], which is ESP32-C3",
       "; ".join(env_less))
+
+# The exemption is only honest while the file says so itself.
+cpr = read("docs/crosspoint-readme.md")
+check("upstream's README" in cpr and "ESP32-C3" in cpr and "x4pro" in cpr,
+      "docs/crosspoint-readme.md is exempt from the env-less scan but no longer says why",
+      "it must state that it is upstream's record and that its commands target C3")
+
+contrib = os.path.join(root, "docs/contributing")
 
 # The two lines that make a stranger's first build work at all.
 check("git submodule update --init" in readme,

--- a/host-tests/docsclaims/run.sh
+++ b/host-tests/docsclaims/run.sh
@@ -1,0 +1,377 @@
+#!/bin/bash
+# The claims the front-door docs make about this repository, checked against the
+# repository.
+#
+# Three separate lies shipped here and every one of them was invisible to every
+# other suite, because no suite reads prose:
+#
+#   1. `docs/contributing/getting-started.md` was upstream's file. It cloned
+#      crosspoint-reader, it built `pio run` with no `-e`, and `[env:default]`
+#      is FREEINK_DEVICE_X4/X3 -- the ESP32-C3 devices the README's one warning
+#      says an S3 image used to brick. The repository's only getting-started
+#      guide flashed the wrong chip from the wrong clone.
+#   2. `docs/README.md` said upstream's docs stayed "untouched", naming
+#      `contributing/` among them, while three files in that directory were
+#      almost entirely this fork's and a fourth did not exist upstream at all.
+#      That file's whole job is saying who wrote what.
+#   3. `LOCAL_SCOPE.md` said "twenty-one apps, seventeen games" long after the
+#      shelf passed both.
+#
+# Every check here DISCOVERS its expected value -- from `Shelf.cpp`, from the
+# includes, from `crosspoint/develop` -- rather than holding a second copy of
+# the number. A test carrying its own literal would have gone stale beside the
+# doc it was guarding.
+#
+#   host-tests/docsclaims/run.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
+
+python3 - "$ROOT" <<'PY'
+import os
+import re
+import subprocess
+import sys
+
+root = sys.argv[1]
+checks = 0
+failed = 0
+
+
+def check(ok, label, detail=""):
+    global checks, failed
+    checks += 1
+    if not ok:
+        failed += 1
+        print(f"FAIL docsclaims  {label}" + (f": {detail}" if detail else ""))
+
+
+def read(rel):
+    with open(os.path.join(root, rel), encoding="utf-8") as f:
+        return f.read()
+
+
+WORDS = {
+    "one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6,
+    "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11, "twelve": 12,
+    "thirteen": 13, "fourteen": 14, "fifteen": 15, "sixteen": 16,
+    "seventeen": 17, "eighteen": 18, "nineteen": 19, "twenty": 20,
+}
+
+
+def number(token):
+    token = token.strip().lower()
+    if token.isdigit():
+        return int(token)
+    return WORDS.get(token)
+
+
+def key(title):
+    """Shelf titles shout, README titles do not, and dirs run words together."""
+    return re.sub(r"[^A-Z0-9&]", "", title.upper())
+
+
+# ---------------------------------------------------------------------------
+# The shelf is the only list of what is on this device. Everything below is
+# measured against it.
+# ---------------------------------------------------------------------------
+shelf = read("src/apps_local/Shelf.cpp")
+
+
+def shelf_table(name):
+    m = re.search(
+        r"constexpr shelf::Item " + name + r"\[\]\s*=\s*\{(.*?)\n\};",
+        shelf,
+        re.S,
+    )
+    if not m:
+        return None
+    return re.findall(r'\{\s*"([^"]+)"', m.group(1))
+
+
+games = shelf_table("kGames")
+apps = shelf_table("kApps")
+check(bool(games), "Shelf.cpp kGames table not found -- every count below is unmeasured")
+check(bool(apps), "Shelf.cpp kApps table not found -- every count below is unmeasured")
+if not games or not apps:
+    print(f"{checks} checks, {failed} failed")
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
+# README.md: the headline count, and the two tables under it.
+# ---------------------------------------------------------------------------
+readme = read("README.md")
+
+m = re.search(r"\*\*(\S+) games and (\S+) apps\*\*", readme)
+check(bool(m), "README.md has no '**N games and M apps**' claim to check")
+if m:
+    said_games, said_apps = number(m.group(1)), number(m.group(2))
+    check(said_games == len(games), "README.md games count",
+          f"says {m.group(1)}, Shelf.cpp kGames has {len(games)}")
+    check(said_apps == len(apps), "README.md apps count",
+          f"says {m.group(2)}, Shelf.cpp kApps has {len(apps)}")
+
+
+def readme_section(heading):
+    m = re.search(r"^### " + heading + r"\s*$(.*?)(?=^#{2,3} |\Z)",
+                  readme, re.S | re.M)
+    return m.group(1) if m else ""
+
+
+def bold_rows(text):
+    return [key(t) for t in re.findall(r"^\|\s*\*\*([^*]+)\*\*", text, re.M)]
+
+
+for heading, table, label in (("Games", games, "kGames"), ("Apps", apps, "kApps")):
+    listed = bold_rows(readme_section(heading))
+    want = [key(t) for t in table]
+    check(bool(listed), f"README.md '### {heading}' table has no rows")
+    missing = [t for t in want if t not in listed]
+    extra = [t for t in listed if t not in want]
+    check(not missing, f"README.md '### {heading}' table is missing shelf entries",
+          ", ".join(missing))
+    check(not extra, f"README.md '### {heading}' table lists rows {label} does not",
+          ", ".join(extra))
+
+# ---------------------------------------------------------------------------
+# PLAY NEARBY. An app plays nearby exactly when it includes the link activity,
+# so the sentence is checked against the includes rather than against itself.
+# ---------------------------------------------------------------------------
+nearby_dirs = set()
+apps_local = os.path.join(root, "src/apps_local")
+for entry in sorted(os.listdir(apps_local)):
+    d = os.path.join(apps_local, entry)
+    if not os.path.isdir(d):
+        continue
+    for fn in os.listdir(d):
+        if not fn.endswith((".cpp", ".h")):
+            continue
+        with open(os.path.join(d, fn), encoding="utf-8", errors="replace") as f:
+            if '"../link/LinkActivity.h"' in f.read():
+                nearby_dirs.add(key(entry))
+                break
+
+m = re.search(r"(\w+) of the games play over \*\*PLAY NEARBY\*\*:\s*(.+?)\.",
+              readme, re.S)
+check(bool(m), "README.md has no PLAY NEARBY sentence to check")
+if m:
+    said = number(m.group(1))
+    named = [key(n) for n in re.split(r",\s*|\s+and\s+", m.group(2).strip()) if n.strip()]
+    check(said == len(named), "README.md PLAY NEARBY count disagrees with its own list",
+          f"says {m.group(1)}, names {len(named)}")
+    check(set(named) == nearby_dirs,
+          "README.md PLAY NEARBY list disagrees with which apps include link/LinkActivity.h",
+          f"named-not-linked={sorted(set(named) - nearby_dirs)} "
+          f"linked-not-named={sorted(nearby_dirs - set(named))}")
+
+# ---------------------------------------------------------------------------
+# No reader must be able to reach a build or an upload that names no
+# environment. `default_envs = default` is upstream's ESP32-C3 target.
+# ---------------------------------------------------------------------------
+env_less = []
+scan = ["README.md", "AGENTS.md"]
+contrib = os.path.join(root, "docs/contributing")
+scan += [f"docs/contributing/{f}" for f in sorted(os.listdir(contrib)) if f.endswith(".md")]
+for rel in scan:
+    fenced = False
+    for n, line in enumerate(read(rel).splitlines(), 1):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        if not fenced:
+            continue
+        cmd = line.strip().lstrip("$").strip()
+        if cmd.startswith("pio run") and " -e " not in cmd:
+            env_less.append(f"{rel}:{n}  {cmd}")
+check(not env_less,
+      "a firmware build or upload that names no environment builds [env:default], which is ESP32-C3",
+      "; ".join(env_less))
+
+# The two lines that make a stranger's first build work at all.
+check("git submodule update --init" in readme,
+      "README.md does not tell a stranger to initialise the submodule",
+      ".gitmodules pins freeink-sdk and nothing builds without it")
+check("docs/contributing" in readme,
+      "README.md never links docs/contributing/",
+      "the correct setup path is unreachable from the front door")
+gs = read("docs/contributing/getting-started.md")
+check("git submodule update --init" in gs,
+      "docs/contributing/getting-started.md is missing the submodule step")
+check("crosspoint-reader/crosspoint-reader\n" not in gs
+      and "clone https://github.com/crosspoint-reader" not in gs,
+      "docs/contributing/getting-started.md still clones upstream's repository")
+
+# ---------------------------------------------------------------------------
+# docs/buttons.md counts which apps read which logical button. It sat at
+# "seventeen apps" and "Up/Down: 3" while ten apps -- seven of them games --
+# had grown to read the two real keys, which inverted the finding the document
+# exists to record.
+# ---------------------------------------------------------------------------
+SHARED = {"link", "player", "sample", "ui", "bridge"}
+button_use = {}
+for entry in sorted(os.listdir(apps_local)):
+    d = os.path.join(apps_local, entry)
+    if not os.path.isdir(d) or entry in SHARED:
+        continue
+    seen = set()
+    for dp, _, fns in os.walk(d):
+        for fn in fns:
+            if fn.endswith((".cpp", ".h")):
+                with open(os.path.join(dp, fn), encoding="utf-8", errors="replace") as f:
+                    seen |= set(re.findall(r"Button::(\w+)", f.read()))
+    button_use[entry] = seen
+
+buttons = read("docs/buttons.md")
+ROWS = (
+    ("Back", ("Back",)),
+    ("Confirm", ("Confirm",)),
+    ("Left / Right", ("Left", "Right")),
+    ("Up / Down", ("Up", "Down")),
+)
+for label, names in ROWS:
+    m = re.search(r"^\|\s*" + re.escape(label) + r"\s*\|\s*(\d+)\s*\|", buttons, re.M)
+    check(bool(m), "docs/buttons.md has no row for this button", label)
+    if m:
+        real = sum(1 for s in button_use.values() if s & set(names))
+        check(int(m.group(1)) == real, "docs/buttons.md button census is stale",
+              f"{label}: says {m.group(1)}, {real} app directories read it")
+
+# ---------------------------------------------------------------------------
+# `.github/skills/crosspoint-reader.md` is a SYMLINK to AGENTS.md, and it has to
+# stay one.
+#
+# It reads as a 41KB byte-identical duplicate to anything that resolves it --
+# `md5` agrees, and a link checker walking the tree resolves AGENTS.md's
+# root-relative links from `.github/skills/` and reports about twenty dead
+# links, which is most of the dead links in the repository. Both are artefacts
+# of the symlink, not a second copy: the links are correct at AGENTS.md's own
+# path. Upstream added this link (a77419be) pointing at `.skills/SKILL.md`,
+# then deleted that file and left it dangling; f6d6482d re-pointed it here.
+#
+# The check exists because "de-duplicate this" is the obvious wrong fix, and
+# making it a real file is how the repository would grow a 41KB copy that
+# drifts.
+# ---------------------------------------------------------------------------
+skill_link = os.path.join(root, ".github/skills/crosspoint-reader.md")
+check(os.path.islink(skill_link),
+      ".github/skills/crosspoint-reader.md is no longer a symlink",
+      "it must point at AGENTS.md, never hold a copy of it")
+if os.path.islink(skill_link):
+    check(os.path.basename(os.readlink(skill_link)) == "AGENTS.md",
+          ".github/skills/crosspoint-reader.md points somewhere other than AGENTS.md",
+          os.readlink(skill_link))
+    check(os.path.exists(skill_link),
+          ".github/skills/crosspoint-reader.md dangles, which aborts any tree walk that opens it")
+
+# ---------------------------------------------------------------------------
+# docs/contributing/README.md is the index of its own directory. It went stale
+# by omission: landing-and-integration.md existed and nothing linked it.
+# ---------------------------------------------------------------------------
+index = read("docs/contributing/README.md")
+for fn in sorted(os.listdir(contrib)):
+    if not fn.endswith(".md") or fn == "README.md":
+        continue
+    check(f"({fn})" in index or f"(./{fn})" in index,
+          "docs/contributing/README.md does not link a file in its own directory", fn)
+
+# ---------------------------------------------------------------------------
+# docs/README.md says who wrote what. Checked against upstream, not believed.
+# ---------------------------------------------------------------------------
+docs_readme = read("docs/README.md")
+
+
+def upstream_ref():
+    for ref in ("crosspoint/develop", "upstream/develop"):
+        r = subprocess.run(["git", "-C", root, "rev-parse", "--verify", "--quiet", ref],
+                           capture_output=True, text=True)
+        if r.returncode == 0:
+            return ref
+    return None
+
+
+ref = upstream_ref()
+if ref is None:
+    print("SKIP docsclaims  no crosspoint/develop or upstream/develop ref; "
+          "docs/README.md's ownership claims were NOT verified "
+          "(git fetch crosspoint develop)")
+else:
+    def upstream_blob(path):
+        r = subprocess.run(["git", "-C", root, "rev-parse", f"{ref}:{path}"],
+                           capture_output=True, text=True)
+        return r.stdout.strip() if r.returncode == 0 else None
+
+    def local_blob(path):
+        # The WORKING TREE, not HEAD. check.sh verifies what you have unless
+        # you pass --committed, and a claim checked against HEAD while the file
+        # on disk says something else is a check that answers about a tree
+        # nobody is looking at.
+        full = os.path.join(root, path)
+        if not os.path.exists(full):
+            return None
+        r = subprocess.run(["git", "-C", root, "hash-object", "--", full],
+                           capture_output=True, text=True)
+        return r.stdout.strip() if r.returncode == 0 else None
+
+    def ownership(path):
+        u = upstream_blob(path)
+        if u is None:
+            return "fork"
+        return "verbatim" if u == local_blob(path) else "edited"
+
+    # Every file the first paragraph says keeps upstream's filename must be a
+    # path upstream actually has.
+    m = re.search(r"\*\*Upstream's reference docs keep upstream's filenames\*\*(.*?)\n\n",
+                  docs_readme, re.S)
+    check(bool(m), "docs/README.md: the upstream-filenames paragraph was reworded past this check")
+    if m:
+        named = [n for n in re.findall(r"`([A-Za-z0-9._\-]+\.md)`", m.group(1))]
+        check(bool(named), "docs/README.md names no upstream-filename docs")
+        for fn in named:
+            check(ownership(f"docs/{fn}") != "fork",
+                  "docs/README.md calls a file upstream's that upstream does not have", fn)
+
+    # Every file it names as fork-edited must really differ from upstream.
+    m = re.search(r"The fork has edited(.*?)at the root", docs_readme, re.S)
+    check(bool(m), "docs/README.md: the fork-edited sentence was reworded past this check")
+    if m:
+        for fn in re.findall(r"`([A-Za-z0-9._\-]+\.md)`", m.group(1)):
+            check(ownership(f"docs/{fn}") == "edited",
+                  "docs/README.md says the fork edited a file it did not",
+                  f"{fn} is {ownership(f'docs/{fn}')}")
+
+    # The contributing/ table, row by row. A row whose wording matches no
+    # marker fails rather than passing quietly: a reworded row is a row nothing
+    # is checking.
+    MARKERS = (
+        ("No upstream counterpart", "fork"),
+        ("verbatim", "verbatim"),
+        ("rewritten for this fork", "edited"),
+        ("fork content", "edited"),
+        ("fork edits", "edited"),
+        ("index extended", "edited"),
+        ("re-pointed", "edited"),
+    )
+    rows = re.findall(r"^\|\s*`([A-Za-z0-9._\-]+\.md)`\s*\|(.+?)\|\s*$", docs_readme, re.M)
+    check(len(rows) >= 5, "docs/README.md contributing table not found or truncated",
+          f"{len(rows)} rows")
+    for fn, desc in rows:
+        want = next((v for k, v in MARKERS if k in desc), None)
+        check(want is not None,
+              "docs/README.md contributing table row matches no known claim, so nothing checks it",
+              f"{fn}: {desc.strip()}")
+        if want is not None:
+            got = ownership(f"docs/contributing/{fn}")
+            check(got == want, "docs/README.md contributing table row is wrong",
+                  f"{fn}: says {want}, is {got}")
+
+    # Every file in the directory has a row. Omission is how this went wrong.
+    listed = {fn for fn, _ in rows}
+    for fn in sorted(os.listdir(contrib)):
+        if fn.endswith(".md"):
+            check(fn in listed,
+                  "docs/README.md contributing table omits a file in that directory", fn)
+
+print(f"{checks} checks, {failed} failed")
+sys.exit(1 if failed else 0)
+PY

--- a/host-tests/docsclaims/run.sh
+++ b/host-tests/docsclaims/run.sh
@@ -257,12 +257,20 @@ for rel in ["README.md", "AGENTS.md"] + [
 # The branch is DISCOVERED, from the remote HEAD git already records, so this
 # check does not become the literal it is guarding.
 # ---------------------------------------------------------------------------
+# origin/HEAD first, but a --single-branch clone and actions/checkout both
+# leave that ref unset, so it cannot be the only source: keying on it alone
+# turned a fresh checkout red. crossplay-ci.yml's own `branches:` filter is the
+# fallback, in the repository, needing no network and no remote.
 _r = subprocess.run(["git", "-C", root, "symbolic-ref", "--short",
                      "refs/remotes/origin/HEAD"], capture_output=True, text=True)
 default_branch = _r.stdout.strip().split("/")[-1] if _r.returncode == 0 else ""
+if not default_branch:
+    _w = re.search(r"^\s*branches:\s*\[([A-Za-z0-9._/-]+)\]",
+                   read(".github/workflows/crossplay-ci.yml"), re.M)
+    default_branch = _w.group(1) if _w else ""
 check(bool(default_branch),
-      "cannot read origin/HEAD, so the branch a contributor is sent at is unchecked",
-      "git remote set-head origin -a")
+      "neither origin/HEAD nor crossplay-ci.yml names a default branch, "
+      "so the branch a contributor is sent at is unchecked")
 if default_branch:
     BRANCH_INSTRUCTION = re.compile(
         r"^[-*\d.)\s]*(?:Branch from|Target)\s+`([A-Za-z0-9._/-]+)`", re.M | re.I)

--- a/host-tests/docsclaims/run.sh
+++ b/host-tests/docsclaims/run.sh
@@ -372,6 +372,16 @@ else:
             check(fn in listed,
                   "docs/README.md contributing table omits a file in that directory", fn)
 
+# docs/README.md is the index of docs/. A doc it never names is a doc nobody
+# finds: four of them (bezel-insets, build-cache, i18n-overflow,
+# trivia-curation) went unmentioned, the same omission that hid
+# landing-and-integration.md. Checked without the upstream ref, so CI sees it.
+for fn in sorted(os.listdir(os.path.join(root, "docs"))):
+    if not fn.endswith(".md") or fn == "README.md":
+        continue
+    check(f"`{fn}`" in docs_readme or f"({fn})" in docs_readme or f"/{fn}" in docs_readme,
+          "docs/README.md never names a doc in its own directory", fn)
+
 print(f"{checks} checks, {failed} failed")
 sys.exit(1 if failed else 0)
 PY

--- a/host-tests/docsclaims/run.sh
+++ b/host-tests/docsclaims/run.sh
@@ -133,6 +133,12 @@ for heading, table, label in (("Games", games, "kGames"), ("Apps", apps, "kApps"
           ", ".join(missing))
     check(not extra, f"README.md '### {heading}' table lists rows {label} does not",
           ", ".join(extra))
+    # Length as well as membership. Set comparison alone passes a table that
+    # lists one game twice, which is a table with the wrong number of rows
+    # sitting under a headline count this same suite checks.
+    check(len(listed) == len(want),
+          f"README.md '### {heading}' table has the wrong number of rows",
+          f"{len(listed)} rows, {label} has {len(want)}")
 
 # ---------------------------------------------------------------------------
 # PLAY NEARBY. An app plays nearby exactly when it includes the link activity,
@@ -181,6 +187,12 @@ EXEMPT = {
 }
 SKIP_DIRS = {".git", ".pio", "freeink-sdk", "node_modules", "fs_agent",
              "fs_mario", "qa-artifacts", "emulator", ".cache", "archive"}
+# Deliberately NOT fence-aware. Fence tracking was a toggle that a nested or
+# `~~~` block desynced silently, and it made a four-space indented code block
+# invisible. The whole tree has exactly one env-less invocation outside a fence
+# and it is the exempt file, so requiring a fence bought nothing and hid two
+# shapes. Both binary names, because `platformio run` is the same command.
+BUILD_CMD = re.compile(r"^(?:\$\s*)?(?:pio|platformio)\s+run\b")
 env_less = []
 scanned = 0
 for dp, dns, fns in os.walk(root):
@@ -192,15 +204,11 @@ for dp, dns, fns in os.walk(root):
         if rel in EXEMPT:
             continue
         scanned += 1
-        fenced = False
         for n, line in enumerate(read(rel).splitlines(), 1):
-            if line.lstrip().startswith("```"):
-                fenced = not fenced
+            cmd = line.strip()
+            if cmd.startswith("```") or cmd.startswith("~~~"):
                 continue
-            if not fenced:
-                continue
-            cmd = line.strip().lstrip("$").strip()
-            if cmd.startswith("pio run") and " -e " not in cmd:
+            if BUILD_CMD.match(cmd) and " -e " not in cmd and "--environment" not in cmd:
                 env_less.append(f"{rel}:{n}  {cmd}")
 check(scanned > 50, "the env-less build scan reached almost nothing",
       f"only {scanned} markdown files; a scan that finds no files reports clean")
@@ -216,19 +224,56 @@ check("upstream's README" in cpr and "ESP32-C3" in cpr and "x4pro" in cpr,
 
 contrib = os.path.join(root, "docs/contributing")
 
-# The two lines that make a stranger's first build work at all.
-check("git submodule update --init" in readme,
-      "README.md does not tell a stranger to initialise the submodule",
-      ".gitmodules pins freeink-sdk and nothing builds without it")
+# The two lines that make a stranger's first build work at all. Asserted as
+# COMMANDS on a line of their own, not as substrings: a bare `in` test is
+# satisfied by any mention anywhere, including a sentence telling you not to.
+SUBMODULE_CMD = re.compile(r"^(?:\$\s*)?git\s+submodule\s+update\s+--init\b", re.M)
+CLONE_UPSTREAM = re.compile(
+    r"^(?:\$\s*)?git\s+clone\b.*crosspoint-reader/crosspoint-reader", re.M)
+for rel, label in (("README.md", "README.md"),
+                   ("docs/contributing/getting-started.md", "getting-started.md")):
+    body = "\n".join(l.strip() for l in read(rel).splitlines())
+    check(bool(SUBMODULE_CMD.search(body)),
+          f"{label} does not carry `git submodule update --init` as a command",
+          ".gitmodules pins freeink-sdk and nothing builds without it")
 check("docs/contributing" in readme,
       "README.md never links docs/contributing/",
       "the correct setup path is unreachable from the front door")
-gs = read("docs/contributing/getting-started.md")
-check("git submodule update --init" in gs,
-      "docs/contributing/getting-started.md is missing the submodule step")
-check("crosspoint-reader/crosspoint-reader\n" not in gs
-      and "clone https://github.com/crosspoint-reader" not in gs,
-      "docs/contributing/getting-started.md still clones upstream's repository")
+# Every doc a contributor follows, not only the one that was wrong. The regex
+# catches the SSH form too: `git@github.com:crosspoint-reader/...` matched
+# neither of the https-only substring tests this replaces.
+for rel in ["README.md", "AGENTS.md"] + [
+        f"docs/contributing/{f}" for f in sorted(os.listdir(contrib)) if f.endswith(".md")]:
+    body = "\n".join(l.strip() for l in read(rel).splitlines())
+    m = CLONE_UPSTREAM.search(body)
+    check(m is None, f"{rel} tells the reader to clone upstream's repository",
+          m.group(0) if m else "")
+
+# ---------------------------------------------------------------------------
+# Which branch a contributor is told to branch from and target. `develop` is
+# upstream's; this repository's is `xteink`, and nothing checked that at all --
+# a doc could say "Branch from `develop`" and every suite stayed green.
+#
+# The branch is DISCOVERED, from the remote HEAD git already records, so this
+# check does not become the literal it is guarding.
+# ---------------------------------------------------------------------------
+_r = subprocess.run(["git", "-C", root, "symbolic-ref", "--short",
+                     "refs/remotes/origin/HEAD"], capture_output=True, text=True)
+default_branch = _r.stdout.strip().split("/")[-1] if _r.returncode == 0 else ""
+check(bool(default_branch),
+      "cannot read origin/HEAD, so the branch a contributor is sent at is unchecked",
+      "git remote set-head origin -a")
+if default_branch:
+    BRANCH_INSTRUCTION = re.compile(
+        r"^[-*\d.)\s]*(?:Branch from|Target)\s+`([A-Za-z0-9._/-]+)`", re.M | re.I)
+    for fn in sorted(os.listdir(contrib)):
+        if not fn.endswith(".md"):
+            continue
+        rel = f"docs/contributing/{fn}"
+        for _m2 in BRANCH_INSTRUCTION.finditer(read(rel)):
+            check(_m2.group(1) == default_branch,
+                  f"{rel} sends a contributor at the wrong branch",
+                  f"says `{_m2.group(1)}`, origin's default is `{default_branch}`")
 
 # ---------------------------------------------------------------------------
 # docs/buttons.md counts which apps read which logical button. It sat at
@@ -236,7 +281,14 @@ check("crosspoint-reader/crosspoint-reader\n" not in gs
 # had grown to read the two real keys, which inverted the finding the document
 # exists to record.
 # ---------------------------------------------------------------------------
-SHARED = {"link", "player", "sample", "ui", "bridge"}
+# Read out of docs/buttons.md rather than written twice. This file's header
+# says every expected value is discovered; a hand-kept copy of the doc's own
+# exclusion list would be the one literal able to disagree with it.
+_m = re.search(r"excluding the shared modules that are not apps\s*\n?\(([^)]*)\)",
+               read("docs/buttons.md"))
+SHARED = set(re.findall(r"`([a-z]+)`", _m.group(1))) if _m else set()
+check(bool(SHARED), "docs/buttons.md no longer names the directories its census excludes",
+      "the census scope is what makes its numbers mean anything")
 button_use = {}
 for entry in sorted(os.listdir(apps_local)):
     d = os.path.join(apps_local, entry)
@@ -320,9 +372,19 @@ def upstream_ref():
 
 ref = upstream_ref()
 if ref is None:
-    print("SKIP docsclaims  no crosspoint/develop or upstream/develop ref; "
-          "docs/README.md's ownership claims were NOT verified "
-          "(git fetch crosspoint develop)")
+    # In CI this is a FAILURE, not a skip. The workflow fetches the ref in a
+    # step of its own precisely so these checks run where a merge is blocked;
+    # if that step is dropped, the suite must say so rather than pass with most
+    # of itself switched off. Locally it stays a loud skip, so a fresh clone
+    # with no upstream remote is not bricked by it.
+    if os.environ.get("CI"):
+        check(False, "no crosspoint/develop ref in CI",
+              "the 'Fetch upstream's tip' step in crossplay-ci.yml is gone, and "
+              "docs/README.md's ownership claims are checked nowhere")
+    else:
+        print("SKIP docsclaims  no crosspoint/develop or upstream/develop ref; "
+              "docs/README.md's ownership claims were NOT verified "
+              "(git fetch crosspoint develop)")
 else:
     def upstream_blob(path):
         r = subprocess.run(["git", "-C", root, "rev-parse", f"{ref}:{path}"],
@@ -380,7 +442,15 @@ else:
         ("index extended", "edited"),
         ("re-pointed", "edited"),
     )
-    rows = re.findall(r"^\|\s*`([A-Za-z0-9._\-]+\.md)`\s*\|(.+?)\|\s*$", docs_readme, re.M)
+    # Scoped to the paragraph that introduces the table, so a future table
+    # elsewhere in this file whose first cell is a backticked filename is not
+    # silently checked as though it named a file in contributing/.
+    tbl = re.search(r"`contributing/` is worth naming file by file(.*?)\n\n(?=[^|])",
+                    docs_readme, re.S)
+    check(bool(tbl),
+          "docs/README.md: the contributing table's introduction was reworded past this check")
+    region = tbl.group(1) if tbl else ""
+    rows = re.findall(r"^\|\s*`([A-Za-z0-9._\-]+\.md)`\s*\|(.+?)\|\s*$", region, re.M)
     check(len(rows) >= 5, "docs/README.md contributing table not found or truncated",
           f"{len(rows)} rows")
     for fn, desc in rows:


### PR DESCRIPTION
Six defects a cold reviewer found in the front-door docs, all verified before fixing. Every one was invisible to every existing suite, because no suite read prose. `host-tests/docsclaims/` now does: 78 checks, each deriving its expected value from `Shelf.cpp`, from the includes, or from `crosspoint/develop`, rather than carrying a second copy of the number.

### 1. `docs/contributing/getting-started.md` built the wrong chip

It was upstream's file, byte-identical. It cloned `crosspoint-reader/crosspoint-reader`, and it built and flashed with a bare `pio run`. `platformio.ini` line 2 is `default_envs = default`, and `[env:default]` sets `FREEINK_DEVICE_X4` and `FREEINK_DEVICE_X3` -- the ESP32-C3 devices the README's one blockquote says an S3 image used to brick. The repository's only getting-started guide built the wrong chip for the wrong device from the wrong clone.

**Rewritten for this fork rather than deleted.** The README's build block is three lines; something has to carry prerequisites, the clone, the submodule step and the hooks, and `docs/contributing/README.md` would otherwise link a dead file on every merge.

Its twins carried the same hazard and are fixed with it, because fixing only the file that was named would have left it reachable one click away:

- `testing-debugging.md`: `pio run --target upload`, which actually flashes the wrong chip.
- `development-workflow.md`: the same bare build, plus `develop` as the branch to branch from and target, and `Fill out .github/PULL_REQUEST_TEMPLATE.md` -- a file this fork does not have.
- `AGENTS.md` Build Commands, which is what every agent working in this repo reads.

A check now fails on any line inside a fenced block in `README.md`, `AGENTS.md` or `docs/contributing/*.md` that starts a build or upload without `-e`.

### 2. The submodule step

`git submodule update --init` appeared nowhere reader-facing, so a stranger's first build failed on missing `freeink-sdk` headers rather than on anything they did. It is now the first line of the README's build block and a section of its own in getting-started, both checked.

### 3. `contributing` appeared zero times in README.md

Linked once, from the build section, next to the env warning.

### 4. `docs/README.md` was wrong about the directory it most needed to be right about

It said upstream's reference docs stay "untouched and unrenamed", naming `contributing/` among them. Verified with `git cat-file -e crosspoint/develop:<path>`:

| Claim | Reality |
|---|---|
| `contributing/` untouched | 3 of 7 files carry fork edits; `testing-debugging.md` is 9 of 10 commits Mario's; `landing-and-integration.md` has no upstream counterpart and was missing from the directory's own index |
| six root docs untouched | `activity-manager.md`, `i18n.md`, `translators.md`, `troubleshooting.md`, `webserver.md`, `webserver-endpoints.md` all carry fork edits |
| `crosspoint-readme.md` "unrenamed" | it is upstream's README under a different name, in the same sentence that claimed nothing was renamed |

It now states the rule it actually follows -- upstream's **filenames** are kept, so merges stay cheap -- says plainly that a filename is not a byline, gives the git one-liner that answers ownership for any path, and carries a per-file table for `contributing/`. The suite checks that table against `crosspoint/develop` row by row, fails on a row whose wording matches no known claim (so a reworded row cannot pass unchecked), and fails when a file in the directory has no row at all, which is exactly how `landing-and-integration.md` went missing.

### 5. `.github/skills/crosspoint-reader.md` is not a duplicate

**The reviewer's finding is wrong, and I would rather say so than "fix" it.** The file is a symlink (`git ls-files -s` reports mode `120000`) to `../../AGENTS.md`. It is upstream's -- added in `a77419be` pointing at `.skills/SKILL.md`, left dangling when upstream deleted that file, and re-pointed at `AGENTS.md` by this fork in `f6d6482d`. `md5` agrees with `AGENTS.md` because it resolves to it, and a link checker walking the tree reports ~20 dead links because it resolves `AGENTS.md`'s root-relative links from `.github/skills/`. Both are artefacts of the symlink; there is no 41KB second copy and the links are correct at `AGENTS.md`'s own path.

Nothing changed. A check now asserts it stays a symlink pointing at `AGENTS.md` and does not dangle, because "de-duplicate this" is the obvious wrong fix and is how the repository would grow the copy it does not have.

### 6. Counts

- `LOCAL_SCOPE.md` said "Twenty-one apps are here now: seventeen games" against a shelf of 19 games and 5 apps. It now names **no total**, which is what the same file already demands two paragraphs later about the upstream-file count.
- README's "19 games and 5 apps" was **correct**. Left alone, now checked against `kGames` / `kApps`, along with both tables row by row and the "Nine of the games play over PLAY NEARBY" sentence (derived from which app directories include `../link/LinkActivity.h`).
- **`docs/buttons.md` was worse than reported.** Its census said Up/Down was read by 3 apps. Ten read it, seven of them games, which inverts the finding that section exists to record: "the two buttons the device actually has are unused by every game we have built". The numbers are corrected, the census is re-derivable from one grep, and the superseded finding is marked as overtaken rather than deleted -- the rule in section 4 is what survived.
- `docs/shelf.md`'s "all seventeen apps" now says "every app here".

### Dismissed

Nothing else. `playground-submission/` untouched, the docs tree unmoved, no section relocated, and README prose changed only where a fact was wrong or missing.

### A cold review, and what it broke

A reviewer with no context on this branch was asked to try to construct wrong repository states the suite still calls green. It built **seven**, and found **five factual errors in my own additions**. All twelve are fixed in `658e88dc` and `fcedeb99`.

Facts I had wrong:

- `AGENTS.md` said "this fork's envs are `x4pro`, `sticky` and `simulator_x4_pro`". Upstream's `platformio.ini` ships `x4pro`, `sticky` **and** `papermono`; what differs here is the release envs and the default.
- getting-started said "CI builds both device environments". CI builds `gh_release_x4pro`, `gh_release_sticky` and `simulator_x4_pro`, and never compiles `x4pro` or `sticky` -- the two dev envs the table above it calls the ones you will actually use. A `CROSSPOINT_DEV_SERIAL_BRIDGE` break is invisible to CI, and the doc promised the opposite.
- "The reported major version must be 21" implied the wrapper enforces it. `bin/clang-format-fix` only refuses **below** 21, which is exactly why 22 gets through.
- "22 reformats 44 files" was a bare literal nothing re-derives, the class this branch's own commentary condemns. Number dropped.
- `docs/buttons.md`'s census excludes GET BOOKS, which is on the shelf but whose activity is upstream's `OpdsBookBrowserActivity.cpp`, outside `apps_local`. It reads Back, Confirm and Left, so the shelf's true Confirm and Left/Right are each one higher. I had replaced one stale number with a differently-scoped one; the scope is now stated in the prose, not just the table.

**The suite was inert where it counted.** Most of it never ran in CI: the ownership block needs `crosspoint/develop`, and `actions/checkout` gives the runner only `origin`, so it SKIPPED there while `docs/README.md` told readers it was enforced. `crossplay-ci.yml` now fetches upstream's tip in a step of its own (shallow -- the suite only reads blobs at the tip), and a missing ref is a **failure** when `$CI` is set, a loud skip otherwise. Verified end to end on a real fresh clone: 37 checks before, 124 after the fetch step, and the failure path names the missing workflow step by name.

Seven wrong states it used to pass, each re-run and now caught:

| State it accepted | Why |
|---|---|
| an SSH clone of upstream | both guards were https-only substrings |
| "Branch from `develop`" / "Target `develop`" | nothing checked the branch at all; now checked against `origin/HEAD`, falling back to the workflow's own `branches:` filter |
| a 4-space indented block with an env-less upload, or a `~~~` fence | fence tracking was a toggle that desynced; it is gone, and the whole tree has exactly one env-less invocation outside a fence (the exempt file) |
| `platformio run --target upload` | the same command under its other name |
| a duplicated table row | membership passed; row **count** is now checked too |
| the submodule line demoted to prose | both guards were bare substrings, satisfiable by a sentence telling you not to run it |
| `buttons.md` dropping the exclusion list its numbers depend on | the suite's `SHARED` set is now read out of that sentence rather than being a second copy of it |

One more the review provoked: my new branch check read `origin/HEAD`, which neither a `--single-branch` clone nor `actions/checkout` sets. It would have reddened **every** CI run. Caught by running the suite in a real fresh clone rather than reasoning about it (`fcedeb99`).

**Left open, deliberately:** `pio check --fail-on-defect high` names no environment in all three contributing docs, so it analyses `[env:default]` -- the C3 target those same files warn about. The docs match what CI actually runs, and changing them would make local results diverge from CI. The bug is in `crossplay-ci.yml`, not the docs; filed rather than smuggled into a docs branch.

### Verification

- `./scripts_local/check.sh --committed`, verifying HEAD `1d1a7992` in a throwaway worktree, after merging `origin/xteink` (an autorelease cut 1.12.24 mid-branch and `host-tests/release` correctly went red on a `docs/release-notes.md` that predated it -- not this diff). Last line, verbatim:

  ```
  HOST GREEN, DEVICE BUILDS SKIPPED (gh_release_x4pro gh_release_sticky) -- nothing in this diff reaches a device image, so none was built.
  ```
- Every new check was seen to FAIL against a deliberate mutation before being trusted: wrong counts, an env-less build reintroduced, a lie in the ownership table, a table row reworded past the matcher, a row deleted, a stale button census, the symlink replaced by a real copy, the submodule line removed, the contributing link removed, and a file dropped from the contributing index. Two mutations initially failed to apply (whitespace the markdown formatter had re-padded) and read exactly like a passing test until checked.
- A relative-link walk over all 100 markdown files: this branch adds zero broken links.

**Not verified:** nothing device-side is touched by this change, so nothing was flashed. The claim that `[env:default]` is C3 is read from `platformio.ini`, not measured on hardware.
