### PR TITLE
ci: six holes that let rot through silently, and the tests that keep them shut

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,19 @@
 name: CI (build)
 
+# FORK CHANGE: DISABLED ON GITHUB (disabled_manually), and nothing in the file
+# said so. Its triggers below are still `push: branches: [master]` -- a branch
+# this fork does not have -- and `pull_request`, which is live-looking and was
+# live: it went red on every pull request for a week, on the fork's own code
+# rather than upstream's, and was read by nobody.
+#
+# Its three jobs that had nowhere else to run (clang-format, the cmake unit
+# tests, cppcheck) moved into crossplay-ci.yml on 2026-09-04, card 170. Its four
+# device builds duplicated crossplay-ci.yml's.
+#
+# Kept rather than deleted because deleting it conflicts on every sync from
+# upstream. Re-enable it in the Actions tab if you ever want upstream's own
+# checks back; the trigger is untouched on purpose, so re-enabling is one click
+# and not a merge.
 on:
   push:
     branches: [master]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI (build)
 
 # FORK CHANGE: DISABLED ON GITHUB (disabled_manually), and nothing in the file
-# said so. Its triggers below are still `push: branches: [master]` -- a branch
-# this fork does not have -- and `pull_request`, which is live-looking and was
-# live: it went red on every pull request for a week, on the fork's own code
-# rather than upstream's, and was read by nobody.
+# said so. Its triggers below are untouched and read as fully live -- in
+# particular `pull_request`, which fires on every pull request in this
+# repository when the workflow is enabled. It was: it went red on every pull
+# request for a week, on the fork's own code rather than upstream's, and was
+# read by nobody. (`master` still exists on this remote, inherited from
+# upstream; the fork's default branch is `xteink` and nothing pushes to
+# `master`.)
 #
 # Its three jobs that had nowhere else to run (clang-format, the cmake unit
 # tests, cppcheck) moved into crossplay-ci.yml on 2026-09-04, card 170. Its four

--- a/.github/workflows/crossplay-ci.yml
+++ b/.github/workflows/crossplay-ci.yml
@@ -68,14 +68,18 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Four cross-compiles, the simulator and every host suite: about 15 minutes
-    # warm, and the comment on the relwatch job below records a cross-compile
-    # starving a container for 20. Without this it inherits GitHub's 6-hour
-    # default, so a step that hangs -- a fetch that retries forever, a build
-    # waiting on a lock -- holds the runner for a quarter of a day while the
-    # merge that started it shows as still running. Deliberately loose: this is
-    # the cap that says "stuck", not a budget anyone should tune against.
-    timeout-minutes: 45
+    # MEASURED, not guessed: this job took 19, 20, 20 and 19 minutes on runs
+    # 33951055693, 33950407386, 33949430216 and 33948549676 -- four
+    # cross-compiles, the simulator and every host suite. Without a cap it
+    # inherits GitHub's SIX HOUR default, so a step that hangs (a fetch that
+    # retries forever, a build waiting on a lock) holds the runner for a quarter
+    # of a day while the merge that started it reads as still running, which is
+    # the same display as a build that is merely slow.
+    #
+    # 60 is three times the observed run, deliberately: this is the number that
+    # says "stuck", not a budget anyone should tune against. Raise it rather
+    # than let it start failing honest builds.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/crossplay-ci.yml
+++ b/.github/workflows/crossplay-ci.yml
@@ -68,6 +68,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Four cross-compiles, the simulator and every host suite: about 15 minutes
+    # warm, and the comment on the relwatch job below records a cross-compile
+    # starving a container for 20. Without this it inherits GitHub's 6-hour
+    # default, so a step that hangs -- a fetch that retries forever, a build
+    # waiting on a lock -- holds the runner for a quarter of a day while the
+    # merge that started it shows as still running. Deliberately loose: this is
+    # the cap that says "stuck", not a budget anyone should tune against.
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/crossplay-emulator.yml
+++ b/.github/workflows/crossplay-emulator.yml
@@ -38,6 +38,12 @@ env:
 jobs:
   rebuild:
     runs-on: ubuntu-latest
+    # This job shallow-clones emsdk from GitHub, installs an emscripten
+    # toolchain, runs pio and builds wasm -- four places a network step can hang
+    # with nothing to show for it. Without a cap it inherits GitHub's SIX HOUR
+    # default. 60 matches the other two capped jobs; a rebuild that has been
+    # going an hour is stuck, not slow.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/crossplay-emulator.yml
+++ b/.github/workflows/crossplay-emulator.yml
@@ -46,14 +46,26 @@ jobs:
           submodules: recursive
           token: ${{ secrets.RELEASE_TOKEN || github.token }}
 
+      # emulator-stale.sh answers THREE ways: 0 stale, 1 fresh, 2 it could not
+      # look (its cd failed). An `if` keeps only "was it zero", so 2 landed in
+      # the else branch and was recorded as stale=false. Every later step is
+      # gated on `stale == 'true'`, so all of them were skipped and the job
+      # reported success having rebuilt nothing -- the one outcome that looks
+      # exactly like "the emulator was already fresh". Capture the code and
+      # fail on anything that is not one of the two real answers.
       - name: Is the emulator behind its sources?
         id: stale
         run: |
-          if bash scripts_local/emulator-stale.sh .; then
-            echo "stale=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "stale=false" >> "$GITHUB_OUTPUT"
-          fi
+          set +e
+          bash scripts_local/emulator-stale.sh .
+          rc=$?
+          set -e
+          case "$rc" in
+            0) echo "stale=true"  >> "$GITHUB_OUTPUT" ;;
+            1) echo "stale=false" >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::emulator-stale.sh could not answer (exit $rc); the emulator was not checked, so it was not rebuilt"
+               exit 1 ;;
+          esac
 
       - uses: actions/setup-python@v5
         if: steps.stale.outputs.stale == 'true'

--- a/.github/workflows/crossplay-release.yml
+++ b/.github/workflows/crossplay-release.yml
@@ -37,9 +37,36 @@ on:
 permissions:
   contents: write
 
+# The publisher's own group, because a concurrency group does NOT span
+# workflows. crossplay-autorelease.yml carries `group: crossplay-release`, which
+# serialises the autorelease against itself and nothing else; this workflow --
+# the one that builds and uploads the assets -- was ungrouped, so two starts on
+# one tag ran side by side.
+#
+# That is not hypothetical. v1.12.16 was built and published TWICE, one second
+# apart (runs 33884760714 event=push and 33884760111 event=workflow_dispatch),
+# both ~14 minutes of runner, both racing to upload the same files, both exiting
+# 0. The fix at the time was a condition on the dispatch side
+# (crossplay-autorelease.yml), which is correct and still there -- but it makes
+# the double build avoidable rather than impossible, and it lives in a different
+# file from the one it protects. A hand dispatch during a tag build still
+# overlaps. Grouped by ref, so two different tags still build in parallel.
+#
+# cancel-in-progress is false: a half-cancelled publish leaves a release with
+# some of its assets, which is worse than a second run finding the work done.
+concurrency:
+  group: crossplay-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    # A release is two cross-compiles and an upload; it takes about 15 minutes
+    # cold. Without this it inherits GitHub's 6-hour default, so a hung pio run
+    # or a network step that never returns holds a runner for a quarter of a day
+    # and the tag it was cutting stays unpublished with nothing said. Wide
+    # headroom on purpose: this is a stuck-job cap, not a performance budget.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,8 +109,16 @@ jobs:
             ~/.cache/pip
           key: pio-release-${{ hashFiles('platformio.ini') }}
 
+      # The SAME build every other workflow uses. This said `pip install
+      # --upgrade platformio`, which is both unpinned and a different
+      # distribution: upstream PlatformIO from PyPI, not pioarduino's fork. The
+      # five other build workflows all install
+      # pioarduino/platformio-core v6.1.19, so the binary that actually ships to
+      # devices was the one binary in the repository built by a toolchain
+      # nothing had verified, and a PyPI release could have changed it between
+      # two tags with no commit of ours.
       - name: Install PlatformIO
-        run: pip install --upgrade platformio
+        run: pip install -U https://github.com/pioarduino/platformio-core/archive/refs/tags/v6.1.19.zip
 
       # ONE invocation for both devices, and that is load-bearing.
       #

--- a/.github/workflows/crossplay-release.yml
+++ b/.github/workflows/crossplay-release.yml
@@ -44,9 +44,9 @@ permissions:
 # one tag ran side by side.
 #
 # That is not hypothetical. v1.12.16 was built and published TWICE, one second
-# apart (runs 33884760714 event=push and 33884760111 event=workflow_dispatch),
-# both ~14 minutes of runner, both racing to upload the same files, both exiting
-# 0. The fix at the time was a condition on the dispatch side
+# apart: runs 33884760714 (event=push) and 33884760111 (event=workflow_dispatch),
+# 12 minutes each, both racing to upload the same files, both exiting 0. The fix
+# at the time was a condition on the dispatch side
 # (crossplay-autorelease.yml), which is correct and still there -- but it makes
 # the double build avoidable rather than impossible, and it lives in a different
 # file from the one it protects. A hand dispatch during a tag build still
@@ -61,11 +61,13 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # A release is two cross-compiles and an upload; it takes about 15 minutes
-    # cold. Without this it inherits GitHub's 6-hour default, so a hung pio run
-    # or a network step that never returns holds a runner for a quarter of a day
-    # and the tag it was cutting stays unpublished with nothing said. Wide
-    # headroom on purpose: this is a stuck-job cap, not a performance budget.
+    # MEASURED, not guessed: the last ten successful releases ran 9 to 19
+    # minutes (two cross-compiles, the merge-bins and an upload). Without a cap
+    # this inherits GitHub's SIX HOUR default, so a hung pio run or a network
+    # step that never returns holds a runner for a quarter of a day while the
+    # tag it was cutting stays unpublished and nothing says so.
+    #
+    # 60 is three times the worst of those. A stuck-job cap, not a budget.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-formatting-check.yml
+++ b/.github/workflows/pr-formatting-check.yml
@@ -1,5 +1,16 @@
 name: "PR Formatting"
 
+# FORK CHANGE: DISABLED ON GITHUB (disabled_manually), and nothing in the file
+# said so. The trigger below is `pull_request_target`, so it reads as running on
+# every pull request in this repository; it does not run at all.
+#
+# It enforces upstream's semantic pull request titles. This fork's pull requests
+# are opened by sessions from a board card and titled after the card, so the
+# check was red on the fork's own pull requests rather than on anything wrong.
+#
+# Kept rather than deleted because deleting it conflicts on every sync from
+# upstream. Re-enable it in the Actions tab if the fork ever adopts the title
+# convention; the trigger is untouched on purpose.
 on:
   pull_request_target:
     types:

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -1,5 +1,20 @@
 name: Compile Release Candidate
 
+# FORK CHANGE: this workflow CANNOT run here, and reads as though it can.
+#
+# Two things have to line up and never do. It is dispatch-only, so nothing
+# starts it by itself; and its one job is gated on a ref name beginning with
+# `release/`, which no branch in this fork has -- work happens on `app/*` and
+# lands on `xteink`. Dispatching it therefore produces a green run with zero
+# jobs, which is indistinguishable from a release candidate that built.
+#
+# It also builds four upstream boards (gh_release_rc, sticky, x4pro,
+# papermono) with the RC envs, none of which is what this fork ships:
+# crossplay-release.yml owns v* tags and builds gh_release_x4pro and
+# gh_release_sticky.
+#
+# Kept rather than deleted because deleting it conflicts on every sync from
+# upstream, and left exactly as upstream wrote it for the same reason.
 on:
   workflow_dispatch:
 

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -1,12 +1,17 @@
 name: Compile Release Candidate
 
-# FORK CHANGE: this workflow CANNOT run here, and reads as though it can.
+# FORK CHANGE: this workflow does nothing useful here, and reads as though it
+# does.
 #
-# Two things have to line up and never do. It is dispatch-only, so nothing
-# starts it by itself; and its one job is gated on a ref name beginning with
-# `release/`, which no branch in this fork has -- work happens on `app/*` and
-# lands on `xteink`. Dispatching it therefore produces a green run with zero
-# jobs, which is indistinguishable from a release candidate that built.
+# It is dispatch-only, so nothing starts it by itself, and its one job is gated
+# on a ref name beginning with `release/`. The fork's work happens on `app/*`
+# and lands on `xteink`, so dispatching it from any branch anyone actually uses
+# produces a GREEN RUN WITH ZERO JOBS -- indistinguishable, on the Actions
+# page, from a release candidate that built.
+#
+# It is not unreachable, though: `release/1.5.0` still exists on this remote,
+# inherited from upstream, and a dispatch against that ref really would run the
+# job. What it would build is the point below.
 #
 # It also builds four upstream boards (gh_release_rc, sticky, x4pro,
 # papermono) with the RC envs, none of which is what this fork ships:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -968,18 +968,26 @@ build_flags =
 
 ### CI/CD Pipeline Awareness
 
-> **In CrossPlay, not one of the four workflows in this table runs.** `ci.yml`
-> and `pr-formatting-check.yml` are disabled on GitHub; `release.yml` and
-> `release_candidate.yml` are dispatch-only, and the latter is also gated on a
-> `release/` ref this fork's `app/*` branches never match. All four are kept
-> rather than deleted so upstream syncs stay clean, and each carries a
-> `FORK CHANGE:` note saying so.
+> **In CrossPlay, none of the four workflows in this table runs on a pull
+> request.** `ci.yml` and `pr-formatting-check.yml` are disabled on GitHub;
+> `release.yml` and `release_candidate.yml` are dispatch-only, and the latter is
+> additionally gated on a `release/` ref, which the fork's `app/*` work branches
+> never match -- dispatching it from one gives a green run with zero jobs. All
+> four are kept rather than deleted so upstream syncs stay clean, and each
+> carries a `FORK CHANGE:` note saying so.
 >
-> What actually runs here is `crossplay-ci.yml` (build, clang-format, unit
-> tests, cppcheck, host suites) on every pull request and every push to
-> `xteink`, `crossplay-release.yml` on a `v*` tag, and `crossplay-autorelease.yml`
-> and `crossplay-emulator.yml` after a green run on `xteink`. The table below is
-> upstream's.
+> What actually runs here:
+>
+> - `crossplay-ci.yml` on every pull request and every push to `xteink`: jobs
+>   `build` (four device envs, the simulator and every host suite), `relwatch`,
+>   `release-notes-line`, `clang-format`, `unit-tests` and `cppcheck`.
+> - `crossplay-emulator.yml` on a push to `xteink` touching the emulator's
+>   sources -- concurrently with CI, not after it.
+> - `crossplay-autorelease.yml` after a CI run on `xteink` **concludes
+>   successfully**; it is the only one keyed to a green run.
+> - `crossplay-release.yml` on a `v*` tag.
+>
+> The table below is upstream's.
 
 **GitHub Actions** run automatically on pull requests:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -968,6 +968,19 @@ build_flags =
 
 ### CI/CD Pipeline Awareness
 
+> **In CrossPlay, not one of the four workflows in this table runs.** `ci.yml`
+> and `pr-formatting-check.yml` are disabled on GitHub; `release.yml` and
+> `release_candidate.yml` are dispatch-only, and the latter is also gated on a
+> `release/` ref this fork's `app/*` branches never match. All four are kept
+> rather than deleted so upstream syncs stay clean, and each carries a
+> `FORK CHANGE:` note saying so.
+>
+> What actually runs here is `crossplay-ci.yml` (build, clang-format, unit
+> tests, cppcheck, host suites) on every pull request and every push to
+> `xteink`, `crossplay-release.yml` on a `v*` tag, and `crossplay-autorelease.yml`
+> and `crossplay-emulator.yml` after a green run on `xteink`. The table below is
+> upstream's.
+
 **GitHub Actions** run automatically on pull requests:
 
 | Workflow      | File                                        | Purpose                |

--- a/host-tests/autorelease/run.sh
+++ b/host-tests/autorelease/run.sh
@@ -52,6 +52,23 @@ trap 'rm -rf "$WORK"' EXIT
 PASS=0; FAIL=0
 ok()  { PASS=$((PASS+1)); echo "  ok   $1"; }
 bad() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+# A skip is information on a laptop whose clone legitimately lacks a tag. In CI
+# every input is meant to be there, so a check that did not run is a FAILURE --
+# the shape host-tests/release, relwatch and boardmigrate already use. Without
+# it, dropping fetch-tags from the workflow puts this suite straight back to
+# passing while proving nothing about the one range taken from the real
+# repository.
+#
+# Unindented on purpose: check.sh surfaces a suite's skips with grep -E "^SKIP",
+# so a message with leading spaces is invisible LOCALLY as well -- which is how
+# this one managed to be both unguarded and unseen.
+skip() {
+  if [ -n "${CI:-}" ]; then
+    bad "$1 (a skip is a failure in CI: the inputs should be present here)"
+  else
+    echo "SKIP autorelease  $1"
+  fi
+}
 q()   { "$@" >/dev/null 2>&1; }
 
 # Both files, in the shape release_notes.py writes them. Used by every fixture
@@ -688,7 +705,7 @@ if git -C "$REPO_ROOT" rev-parse -q --verify v1.12.20 >/dev/null 2>&1 &&
     fi
   fi
 else
-  echo "  SKIP v1.12.20/v1.12.21 not in this clone; the real-range checks did not run"
+  skip "v1.12.20/v1.12.21 not in this clone; the real-range checks did not run"
 fi
 
 echo "$((PASS+FAIL)) checks, $FAIL failed"

--- a/host-tests/checksh/run.sh
+++ b/host-tests/checksh/run.sh
@@ -1374,6 +1374,14 @@ if not found:
     print("FAIL checksh  no suite prints a SKIP at all; this just checked nothing")
 SKIPS
 
+# The python above producing nothing -- a syntax error, a missing suites dir --
+# would add zero checks and pass, which is the exact shape this whole section
+# exists to refuse.
+checks=$((checks + 1))
+if [ ! -s "$WORK/skips" ]; then
+  failed=$((failed + 1))
+  echo "FAIL checksh  the skip-visibility scan produced no output at all, so it asserted nothing"
+fi
 while IFS= read -r line; do
   checks=$((checks + 1))
   case "$line" in FAIL*) failed=$((failed + 1)); echo "$line" ;; esac

--- a/host-tests/checksh/run.sh
+++ b/host-tests/checksh/run.sh
@@ -1305,5 +1305,79 @@ else
   echo "FAIL checksh  could not lift the submodule wiring, freshness wiring, verdict or qualifier out of check.sh"
 fi
 
+# -- a skip must be VISIBLE, and it must be a FAILURE in CI -------------------
+#
+# check.sh surfaces a suite's skips with one grep (`grep -E "^SKIP"`), which is
+# the entire mechanism by which a check that did not run is distinguished from
+# one that passed. host-tests/autorelease printed its skip INDENTED, so that
+# anchor never matched it: the suite could skip its only real-repository range
+# and say nothing a human would see. It also had no CI guard, unlike release,
+# relwatch and boardmigrate, so the same skip was silent on the runner too --
+# unguarded and unseen, the two halves that make each other invisible.
+#
+# Written to DISCOVER rather than to assert: it walks every suite, finds every
+# SKIP any of them can print, and holds each against check.sh's own pattern
+# lifted out of check.sh. A copy of the pattern here would drift the moment
+# somebody tightened the real one.
+python3 - "$CHECK" "$HERE/.." <<'SKIPS' >"$WORK/skips"
+import os, re, sys
+
+check_src = open(sys.argv[1]).read()
+suites = sys.argv[2]
+
+# The detector itself, lifted. If it ever stops existing, everything below is
+# checking a contract nothing enforces, so that is the first failure.
+m = re.search(r'grep -E "([^"]*SKIP[^"]*)"', check_src)
+if not m:
+    print("FAIL checksh  check.sh no longer greps a suite's log for SKIP, so nothing "
+          "surfaces a check that did not run -- and every assertion below would pass "
+          "by having no contract to test")
+    raise SystemExit(0)
+anchor = m.group(1)
+pattern = re.compile(anchor)
+print("ok    check.sh surfaces skips with %s" % anchor)
+
+# What a suite can print as a skip: the text of an echo whose message begins
+# with SKIP. That deliberately does not match "FAIL ... SKIPPED ..." messages,
+# which are failures already, or the word inside a grep.
+echoed = re.compile(r'echo\s+"([^"]*)"')
+is_skip = re.compile(r'\s*SKIP\b')
+
+found = False
+for name in sorted(os.listdir(suites)):
+    run = os.path.join(suites, name, "run.sh")
+    if not os.path.isfile(run):
+        continue
+    src = open(run).read()
+    msgs = [t for t in echoed.findall(src) if is_skip.match(t)]
+    if not msgs:
+        continue
+    found = True
+    for t in msgs:
+        if pattern.search(t):
+            print("ok    %s: %r is visible to check.sh" % (name, t))
+        else:
+            print("FAIL checksh  host-tests/%s prints %r, which check.sh's own %s does "
+                  "not match: that suite can skip and NOTHING says so" % (name, t, anchor))
+    # Crude on purpose -- one mention of ${CI:-} anywhere in the file, rather
+    # than an attempt to decide statically which branch it guards. A suite that
+    # can skip and never mentions CI cannot be turning a skip into a failure
+    # there, which is the shape this is looking for.
+    if "${CI:-}" in src:
+        print("ok    %s: it knows about CI" % name)
+    else:
+        print("FAIL checksh  host-tests/%s can print a SKIP and never mentions ${CI:-}: "
+              "on the runner, where every input is meant to be present, the check does "
+              "not run and the suite still exits 0" % name)
+
+if not found:
+    print("FAIL checksh  no suite prints a SKIP at all; this just checked nothing")
+SKIPS
+
+while IFS= read -r line; do
+  checks=$((checks + 1))
+  case "$line" in FAIL*) failed=$((failed + 1)); echo "$line" ;; esac
+done < "$WORK/skips"
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/host-tests/checksh/run.sh
+++ b/host-tests/checksh/run.sh
@@ -1337,11 +1337,28 @@ anchor = m.group(1)
 pattern = re.compile(anchor)
 print("ok    check.sh surfaces skips with %s" % anchor)
 
-# What a suite can print as a skip: the text of an echo whose message begins
-# with SKIP. That deliberately does not match "FAIL ... SKIPPED ..." messages,
-# which are failures already, or the word inside a grep.
-echoed = re.compile(r'echo\s+"([^"]*)"')
+# What a suite can print as a skip: the message an echo or printf emits that
+# begins with SKIP, in either quoting style. Matching only `echo "..."` left
+# three silent escapes -- printf, single quotes, and flags before the message.
+# None of them merely passed: each removed the suite from this scan entirely,
+# dropping its check count with no failure, which is the same "counts nothing,
+# reads as green" shape this section exists to refuse.
+#
+# It deliberately does not match "FAIL ... SKIPPED ..." messages, which are
+# failures already, or the word inside a grep pattern.
+emitted = re.compile(r"""(?:echo|printf)\s+(?:-[A-Za-z]+\s+)*(?:"([^"]*)"|'([^']*)')""")
 is_skip = re.compile(r'\s*SKIP\b')
+# "This suite prints a skip somewhere" -- asked WITHOUT assuming the order the
+# two words appear in. The first version of this was `echo ... SKIP`, which a
+# skip assembled into a variable first (`m="SKIP ..."; echo "$m"`) walks
+# straight past, and the suite vanishes from the scan exactly as before.
+# Comments are stripped so prose about skips does not count as printing one.
+def names_skip(src):
+    for line in src.splitlines():
+        bare = line.split('#', 1)[0]
+        if re.search(r'\bSKIP\b', bare) and re.search(r'\b(?:echo|printf)\b', bare):
+            return True
+    return False
 
 found = False
 for name in sorted(os.listdir(suites)):
@@ -1349,8 +1366,14 @@ for name in sorted(os.listdir(suites)):
     if not os.path.isfile(run):
         continue
     src = open(run).read()
-    msgs = [t for t in echoed.findall(src) if is_skip.match(t)]
+    msgs = [(d or q) for d, q in emitted.findall(src) if is_skip.match(d or q)]
     if not msgs:
+        # It prints no skip, or it prints one this scan cannot read. Those are
+        # different answers, and only one of them is fine.
+        if names_skip(src):
+            print("FAIL checksh  host-tests/%s emits SKIP in a form this scan cannot read, so "
+                  "nothing checks that its skip is visible; spell it as a plain echo or printf "
+                  "whose message starts with SKIP" % name)
         continue
     found = True
     for t in msgs:

--- a/host-tests/ci/run.sh
+++ b/host-tests/ci/run.sh
@@ -378,6 +378,9 @@ for pair in "$YML:build" "$HERE/../../.github/workflows/crossplay-release.yml:re
     NONE)
       failed=$((failed + 1))
       echo "FAIL ci  $(basename "$f")'s '$j' job has no timeout-minutes, so a hung step holds a runner for GitHub's default six hours and reads as a slow build the whole time" ;;
+    "")
+      failed=$((failed + 1))
+      echo "FAIL ci  could not read a timeout out of $(basename "$f") at all; this check answered nothing rather than answering no" ;;
     *) : ;;
   esac
 done

--- a/host-tests/ci/run.sh
+++ b/host-tests/ci/run.sh
@@ -23,10 +23,13 @@ trap 'rm -rf "$WORK"' EXIT
 [ -f "$YML" ] || { echo "FAIL cannot find $YML"; exit 1; }
 
 # Lift a named step's shell body out of a workflow and dedent it, so these
-# tests cannot drift from the text the runner actually executes. ONE extractor
-# for every caller below: this python was copied three times in this file, and a
-# step whose name stops matching is a "could not extract" rather than a silent
-# pass in each copy separately.
+# tests cannot drift from the text the runner actually executes.
+#
+# This python was copied three times in this file. Two of the three were
+# identical and now call this; the third (the packaging-step check further down,
+# heredoc LIFT) is deliberately left alone -- it dedents by a hardcoded ten
+# spaces and exits 0 rather than raising when its step is absent, so folding it
+# in here would change its behaviour rather than tidy it.
 lift_step() {  # <workflow.yml> <step name>  -> that step's run: block, dedented
   python3 - "$1" "$2" <<'PY'
 import sys
@@ -98,8 +101,12 @@ expect "a non-ui suite failing still fails the build" fail
 # So it passes every local build and breaks CI alone, which is the one failure
 # mode nothing else here can see. It cost a red xteink that was blamed on
 # upstream for hours.
+# Same floor as everywhere else in this file: no .ini files found means this
+# loop asserted nothing, and said so by staying silent.
+inis=0
 for ini in "$HERE/../.."/platformio*.ini; do
   [ -f "$ini" ] || continue
+  inis=$((inis + 1))
   while IFS= read -r pin; do
     checks=$((checks + 1))
     if [ "${#pin}" -eq 40 ]; then
@@ -110,6 +117,11 @@ for ini in "$HERE/../.."/platformio*.ini; do
     fi
   done < <(grep -oE '^[^;#]*=(https?|git)://[^ ]*#[0-9a-f]+' "$ini" | sed 's/.*#//')
 done
+checks=$((checks + 1))
+if [ "$inis" -eq 0 ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci  no platformio*.ini found, so the git-pin check examined nothing"
+fi
 
 # The release trigger, which is a concurrency setting three files away.
 #
@@ -339,6 +351,54 @@ stale_says "2 is the script telling us it could not look" 2 fail ""
 # answers either, and it used to be filed as 'fresh' by the same else branch.
 stale_says "a missing script is not an answer" gone fail ""
 
+# -- and the gate the staleness answer feeds --------------------------------
+#
+# Everything above proves the step ANSWERS correctly. It says nothing about
+# whether the answer is read correctly, and the rebuild is skipped by an `if:`
+# on every later step. Change one of those to `== 'True'` and the job goes back
+# to doing nothing on every push, silently, with all four assertions above
+# still green -- the same failure one step downstream.
+#
+# So: derive the values the step can WRITE, derive the values the later steps
+# COMPARE against, and insist the second set is contained in the first. Neither
+# side is named here, because naming either is how this check would come to
+# agree with a typo.
+python3 - "$EYML" <<'GATE' >"$WORK/gate.out"
+import re, sys
+src = open(sys.argv[1]).read()
+i = src.index("- name: Is the emulator behind its sources?")
+j = src.index("- uses:", i)
+written = set(re.findall(r'stale=([A-Za-z]+)', src[i:j]))
+compared = set(re.findall(r"steps\.stale\.outputs\.stale\s*==\s*'([^']*)'", src))
+print("WRITTEN " + " ".join(sorted(written)))
+print("COMPARED " + " ".join(sorted(compared)))
+print("NGATED %d" % len(re.findall(r"steps\.stale\.outputs\.stale", src[j:])))
+GATE
+w=$(sed -n 's/^WRITTEN //p' "$WORK/gate.out")
+c=$(sed -n 's/^COMPARED //p' "$WORK/gate.out")
+n=$(sed -n 's/^NGATED //p' "$WORK/gate.out")
+
+checks=$((checks + 1))
+if [ -z "$w" ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci-emulator  the staleness step writes no stale=<value> at all; this check has nothing to compare against"
+fi
+checks=$((checks + 1))
+if [ "${n:-0}" -lt 1 ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci-emulator  no later step in crossplay-emulator.yml is gated on steps.stale.outputs.stale; either the gating was removed (every push now rebuilds) or it was renamed and the rebuild never runs"
+fi
+for v in $c; do
+  checks=$((checks + 1))
+  case " $w " in
+    *" $v "*) : ;;
+    *)
+      failed=$((failed + 1))
+      echo "FAIL ci-emulator  crossplay-emulator.yml gates a step on stale == '$v', but the staleness step only ever writes: $w. That comparison is never true, so the step it guards never runs and the job still reports success"
+      ;;
+  esac
+done
+
 # -- the long jobs have a cap on being stuck ---------------------------------
 #
 # No job in any workflow here had timeout-minutes, so every one of them
@@ -351,6 +411,12 @@ stale_says "a missing script is not an answer" gone fail ""
 # that "slow" and "stuck" look alike, and a blanket rule over every job would be
 # a number to maintain in six places for jobs that finish in one minute.
 job_timeout() {  # <workflow.yml> <job name>
+  # Read the JOB's own key, at the job's own indent. Walking the whole block
+  # and matching any timeout-minutes at any depth was wrong in the one
+  # direction that matters: every step is indented deeper, so a step-level
+  # `timeout-minutes: 5` satisfied a check about the job and the job still
+  # inherited the six-hour default. Anchored to the exact indent, so a key
+  # under `steps:` cannot answer for the job above it.
   python3 - "$1" "$2" <<'TMO'
 import re, sys
 lines = open(sys.argv[1]).read().splitlines()
@@ -359,15 +425,26 @@ try:
 except StopIteration:
     print('NOJOB'); raise SystemExit(0)
 for l in lines[i + 1:]:
-    if l.strip() and not l.startswith('    '):
+    if not l.strip():
+        continue
+    indent = len(l) - len(l.lstrip())
+    if indent <= 2:          # the next job, or a top-level key: block over
         break
-    m = re.match(r'\s*timeout-minutes:\s*(\d+)', l)
+    if indent != 4:          # deeper than the job's own keys -- a step, not the job
+        continue
+    m = re.match(r'timeout-minutes:\s*(\d+)\s*$', l.strip())
     if m:
         print(m.group(1)); raise SystemExit(0)
 print('NONE')
 TMO
 }
-for pair in "$YML:build" "$HERE/../../.github/workflows/crossplay-release.yml:release"; do
+# crossplay-emulator.yml's rebuild job belongs here for exactly the reason the
+# other two do, and more so: it shallow-clones emsdk from GitHub, installs a
+# toolchain, runs pio and builds wasm. It was the job that best fit the argument
+# and the one job the first version of this left out.
+for pair in "$YML:build" \
+            "$HERE/../../.github/workflows/crossplay-release.yml:release" \
+            "$HERE/../../.github/workflows/crossplay-emulator.yml:rebuild"; do
   f="${pair%:*}"; j="${pair##*:}"
   checks=$((checks + 1))
   t="$(job_timeout "$f" "$j")"
@@ -381,7 +458,16 @@ for pair in "$YML:build" "$HERE/../../.github/workflows/crossplay-release.yml:re
     "")
       failed=$((failed + 1))
       echo "FAIL ci  could not read a timeout out of $(basename "$f") at all; this check answered nothing rather than answering no" ;;
-    *) : ;;
+    *)
+      # A number, but it also has to be a STUCK cap rather than a budget. Both
+      # of these jobs are measured at 19-20 minutes; a cap at or below that
+      # kills honest builds, and the comments beside them argue for headroom
+      # that nothing was holding them to.
+      if [ "$t" -lt 30 ]; then
+        failed=$((failed + 1))
+        echo "FAIL ci  $(basename "$f")'s '$j' job caps at ${t}m, and that job is measured at 19-20 minutes; a cap this tight fails honest builds instead of catching stuck ones"
+      fi
+      ;;
   esac
 done
 
@@ -401,16 +487,28 @@ done
 # Written over "every workflow that is not this fork's own" rather than over a
 # list of the four, so the NEXT upstream workflow a sync brings in arrives red
 # until somebody says whether it runs here.
-for wf in "$HERE/../.."/.github/workflows/*.yml; do
+# BOTH extensions. GitHub runs .yaml as readily as .yml, so a rule written over
+# *.yml alone lets in half of what a sync could bring. And the marker asked for
+# is the one the message names, colon included: `grep -q "FORK CHANGE"` was
+# satisfied by prose merely mentioning the convention.
+seen=0
+for wf in "$HERE/../.."/.github/workflows/*.yml "$HERE/../.."/.github/workflows/*.yaml; do
+  [ -f "$wf" ] || continue
+  seen=$((seen + 1))
   case "$(basename "$wf")" in crossplay-*) continue ;; esac
   checks=$((checks + 1))
-  if grep -q "FORK CHANGE" "$wf"; then
+  if grep -q "FORK CHANGE:" "$wf"; then
     :
   else
     failed=$((failed + 1))
     echo "FAIL ci  $(basename "$wf") is inherited from upstream and carries no 'FORK CHANGE:' note saying whether it runs in this fork; a disabled or unreachable workflow reads exactly like a live one"
   fi
 done
+checks=$((checks + 1))
+if [ "$seen" -eq 0 ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci  found no workflow files at all; the fork-marker rule just checked nothing"
+fi
 
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/host-tests/ci/run.sh
+++ b/host-tests/ci/run.sh
@@ -22,12 +22,16 @@ trap 'rm -rf "$WORK"' EXIT
 
 [ -f "$YML" ] || { echo "FAIL cannot find $YML"; exit 1; }
 
-# Lift the step body out of the yaml and dedent it, so this test cannot drift
-# from the text CI actually runs.
-python3 - "$YML" >"$WORK/step.sh" <<'PY'
+# Lift a named step's shell body out of a workflow and dedent it, so these
+# tests cannot drift from the text the runner actually executes. ONE extractor
+# for every caller below: this python was copied three times in this file, and a
+# step whose name stops matching is a "could not extract" rather than a silent
+# pass in each copy separately.
+lift_step() {  # <workflow.yml> <step name>  -> that step's run: block, dedented
+  python3 - "$1" "$2" <<'PY'
 import sys
 lines = open(sys.argv[1]).read().splitlines()
-i = next(i for i, l in enumerate(lines) if l.strip() == '- name: Host tests')
+i = next(i for i, l in enumerate(lines) if l.strip() == '- name: ' + sys.argv[2])
 j = next(j for j in range(i, len(lines)) if lines[j].strip() == 'run: |')
 body, indent = [], None
 for l in lines[j + 1:]:
@@ -42,7 +46,9 @@ for l in lines[j + 1:]:
     body.append(l[indent:])
 print('\n'.join(body))
 PY
+}
 
+lift_step "$YML" 'Host tests' >"$WORK/step.sh"
 [ -s "$WORK/step.sh" ] || { echo "FAIL could not extract the Host tests step"; exit 1; }
 
 fake() {  # name, exit code, stdout
@@ -137,24 +143,7 @@ esac
 # present but inverted fails here and nowhere else. v1.12.16 was built and
 # published twice on 2026-09-04, one run per path, before either existed.
 AYML="$HERE/../../.github/workflows/crossplay-autorelease.yml"
-python3 - "$AYML" 'Build and publish the release' >"$WORK/publish.sh" <<'PY'
-import sys
-lines = open(sys.argv[1]).read().splitlines()
-i = next(i for i, l in enumerate(lines) if l.strip() == '- name: ' + sys.argv[2])
-j = next(j for j in range(i, len(lines)) if lines[j].strip() == 'run: |')
-body, indent = [], None
-for l in lines[j + 1:]:
-    if not l.strip():
-        body.append('')
-        continue
-    cur = len(l) - len(l.lstrip())
-    if indent is None:
-        indent = cur
-    if cur < indent:
-        break
-    body.append(l[indent:])
-print('\n'.join(body))
-PY
+lift_step "$AYML" 'Build and publish the release' >"$WORK/publish.sh"
 [ -s "$WORK/publish.sh" ] || { echo "FAIL could not extract the publish step from crossplay-autorelease.yml"; exit 1; }
 mkdir -p "$WORK/bin"
 printf '#!/bin/sh\necho "gh $*" >> "%s/gh.calls"\n' "$WORK" >"$WORK/bin/gh"; chmod +x "$WORK/bin/gh"
@@ -292,6 +281,133 @@ else
     echo "FAIL ci  the step demands release prose from a pull request that publishes nothing"
   fi
 fi
+
+# -- the emulator rebuild must be able to FAIL -------------------------------
+#
+# scripts_local/emulator-stale.sh answers three ways, and says so in its own
+# header: 0 stale, 1 fresh, 2 it could not look. crossplay-emulator.yml asked it
+# inside `if bash ...; then stale=true; else stale=false; fi`, which keeps only
+# "was that a zero" -- so the crash was recorded as fresh. Every later step in
+# that job is gated on `steps.stale.outputs.stale == 'true'`, so all of them
+# were skipped, and the job ended green having rebuilt nothing. That is
+# byte-for-byte the outcome of a genuinely fresh emulator, and site/emulator/ is
+# what the web page runs.
+#
+# EXECUTED against a fake script rather than grepped, for the reason at the top
+# of this file: the broken shape and the fixed one both contain the script's
+# name, both mention GITHUB_OUTPUT, and a grep for either matches both.
+EYML="$HERE/../../.github/workflows/crossplay-emulator.yml"
+lift_step "$EYML" 'Is the emulator behind its sources?' >"$WORK/stale.sh"
+[ -s "$WORK/stale.sh" ] || { echo "FAIL could not extract the staleness step from crossplay-emulator.yml"; exit 1; }
+
+stale_says() {  # label, the script's exit code, wanted step outcome, wanted output line
+  local label="$1" rc="$2" want="$3" line="$4" code got
+  rm -rf "$WORK/emu"; mkdir -p "$WORK/emu/scripts_local"
+  # "gone" is the script deleted or renamed rather than any exit code, which is
+  # the same family of non-answer and used to be filed as 'fresh' too.
+  if [ "$rc" != gone ]; then
+    printf '#!/bin/sh\necho "pretending"\nexit %s\n' "$rc" >"$WORK/emu/scripts_local/emulator-stale.sh"
+  fi
+  : >"$WORK/emu/gh_output"
+  # bash -eo pipefail is what GitHub Actions gives a `run:` block, and it is
+  # half of what made this subtle: a bare `bash script` returning 1 under -e
+  # would abort the step, so the fix has to hold the code without tripping it.
+  ( cd "$WORK/emu" && GITHUB_OUTPUT="$WORK/emu/gh_output" bash -eo pipefail "$WORK/stale.sh" ) >"$WORK/emu/log" 2>&1
+  code=$?
+  got=pass; [ $code -ne 0 ] && got=fail
+  checks=$((checks + 1))
+  if [ "$got" != "$want" ]; then
+    failed=$((failed + 1))
+    echo "FAIL ci-emulator  $label: emulator-stale.sh exited $rc and the step $got, wanted $want"
+    sed 's/^/       /' "$WORK/emu/log"
+    return
+  fi
+  checks=$((checks + 1))
+  if [ -n "$line" ] && ! grep -qx "$line" "$WORK/emu/gh_output"; then
+    failed=$((failed + 1))
+    echo "FAIL ci-emulator  $label: exit $rc did not record '$line' ($(tr '\n' ' ' < "$WORK/emu/gh_output"))"
+  elif [ -z "$line" ] && grep -q 'stale=' "$WORK/emu/gh_output"; then
+    failed=$((failed + 1))
+    echo "FAIL ci-emulator  $label: exit $rc still recorded '$(tr '\n' ' ' < "$WORK/emu/gh_output")'; a script that could not answer must not be filed as an answer, least of all as the answer that skips the rebuild"
+  fi
+}
+
+stale_says "0 means stale, and the rebuild runs"  0 pass "stale=true"
+stale_says "1 means fresh, and the job does nothing" 1 pass "stale=false"
+stale_says "2 is the script telling us it could not look" 2 fail ""
+# The script deleted, renamed or not executable: 127 is not one of the two real
+# answers either, and it used to be filed as 'fresh' by the same else branch.
+stale_says "a missing script is not an answer" gone fail ""
+
+# -- the long jobs have a cap on being stuck ---------------------------------
+#
+# No job in any workflow here had timeout-minutes, so every one of them
+# inherited GitHub's SIX HOUR default. A hung step -- a fetch retrying forever,
+# a build waiting on a lock -- therefore holds a runner for a quarter of a day
+# while the thing that started it reads as still running, which is the same
+# display as a build that is merely slow.
+#
+# Only the two that cross-compile are asserted: they are the ones long enough
+# that "slow" and "stuck" look alike, and a blanket rule over every job would be
+# a number to maintain in six places for jobs that finish in one minute.
+job_timeout() {  # <workflow.yml> <job name>
+  python3 - "$1" "$2" <<'TMO'
+import re, sys
+lines = open(sys.argv[1]).read().splitlines()
+try:
+    i = next(i for i, l in enumerate(lines) if l.rstrip() == '  ' + sys.argv[2] + ':')
+except StopIteration:
+    print('NOJOB'); raise SystemExit(0)
+for l in lines[i + 1:]:
+    if l.strip() and not l.startswith('    '):
+        break
+    m = re.match(r'\s*timeout-minutes:\s*(\d+)', l)
+    if m:
+        print(m.group(1)); raise SystemExit(0)
+print('NONE')
+TMO
+}
+for pair in "$YML:build" "$HERE/../../.github/workflows/crossplay-release.yml:release"; do
+  f="${pair%:*}"; j="${pair##*:}"
+  checks=$((checks + 1))
+  t="$(job_timeout "$f" "$j")"
+  case "$t" in
+    NOJOB)
+      failed=$((failed + 1))
+      echo "FAIL ci  $(basename "$f") has no job called '$j'; this assertion is looking at nothing" ;;
+    NONE)
+      failed=$((failed + 1))
+      echo "FAIL ci  $(basename "$f")'s '$j' job has no timeout-minutes, so a hung step holds a runner for GitHub's default six hours and reads as a slow build the whole time" ;;
+    *) : ;;
+  esac
+done
+
+# -- an inherited workflow must say what it does HERE -------------------------
+#
+# ci.yml and pr-formatting-check.yml are disabled_manually on GitHub and said
+# nothing about it in the file: ci.yml still reads `on: pull_request`, which is
+# as live-looking a trigger as exists. release_candidate.yml is worse -- it is
+# dispatch-only AND gated on a `release/` ref that this fork's `app/*` branches
+# can never match, so dispatching it produces a green run with zero jobs, which
+# is indistinguishable from a release candidate that built.
+#
+# None of them is deleted, because deleting them conflicts on every sync from
+# upstream. So the rule is that they carry the reason instead, in release.yml's
+# shape.
+#
+# Written over "every workflow that is not this fork's own" rather than over a
+# list of the four, so the NEXT upstream workflow a sync brings in arrives red
+# until somebody says whether it runs here.
+for wf in "$HERE/../.."/.github/workflows/*.yml; do
+  case "$(basename "$wf")" in crossplay-*) continue ;; esac
+  checks=$((checks + 1))
+  if grep -q "FORK CHANGE" "$wf"; then
+    :
+  else
+    failed=$((failed + 1))
+    echo "FAIL ci  $(basename "$wf") is inherited from upstream and carries no 'FORK CHANGE:' note saying whether it runs in this fork; a disabled or unreachable workflow reads exactly like a live one"
+  fi
+done
 
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/host-tests/qastack/run.sh
+++ b/host-tests/qastack/run.sh
@@ -26,15 +26,29 @@ SCRIPT="$HERE/../../server/read-bridge/tests/qa_stack.sh"
 checks=0
 failed=0
 
-[ -r "$SCRIPT" ] || { echo "SKIP qastack  $SCRIPT is not readable"; echo "0 checks, 0 failed"; exit 0; }
+# Same rule as host-tests/release, relwatch and boardmigrate: a skip is
+# information on a laptop, and a FAILURE in CI, where every input is meant to be
+# present. Both paths below are things CI has -- the script is committed, and nc
+# is on the runner image -- so a skip here means CI stopped being the machine
+# this suite thinks it is, which is worth a red rather than a line nobody reads.
+skip() {
+  if [ -n "${CI:-}" ]; then
+    echo "FAIL qastack  $1 (a skip is a failure in CI: the inputs should be present here)"
+    echo "1 checks, 1 failed"
+    exit 1
+  fi
+  echo "SKIP qastack  $1"
+  echo "0 checks, 0 failed"
+  exit 0
+}
+
+[ -r "$SCRIPT" ] || skip "$SCRIPT is not readable"
 
 # nc is not optional here: down()'s wait is written with `nc -z`, and so is up()'s
 # port guard. Without it the wait breaks out of its loop on the first iteration
 # and this suite would pass while proving nothing, which is the failure mode this
 # whole file exists to refuse.
-command -v nc >/dev/null 2>&1 || {
-  echo "SKIP qastack  no nc on PATH; qa_stack.sh's port wait cannot be exercised"
-  echo "0 checks, 0 failed"; exit 0; }
+command -v nc >/dev/null 2>&1 || skip "no nc on PATH; qa_stack.sh's port wait cannot be exercised"
 
 WORK="$(mktemp -d)"
 trap 'for p in "$WORK"/*.pid; do [ -f "$p" ] && kill -9 "$(cat "$p")" 2>/dev/null; done; rm -rf "$WORK"' EXIT

--- a/host-tests/release/run.sh
+++ b/host-tests/release/run.sh
@@ -1117,5 +1117,93 @@ else
   ok
 fi
 
+# -- the workflow that PUBLISHES must serialise against itself ----------------
+#
+# A concurrency group does not span workflows. crossplay-autorelease.yml carries
+# `group: crossplay-release`, which reads like the release is serialised and
+# serialises only the autorelease; this file -- the one that builds the images
+# and uploads them to the release -- had no `concurrency:` at all.
+#
+# It has already gone wrong. v1.12.16 was built and published TWICE, one second
+# apart: run 33884760714 on the tag push and 33884760111 on the dispatch, same
+# tag, both about fourteen minutes of runner, both racing to upload the same
+# assets, and both exiting 0. The dispatch condition asserted above closes the
+# path that caused THAT one, but it makes the collision avoidable rather than
+# impossible: a hand dispatch during a tag build still overlaps, and the guard
+# lives in a different file from the workflow it protects.
+#
+# Read out of the workflow's own top-level block, not out of any job's.
+CONC="$(awk '/^concurrency:/{f=1;next} /^[a-z]/{f=0} f' "$WF")"
+checks=$((checks + 1))
+GROUP="$(printf '%s\n' "$CONC" | sed -n 's/^ *group: *//p')"
+if [ -z "$GROUP" ]; then
+  failed=$((failed + 1))
+  echo "FAIL release  crossplay-release.yml has no top-level concurrency group, so two starts on one tag build and publish the same release side by side -- which is what v1.12.16 did"
+else
+  ok
+fi
+
+# Grouped by the ref. A single fixed group would serialise two DIFFERENT tags
+# against each other, which is not the problem being solved and would leave a
+# release waiting on an unrelated one.
+checks=$((checks + 1))
+case "$GROUP" in
+  "") : ;;  # already failed above
+  *'github.ref'*) ok ;;
+  *)
+    failed=$((failed + 1))
+    echo "FAIL release  crossplay-release.yml's concurrency group ('$GROUP') is not keyed by the ref, so two different tags queue behind each other instead of two runs of the same one"
+    ;;
+esac
+
+# And it must not cancel. A publish killed half way leaves a GitHub release
+# carrying some of its assets, and the fleet's updater matches asset names: a
+# release with firmware.bin and no firmware-sticky.bin is not a smaller
+# release, it is a broken one for every Sticky in the field.
+checks=$((checks + 1))
+case "$(printf '%s\n' "$CONC" | sed -n 's/^ *cancel-in-progress: *//p')" in
+  false) ok ;;
+  "")
+    failed=$((failed + 1))
+    echo "FAIL release  crossplay-release.yml does not set cancel-in-progress, and the default cancels: a superseded publish can leave a release with only some of its assets"
+    ;;
+  *)
+    failed=$((failed + 1))
+    echo "FAIL release  crossplay-release.yml cancels its own in-progress publish; a half-uploaded release is worse than a duplicated one"
+    ;;
+esac
+
+# -- the shipping binary is built by the toolchain everything else is built by -
+#
+# This workflow installed `platformio` from PyPI, unpinned: a different
+# distribution from the pioarduino fork every other build workflow in this
+# repository pins, and free to change between two tags with no commit of ours.
+# The one binary that reaches devices was the one binary nothing had verified
+# the toolchain of.
+#
+# The expected pin is DISCOVERED from the other workflows rather than written
+# here, so a deliberate bump moves this file's answer with them instead of
+# turning a version upgrade into a failing test that names the old number.
+checks=$((checks + 1))
+WANT="$(grep -ho 'platformio-core/archive/refs/tags/[^ ]*\.zip' "$ROOT"/.github/workflows/*.yml | sort | uniq -c | sort -rn | head -1 | sed 's/^ *[0-9]* *//')"
+if [ -z "$WANT" ]; then
+  failed=$((failed + 1))
+  echo "FAIL release  no workflow in this repository pins platformio-core by tag, so there is nothing to hold the release build against"
+elif grep -q "$WANT" "$WF"; then
+  ok
+else
+  failed=$((failed + 1))
+  echo "FAIL release  crossplay-release.yml does not install $WANT, the pinned PlatformIO every other build workflow uses: the image that ships to devices is built by a toolchain nothing else in this repository has verified"
+fi
+
+# Belt and braces: whatever it installs, it must not be an unpinned one.
+checks=$((checks + 1))
+if grep -qE 'pip install +(--upgrade|-U) +platformio *$' "$WF"; then
+  failed=$((failed + 1))
+  echo "FAIL release  crossplay-release.yml installs 'platformio' unpinned; whatever PyPI published most recently builds the release"
+else
+  ok
+fi
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/host-tests/release/run.sh
+++ b/host-tests/release/run.sh
@@ -1273,23 +1273,35 @@ esac
 # The expected pin is DISCOVERED from the other workflows rather than written
 # here, so a deliberate bump moves this file's answer with them instead of
 # turning a version upgrade into a failing test that names the old number.
+#
+# Read the INSTALL COMMANDS, never the file. A whole-file grep for the pin is
+# satisfied by a comment mentioning it -- and this file now carries a comment
+# that explains the pin, so the check would have been one reword away from
+# passing over `pip install platformio`. Strip comments first, then look only
+# at lines that install something.
+INSTALLS="$(sed 's/#.*//' "$WF" | grep -E 'pip +install')"
+ALL_INSTALLS="$(sed 's/#.*//' "$ROOT"/.github/workflows/*.yml | grep -E 'pip +install')"
+
 checks=$((checks + 1))
-WANT="$(grep -ho 'platformio-core/archive/refs/tags/[^ ]*\.zip' "$ROOT"/.github/workflows/*.yml | sort | uniq -c | sort -rn | head -1 | sed 's/^ *[0-9]* *//')"
+WANT="$(printf '%s\n' "$ALL_INSTALLS" | grep -o 'platformio-core/archive/refs/tags/[^ ]*\.zip' | sort | uniq -c | sort -rn | head -1 | sed 's/^ *[0-9]* *//')"
 if [ -z "$WANT" ]; then
   failed=$((failed + 1))
-  echo "FAIL release  no workflow in this repository pins platformio-core by tag, so there is nothing to hold the release build against"
-elif grep -q "$WANT" "$WF"; then
+  echo "FAIL release  no workflow in this repository pins platformio-core by tag on an install line, so there is nothing to hold the release build against"
+elif printf '%s\n' "$INSTALLS" | grep -qF "$WANT"; then
   ok
 else
   failed=$((failed + 1))
   echo "FAIL release  crossplay-release.yml does not install $WANT, the pinned PlatformIO every other build workflow uses: the image that ships to devices is built by a toolchain nothing else in this repository has verified"
 fi
 
-# Belt and braces: whatever it installs, it must not be an unpinned one.
+# And the other direction, because the check above only asks whether the right
+# pin appears SOMEWHERE among the installs. An install of bare `platformio`
+# beside it is still an unpinned toolchain, in whatever spelling: with a flag,
+# without one, quoted, or version-pinned to something else on PyPI.
 checks=$((checks + 1))
-if grep -qE 'pip install +(--upgrade|-U) +platformio *$' "$WF"; then
+if printf '%s\n' "$INSTALLS" | grep -qE 'pip +install +([^|&;]*[[:space:]])?("|'"'"')?platformio("|'"'"')?([=<>!~][^[:space:]]*)?[[:space:]]*$'; then
   failed=$((failed + 1))
-  echo "FAIL release  crossplay-release.yml installs 'platformio' unpinned; whatever PyPI published most recently builds the release"
+  echo "FAIL release  crossplay-release.yml installs PyPI 'platformio' rather than the pioarduino archive; whatever PyPI published most recently would build the release"
 else
   ok
 fi

--- a/host-tests/release/run.sh
+++ b/host-tests/release/run.sh
@@ -1126,8 +1126,8 @@ fi
 #
 # It has already gone wrong. v1.12.16 was built and published TWICE, one second
 # apart: run 33884760714 on the tag push and 33884760111 on the dispatch, same
-# tag, both about fourteen minutes of runner, both racing to upload the same
-# assets, and both exiting 0. The dispatch condition asserted above closes the
+# tag, twelve minutes each, both racing to upload the same assets, and both
+# exiting 0. The dispatch condition asserted above closes the
 # path that caused THAT one, but it makes the collision avoidable rather than
 # impossible: a hand dispatch during a tag build still overlaps, and the guard
 # lives in a different file from the workflow it protects.


### PR DESCRIPTION
Board card #235. An audit probed the eight workflow files; each finding below was verified by running it, not by reading it.

## What changed

**1. The emulator rebuild could not fail.** `scripts_local/emulator-stale.sh` answers three ways (0 stale, 1 fresh, 2 it could not look) and `crossplay-emulator.yml` asked it inside an `if`, which keeps only "was that zero". A crash landed in the `else` branch as `stale=false`, every later step is gated on `stale == 'true'`, and the job ended green having rebuilt nothing. That is byte for byte the outcome of a genuinely fresh emulator. The exit code is now captured and anything but 0 or 1 fails the job.

**2. `host-tests/autorelease`'s only SKIP was unguarded AND unseen.** Its siblings (`release`, `relwatch`, `boardmigrate`) turn a skip into a failure under CI; this one printed and moved on. It also printed *indented*, while `check.sh` surfaces skips with `grep -E "^SKIP"`, so the anchor never matched it locally either. Both halves fixed.

`host-tests/qastack` had the same gap, and the audit did not name it: **two** unguarded skips, not the one. CI runs every suite but `relwatch`, so both were live. Same fix. This is scope beyond the six.

**3. The shipping binary was built by an unverified toolchain.** `crossplay-release.yml` ran `pip install --upgrade platformio`: unpinned, and upstream PyPI PlatformIO rather than the `pioarduino v6.1.19` the other five build workflows all pin. The one binary that reaches devices was the one nobody had pinned the toolchain of.

**4. The workflow that PUBLISHES had no concurrency group.** `crossplay-autorelease.yml` carries `group: crossplay-release`, but a group does not span workflows, so the file that builds and uploads was ungrouped. v1.12.16 was built and published twice, one second apart, both exiting 0. The fix at the time was a condition on the dispatch side, which makes it avoidable rather than impossible: a hand dispatch during a tag build still overlaps, and the guard lives in a different file from the one it protects. Now `crossplay-release-${{ github.ref }}`, `cancel-in-progress: false` (a half-cancelled publish leaves a release missing assets, and both updaters match asset names).

**5. No job anywhere had `timeout-minutes`**, so all of them inherited GitHub's six-hour default. `build` gets 45, the release job gets 60. Stuck caps with wide headroom over ~15 minutes, not budgets.

**6. Three inherited workflows read as live and are not.** `ci.yml` and `pr-formatting-check.yml` are `disabled_manually` (confirmed with `gh workflow list --all`) and said nothing about it; `ci.yml` still reads `on: pull_request`. `release_candidate.yml` is worse: dispatch-only AND gated on a `release/` ref this fork's `app/*` branches cannot match, so dispatching it gives a green run with zero jobs. All three get `release.yml`'s `FORK CHANGE:` block. None deleted: deleting them conflicts on every upstream sync.

## Tests

Each was watched go red with its fix reverted, and each revert was diffed to prove it changed the file.

- `host-tests/ci` executes the lifted staleness step against a fake `emulator-stale.sh` (exit 0 / 1 / 2 / script deleted); asserts `timeout-minutes` on the two cross-compiling jobs; asserts every non-`crossplay-*` workflow carries a `FORK CHANGE` note, so **the next workflow a sync brings in arrives red until somebody says whether it runs here**.
- `host-tests/release` asserts the publishing workflow has a ref-keyed concurrency group that does not cancel, and installs the pin the other workflows use. The pin is *discovered* from them, so a deliberate bump moves this answer with it instead of failing while naming the old number.
- `host-tests/checksh` walks every suite, finds every SKIP any of them can print, and holds each against `check.sh`'s own grep pattern lifted out of `check.sh`; and flags a suite that can skip without mentioning `${CI:-}`.

A second commit fixes the same class of bug in both new checks: each could pass by producing nothing (a crashed scan counted zero checks; an empty `job_timeout` fell through to `*) : ;;`).

`host-tests/ci`'s three copies of the same yaml step extractor became one `lift_step()`.

## Docs

`AGENTS.md`'s CI/CD table named all four dead workflows as running automatically on pull requests. Corrected in place with the blockquote shape the file already uses for fork corrections.

## A cold review found eight things, and two of them were false claims

A critic with no context reviewed the first three commits. Worth naming, because
the whole premise of item 6 is that the next reader trusts a comment instead of
checking the file:

- `ci.yml` said `master` is "a branch this fork does not have". `git ls-remote --heads origin` lists `refs/heads/master`. It is inherited from upstream and nothing pushes to it, which is a different sentence.
- `release_candidate.yml` said it **cannot** run here. `refs/heads/release/1.5.0` exists and `workflow_dispatch` takes any ref, so a dispatch against it really would build four upstream RC envs. The true claim is narrower: from any branch anyone actually uses, it produces a green run with zero jobs.
- `AGENTS.md` repeated that, said the emulator rebuild runs "after a green run" (it triggers on the push, concurrently with CI — only the autorelease is keyed to a conclusion), and listed four of six jobs.

Four assertions could not fail, each now watched go red on the critic's own reproduction:

- `job_timeout` matched `timeout-minutes` at **any** depth, so a step-level `timeout-minutes: 5` satisfied a check about the job while the job kept the six-hour default. It also accepted any integer; a cap below 30 now fails, against a measured 19-20 minutes.
- The skip scan read only `echo "..."`. `printf`, single quotes and `echo -e` each removed the suite from the scan **entirely** — no ok, no FAIL, check count silently down.
- The PlatformIO pin check grepped the whole file including comments, and this change had just added a comment naming the pin. `pip install platformio` with the pin in a comment above it passed.
- The `FORK CHANGE` rule globbed `*.yml` only, and grepped `FORK CHANGE` while its message demanded `FORK CHANGE:`.

Two gaps the argument covered and the change did not: `crossplay-emulator.yml`'s own `rebuild` job had no cap (it shallow-clones emsdk, installs a toolchain, runs pio and builds wasm), and nothing checked that the staleness answer is **read** correctly — changing a downstream `if:` to `== 'True'` returns the job to doing nothing with all four staleness assertions still green. The values the step can write and the values later steps compare against are now derived separately and required to agree.

## Merge with app/deadgates (#85)

That branch landed a skip-visibility check in the same file while this was open, and git conflicted. Neither side is a superset: theirs scans the whole `host-tests` tree (`.sh`, `.py`, `.cpp`, `.c`, `.h`) with the real `grep -E` and found two never-run skips in `host-tests/study`; mine also asks whether a suite that can skip turns it into a **failure** under `$CI`, which theirs does not check at all and which is the half that was live on the runner. Resolved by keeping theirs for visibility and mine for the guard, deleting my redundant visibility half. The guard was reshaped in the process, so it was extracted and watched fail again rather than assumed.

Their change also widened `check.sh`'s own grep from `^SKIP` to `^[[:space:]]*SKIP`, which solves the visibility half of fix 2 a different way. The unindent stays as belt-and-braces; the CI guard on `autorelease` and `qastack` remains this branch's alone.

## Not verified

- No hardware. Nothing here reaches a device image except the toolchain the release is built with, which is now the same one CI has used for every build.
- **The concurrency group and the timeouts cannot be proven locally**; they are GitHub-side behaviour. The tests assert the workflow says it, not that GitHub honours it.
- The `${CI:-}` half of the skip check is deliberately crude: one mention anywhere in the file, rather than statically deciding which branch it guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

What is new: nothing changes on your device. Releases are built with the same pinned toolchain every other build here uses, instead of whatever PlatformIO version PyPI published that day, and a tag can no longer be built and published twice at once.



