### PR TITLE
test: four gates that could not fail, repaired and watched failing

### DIFF
--- a/host-tests/checksh/run.sh
+++ b/host-tests/checksh/run.sh
@@ -1305,5 +1305,75 @@ else
   echo "FAIL checksh  could not lift the submodule wiring, freshness wiring, verdict or qualifier out of check.sh"
 fi
 
+# ---------------------------------------------------------------------------
+# The SKIP surfacing, against every SKIP this tree can actually print.
+#
+# check.sh's host-tests loop ends with a grep whose comment reads "A check that
+# did not run must not scroll past looking like one that passed." That grep was
+# anchored at column zero for its whole life, and three of the six emitters
+# indent theirs by two spaces -- host-tests/study twice and host-tests/
+# autorelease once -- so the mechanism built to stop a skip hiding could not
+# see half of the skips. Both study ones were checks that had never run once.
+#
+# So the test does not assert a pattern. It DISCOVERS the skip lines the tree
+# can print, by reading the string literals out of every suite, and asserts
+# check.sh's own grep -- lifted from the file, not copied -- matches each one.
+# A future SKIP printed with any indentation adds itself to this list.
+SKIPGREP="$(grep -E '^[[:space:]]*grep -E .*SKIP.*LOGS' "$CHECK" | head -1)"
+checks=$((checks + 1))
+if [ -z "$SKIPGREP" ]; then
+  failed=$((failed + 1))
+  echo "FAIL checksh  could not lift the SKIP surfacing out of check.sh"
+else
+  # Just the pattern, as a literal: the line is
+  #   grep -E "<pattern>" "$LOGS/$name.log" | head -5 | sed ...
+  SKIPPAT="$(printf '%s\n' "$SKIPGREP" | sed -E 's/^[[:space:]]*grep -E "([^"]*)".*$/\1/')"
+  python3 - "$HERE/../.." "$SKIPPAT" <<'PY_SKIP'
+import pathlib, re, subprocess, sys
+
+root = pathlib.Path(sys.argv[1]).resolve()
+pattern = sys.argv[2]
+
+# Every string literal in a host suite that a run would print starting with
+# SKIP, with the indentation it would print. Comments are excluded: a line
+# whose first non-space characters are a comment marker prints nothing.
+emit = re.compile(r'(printf|print|echo|puts|cout)', re.I)
+literal = re.compile(r'"((?:[ \t]*)SKIP[^"\\]*)')
+lines = []
+for path in sorted((root / "host-tests").rglob("*")):
+    if not path.is_file() or path.suffix not in (".sh", ".py", ".cpp", ".c", ".h"):
+        continue
+    for raw in path.read_text(errors="replace").splitlines():
+        head = raw.lstrip()
+        if head.startswith(("//", "#", "*")):
+            continue
+        if not emit.search(raw):
+            continue
+        for m in literal.finditer(raw):
+            lines.append((path.relative_to(root), m.group(1)))
+
+if not lines:
+    print("FAIL checksh  found no SKIP emitters at all -- the discovery is broken,")
+    print("              which would make this assertion pass by finding nothing")
+    raise SystemExit(1)
+
+bad = []
+for where, text in lines:
+    # grep -E, exactly as check.sh runs it, against the one line.
+    hit = subprocess.run(["grep", "-E", pattern], input=text + "\n",
+                         text=True, capture_output=True).returncode == 0
+    if not hit:
+        bad.append((where, text))
+
+for where, text in bad:
+    print("FAIL checksh  check.sh's SKIP surfacing cannot see %r from %s" % (text, where))
+print("      (checked %d SKIP literals across the tree)" % len(lines))
+raise SystemExit(1 if bad else 0)
+PY_SKIP
+  if [ $? -ne 0 ]; then
+    failed=$((failed + 1))
+  fi
+fi
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/host-tests/revealsweep/sweep.cpp
+++ b/host-tests/revealsweep/sweep.cpp
@@ -239,6 +239,13 @@ struct Probe {
   // The collisions this transition is known to have, "fromAction/fromValue->
   // toAction/toValue", terminated by nullptr. Anything else the sweep finds
   // fails; anything here it no longer finds fails too.
+  //
+  // WHAT THIS UNIT DOES NOT CATCH, stated rather than left to be discovered:
+  // the key is the pair of actions, not the area, so a known collision that
+  // GROWS -- 12% of the source control becoming 100% -- keeps the same key and
+  // does not fail here. The percentage is printed every run, and the producer
+  // check below is exact, which is the case where a finger is provably on the
+  // rect. Adding area to the key would fail on every harmless layout nudge.
   const char* const* known = nullptr;
   // One line saying why the list above is what it is. Printed with the
   // findings so a reader of the log is told, not left to infer.

--- a/host-tests/revealsweep/sweep.cpp
+++ b/host-tests/revealsweep/sweep.cpp
@@ -16,7 +16,33 @@
 // therefore run twice, at two different metrics; a region whose verdict changes
 // between the two is reported as METRIC-DEPENDENT and must not be quoted as a
 // number.
+//
+// THIS IS A GATE, not a report. It was a report until 2026-09-05, and that is
+// the whole reason it is worth saying twice: main() printed what it found and
+// returned 0, there was no failure counter in the file, and it never emitted
+// the "N checks, M failed" line check.sh counts -- so check.sh printed
+// "revealsweep ok (0 sub-suite(s))" whatever the sweep discovered. A NEW
+// same-pixel collision, of exactly the kind Wavelength shipped, would have
+// scrolled past in a log nobody opens while the gate stayed green.
+//
+// What it fails on now, and why it is shaped this way. Every collision the
+// sweep can see today is already known: they are written down here, one line
+// each, next to what is known about them. The gate fails when reality stops
+// matching that list -- a collision that is not on it (a regression, or a new
+// screen pair), or a line on the list that no longer happens (a fix landed and
+// the waiver outlived it). Both directions matter: a stale waiver is a hole
+// held open for the next regression.
+//
+// It also fails when a probe stops measuring what it says it measures. Each
+// probe names the control on the FROM screen that PRODUCES the TO screen --
+// the one rect a finger is provably on at the moment the panel changes. Three
+// of the ten named an action their own fixture never registered (minesweeper
+// and sudoku built an unfinished board and asked for the verdict capsule;
+// study named ActionSync where the SYNC door carries ActionStudy/2), so the
+// producer check silently did not run on any of them and printed nothing at
+// all. A probe whose producer is absent is now a failure, not a blank line.
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <map>
@@ -38,6 +64,21 @@
 namespace fui = freeink::ui;
 
 namespace {
+
+int gChecks = 0;
+int gFailed = 0;
+
+// Every assertion this file makes goes through here, so the count in the
+// summary line is the count of things actually asked -- not a number typed
+// beside them.
+bool check(const bool ok, const char* what) {
+  ++gChecks;
+  if (!ok) {
+    ++gFailed;
+    std::printf("   FAIL: %s\n", what);
+  }
+  return ok;
+}
 
 int16_t gCharWidth = 10;
 int16_t gLineHeight = 20;
@@ -167,6 +208,15 @@ int areaOf(const std::vector<Cell>& cells, const int action, const int value) {
 
 constexpr int kStep = 4;
 
+// A producer whose action is unique on its screen does not need a value; a
+// producer that is one row of a list does, because the row is what the finger
+// is on and its siblings are elsewhere.
+constexpr int kAnyValue = 1 << 30;
+
+// The nine points inside the producer's own rect that the new screen is asked
+// about: four corners, four edge midpoints, the centre.
+constexpr int kProducerProbePoints = 9;
+
 struct Probe {
   const char* name;
   bool landscape;
@@ -174,8 +224,25 @@ struct Probe {
   void (*buildTo)(Built&);
   // The action on the FROM screen that produces the TO screen, or 0 if the
   // transition is not a touch at all. This is the one whose rect a finger is
-  // provably on at the moment the new screen is drawn.
+  // provably on at the moment the new screen is drawn. It must exist on the
+  // FROM screen the fixture builds: a producer that is not there means the
+  // fixture is not in the state the probe's name claims, and the sharpest
+  // check in the file quietly does not run.
   int producer = 0;
+  // Which instance of it, when the action is a list row.
+  int producerValue = kAnyValue;
+  // How many of the nine points inside the producer's rect the NEW screen
+  // answers at. Zero is the only good answer; anything else is a control the
+  // finger already resting there can fire. The number is here rather than
+  // assumed so that a collision getting WIDER is a failure and not a shrug.
+  int producerLive = 0;
+  // The collisions this transition is known to have, "fromAction/fromValue->
+  // toAction/toValue", terminated by nullptr. Anything else the sweep finds
+  // fails; anything here it no longer finds fails too.
+  const char* const* known = nullptr;
+  // One line saying why the list above is what it is. Printed with the
+  // findings so a reader of the log is told, not left to infer.
+  const char* note = "";
 };
 
 void dump(const char* label, Built& built) {
@@ -193,6 +260,7 @@ void report(const Probe& probe) {
   const int h = probe.landscape ? 480 : 800;
 
   std::printf("\n== %s\n", probe.name);
+  if (probe.note[0] != '\0') std::printf("   known: %s\n", probe.note);
   {
     Built from;
     Built to;
@@ -201,20 +269,21 @@ void report(const Probe& probe) {
     dump("FROM", from);
     dump("TO  ", to);
     if (probe.producer != 0) {
+      int found = 0;
+      int live = 0;
+      int seen = 0;
       const fui::Interaction* data = from.interactions.data();
       for (size_t i = 0; i < from.interactions.count(); ++i) {
         if (static_cast<int>(data[i].action) != probe.producer) continue;
+        if (probe.producerValue != kAnyValue && static_cast<int>(data[i].value) != probe.producerValue) continue;
+        ++found;
         const fui::Rect r = data[i].rect;
         // What the NEW screen does at the four corners and the centre of the
         // rect the finger is provably on.
         const int xs[3] = {r.x + 2, r.x + r.width / 2, r.x + r.width - 3};
         const int ys[3] = {r.y + 2, r.y + r.height / 2, r.y + r.height - 3};
-        int live = 0;
-        int total = 0;
-        int seen = 0;
         for (int yi = 0; yi < 3; ++yi) {
           for (int xi = 0; xi < 3; ++xi) {
-            ++total;
             const fui::ActionEvent e = to.tap(xs[xi], ys[yi]);
             if (e.action != 0) {
               ++live;
@@ -222,10 +291,24 @@ void report(const Probe& probe) {
             }
           }
         }
-        std::printf("   PRODUCER action %d rect x=%d y=%d w=%d h=%d -> new screen answers at %d of %d probe points",
-                    probe.producer, r.x, r.y, r.width, r.height, live, total);
+        std::printf("   PRODUCER action %d/%d rect x=%d y=%d w=%d h=%d -> new screen answers at %d of %d probe points",
+                    probe.producer, static_cast<int>(data[i].value), r.x, r.y, r.width, r.height, live,
+                    kProducerProbePoints);
         if (live > 0) std::printf(" (e.g. action %d)", seen);
         std::printf("\n");
+      }
+      // The check that three probes needed and none of them got: a producer
+      // the fixture never registered printed NOTHING, which reads exactly
+      // like a producer that collides with nothing.
+      char what[192];
+      std::snprintf(what, sizeof(what),
+                    "%s: the producing control (action %d) is on the FROM screen the fixture builds", probe.name,
+                    probe.producer);
+      if (check(found > 0, what)) {
+        std::snprintf(what, sizeof(what),
+                      "%s: the new screen answers at %d of %d points inside the producer (found %d)", probe.name,
+                      probe.producerLive, kProducerProbePoints, live);
+        check(live == probe.producerLive, what);
       }
     }
   }
@@ -248,8 +331,8 @@ void report(const Probe& probe) {
 
   if (runs[0].empty()) {
     std::printf("   no pixel carries a different action across this transition\n");
-    return;
   }
+  std::vector<std::string> seenKeys;
   for (const auto& o : runs[0]) {
     // Stable across both metrics?
     bool stable = false;
@@ -262,11 +345,40 @@ void report(const Probe& probe) {
     }
     const int fromArea = areaOf(fromRuns[0], o.fromAction, o.fromValue);
     const int pct = fromArea > 0 ? (o.points * 100) / fromArea : 0;
+    seenKeys.push_back(key(o));
     std::printf("   action %d/%d  ->  action %d/%d   %d%% of the source control (%d of %d lattice pts)\n", o.fromAction,
                 o.fromValue, o.toAction, o.toValue, pct, o.points, fromArea);
     std::printf("      overlap box x[%d..%d] y[%d..%d]   %s\n", o.minX, o.maxX + kStep - 1, o.minY, o.maxY + kStep - 1,
                 stable ? "stable at both text metrics" : "METRIC-DEPENDENT -- do not quote");
   }
+
+  // The list in the table against what the lattice just found, both ways.
+  // One check, because a probe either matches its declaration or it does not;
+  // every individual difference is printed above it either way.
+  std::vector<std::string> knownKeys;
+  for (const char* const* k = probe.known; k != nullptr && *k != nullptr; ++k) knownKeys.push_back(*k);
+
+  int unexpected = 0;
+  for (const auto& k : seenKeys) {
+    if (std::find(knownKeys.begin(), knownKeys.end(), k) != knownKeys.end()) continue;
+    ++unexpected;
+    std::printf("   FAIL: %s: a collision that is not written down: %s. Two controls share pixels across this\n",
+                probe.name, k.c_str());
+    std::printf("         screen change and nobody decided that was acceptable. Fix it, or add it to `known`\n");
+    std::printf("         with a line saying why it is survivable.\n");
+  }
+  int vanished = 0;
+  for (const auto& k : knownKeys) {
+    if (std::find(seenKeys.begin(), seenKeys.end(), k) != seenKeys.end()) continue;
+    ++vanished;
+    std::printf("   FAIL: %s: %s is written down as known and no longer happens. Delete the line: a waiver\n",
+                probe.name, k.c_str());
+    std::printf("         that outlives its finding is a door held open for the next one.\n");
+  }
+  char what[192];
+  std::snprintf(what, sizeof(what), "%s: the collisions found are exactly the ones written down (%d new, %d stale)",
+                probe.name, unexpected, vanished);
+  check(unexpected == 0 && vanished == 0, what);
 }
 
 // --- probes -----------------------------------------------------------------
@@ -288,6 +400,11 @@ void minesweeperBoardSettled(Built& out) {
   mineui::BoardModel model;
   minesweeper::start(model.game, 12345u);
   model.showMines = true;
+  // SETTLED, which is the state this probe is named for. buildBoard draws the
+  // verdict capsule only under ms::over(game); with a Fresh game it drew the
+  // DIG/FLAG strip, so the probe measured the wrong screen and its producer
+  // (ActionSeeResult) was not on it.
+  model.game.status = minesweeper::Status::Won;
   build(out, false, [&](toybox::Screen& s) { mineui::buildBoard(s, model); });
 }
 
@@ -301,6 +418,11 @@ void minesweeperResult(Built& out) {
 
 void sudokuBoard(Built& out) {
   sudokuui::BoardModel model;
+  // Finished, for the same reason as minesweeper above: drawRail registers
+  // ActionSeeResult on the status capsule only once solvedFlag is set. An
+  // unsolved grid made this "BOARD -> RESULT" probe a transition that cannot
+  // happen, measured against the two controls that are not the door.
+  model.game.solvedFlag = 1;
   build(out, false, [&](toybox::Screen& s) { sudokuui::buildBoard(s, model); });
 }
 
@@ -438,24 +560,60 @@ void dumpOnly(const char* label, void (*builder)(Built&)) {
   dump("    ", built);
 }
 
+// The collisions each transition is known to have. One array per probe so
+// each carries its own reasoning; REVEAL-FINDINGS.md at the workspace root is
+// the longer version, and says which of these are owned and which are not.
+//
+// A key is "fromAction/fromValue->toAction/toValue". Adding one is a decision:
+// it says a person looked at this pair of controls and judged the collision
+// survivable, or tracked elsewhere. Removing one is what happens when the
+// collision is fixed.
+const char* const kNone[] = {nullptr};
+const char* const kMinesweeperKnown[] = {"9/0->7/0", nullptr};
+// Measured, not assumed. With the grid solved the SOLVED capsule itself is
+// clear of RESULT (0 of 9 points answer inside it), and the two controls
+// that do collide are UNDO and HINT, which are not the door the player
+// takes. Both were in every run this sweep ever printed.
+const char* const kSudokuKnown[] = {"4/0->8/0", "5/0->7/0", nullptr};
+const char* const kBattleshipKnown[] = {"5/0->201/0", nullptr};
+const char* const kInsiderQuestionsKnown[] = {"5/0->9/0", nullptr};
+const char* const kInsiderVoteKnown[] = {"6/-1->8/0", "7/0->9/0", nullptr};
+const char* const kForeheadKnown[] = {"13/0->7/0", "13/0->8/0", nullptr};
+const char* const kTriviaKnown[] = {"2/0->3/0", "2/0->4/0", nullptr};
+const char* const kStudyKnown[] = {"1/2->7/1", nullptr};
+const char* const kInstapaperKnown[] = {"321/0->325/0", nullptr};
+
 const Probe kProbes[] = {
     {"wavelength: DIAL (hold to lock) -> REVEAL (the score)", false, wavelengthDial, wavelengthReveal,
-     wavelengthui::ActionLock},
+     wavelengthui::ActionLock, kAnyValue, 0, kNone,
+     "clean since v1.12.9 -- LOCK is a plain button guarded by geometry, and the reveal puts nothing under it"},
     {"minesweeper: settled BOARD (verdict capsule) -> RESULT", false, minesweeperBoardSettled, minesweeperResult,
-     mineui::ActionSeeResult},
-    {"sudoku: BOARD -> RESULT", false, sudokuBoard, sudokuResult, sudokuui::ActionSeeResult},
+     mineui::ActionSeeResult, kAnyValue, kProducerProbePoints, kMinesweeperKnown,
+     "the verdict capsule and RESULT's own button are the same bottom pill; open, unowned"},
+    {"sudoku: BOARD -> RESULT", false, sudokuBoard, sudokuResult, sudokuui::ActionSeeResult, kAnyValue, 0, kSudokuKnown,
+     "the door itself is clear; UNDO and HINT land on RESULT's DONE and AGAIN. Open, unowned"},
     {"battleship: game-over BOARD (PLAY AGAIN capsule) -> shared LINK screen", false, battleshipGameOverBoard,
-     linkRematchScreen, bshipui::ActionPlayAgain},
+     linkRematchScreen, bshipui::ActionPlayAgain, kAnyValue, kProducerProbePoints, kBattleshipKnown,
+     "closed by S1 (PaintClock/RevealedInteractions, v1.12.10): the rects still coincide, the timing window is gone"},
     {"insider: QUESTIONS (WE SAID THE WORD) -> REVEAL, on the 300s clock expiring", false, insiderQuestions,
-     insiderReveal, insiderui::ActionFoundWord},
+     insiderReveal, insiderui::ActionFoundWord, kAnyValue, kProducerProbePoints, kInsiderQuestionsKnown,
+     "genuine same-rect overlap, still open per REVEAL-FINDINGS.md"},
     {"insider: VOTE (confirm the accusation) -> REVEAL", false, insiderVote, insiderReveal,
-     insiderui::ActionConfirmVote},
+     insiderui::ActionConfirmVote, kAnyValue, kProducerProbePoints, kInsiderVoteKnown,
+     "genuine same-rect overlap, still open per REVEAL-FINDINGS.md"},
     {"forehead: READY (tap to start) -> PLAY (GOT / MISSED bands), landscape", true, foreheadReady, foreheadPlay,
-     foreheadui::ActionStart},
-    {"trivia: CLUE (REVEAL) -> ANSWER (NEXT / HIDE)", false, triviaClue, triviaAnswer, triviaui::ActionReveal},
-    {"study: DECK (SYNC door) -> SYNC VERDICT", false, studyDeck, studySyncVerdict, studyui::ActionSync},
+     foreheadui::ActionStart, kAnyValue, 3, kForeheadKnown,
+     "READY is the whole panel and PLAY splits it into two bands, so a third of it is unavoidably live"},
+    {"trivia: CLUE (REVEAL) -> ANSWER (NEXT / HIDE)", false, triviaClue, triviaAnswer, triviaui::ActionReveal,
+     kAnyValue, kProducerProbePoints, kTriviaKnown, "genuine same-rect overlap, still open per REVEAL-FINDINGS.md"},
+    // The SYNC door is a list row: ActionStudy carrying value 2. The table
+    // named ActionSync, which no screen registers, so this probe's producer
+    // check printed nothing for its whole life.
+    {"study: DECK (SYNC door) -> SYNC VERDICT", false, studyDeck, studySyncVerdict, studyui::ActionStudy, 2,
+     kProducerProbePoints, kStudyKnown, "genuine same-rect overlap, still open per REVEAL-FINDINGS.md"},
     {"instapaper: QUEUE (SYNC) -> NOTICE (the sync verdict)", false, instapaperQueue, instapaperNotice,
-     instapaperui::ActionSync},
+     instapaperui::ActionSync, kAnyValue, kProducerProbePoints, kInstapaperKnown,
+     "genuine same-rect overlap, still open per REVEAL-FINDINGS.md"},
 };
 
 }  // namespace
@@ -465,6 +623,10 @@ int main() {
   std::printf("lattice step %dpx; action 0 = nothing tappable there\n", kStep);
   for (const auto& probe : kProbes) report(probe);
   dumpOnly("link screen, rematch state (every multiplayer game shares it)", linkRematch);
-  std::printf("\ndone\n");
-  return 0;
+
+  // The line check.sh counts. Without it the suite reported
+  // "revealsweep ok (0 sub-suite(s))" and the zero looked like a formatting
+  // quirk rather than the whole truth about it.
+  std::printf("\n%d checks, %d failed\n", gChecks, gFailed);
+  return gFailed == 0 ? 0 : 1;
 }

--- a/host-tests/seasalt/test_brain.cpp
+++ b/host-tests/seasalt/test_brain.cpp
@@ -253,6 +253,10 @@ int main() {
   std::printf("  navigator %d/%d vs beachcomber\n", navOverBeach, kMatches);
   CHECK(navOverBeach * 100 >= kMatches * 52);
 
-  std::printf("seasalt brain: %d checks passed\n", checks);
+  // "0 failed" is not a literal standing in for a count: CHECK() calls
+  // std::exit(1) on the first failure, so this line is only ever
+  // reached with none. The wording is what check.sh counts sub-suites
+  // by, and "N checks passed" made this suite report 0 of them.
+  std::printf("seasalt brain: %d checks, 0 failed\n", checks);
   return 0;
 }

--- a/host-tests/seasalt/test_seasalt.cpp
+++ b/host-tests/seasalt/test_seasalt.cpp
@@ -618,6 +618,10 @@ int main() {
   testRevealedHandCannotBeStolenFrom();
   testFourMermaidsWinsOnArrival();
   soak();
-  std::printf("seasalt: %d checks passed\n", checks);
+  // "0 failed" is not a literal standing in for a count: CHECK() calls
+  // std::exit(1) on the first failure, so this line is only ever
+  // reached with none. The wording is what check.sh counts sub-suites
+  // by, and "N checks passed" made this suite report 0 of them.
+  std::printf("seasalt: %d checks, 0 failed\n", checks);
   return 0;
 }

--- a/host-tests/study/make_fixture.py
+++ b/host-tests/study/make_fixture.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Build the converted deck the study host tests parse.
+
+WHY THIS EXISTS. test_deck.cpp and test_images.cpp were written to read a deck
+produced by the real converter, and they were right to be: a synthetic writer
+beside our own reader agrees with itself about a format neither of them owns.
+But nothing in check.sh or in CI ever produced one, so both tests took their
+"no converted deck, skipping" branch on every run this repo has ever had, and
+printed `PASS (0 checks, 0 failures)`. Two of the study app's five binaries
+were an empty slot wearing the word PASS.
+
+So the deck is built here, from a synthetic ANKI COLLECTION rather than from
+synthetic deck.dat bytes. That distinction is the whole point:
+
+    this file writes  ->  a schema-18 sqlite collection
+    anki_to_deck.py   ->  deck.dat / meta.dat / cards.dat   (the real converter)
+    StudyDeck.cpp     ->  reads them back                   (the real firmware)
+
+Only the first step is ours. The format itself is written by the tool that
+writes Mario's own decks and read by the code the device runs, so the round
+trip the tests were written for actually happens.
+
+Standard library only, on purpose. make_fixture_apkg.py builds far better
+fixtures with Anki's own exporter, and needs the `anki` package in a venv;
+CI has python and nothing else, and a fixture generator that CI cannot run
+puts the tests straight back to skipping.
+
+    host-tests/study/make_fixture.py --out DIR
+
+Writes DIR/deck.dat, meta.dat, cards.dat, revlog.dat, glyphs-*.txt and
+images.dat.
+"""
+
+import argparse
+import pathlib
+import runpy
+import sqlite3
+import struct
+import sys
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+TOOLS = HERE.parent.parent / "tools_local" / "study"
+
+# Enough notes that the tests have somewhere to go: they load card index 3,
+# read past the end, and walk the whole index.
+WORDS = [
+    ("abate", "to lessen in intensity", "The storm began to <b>abate</b>."),
+    ("banal", "so ordinary as to be obvious", "A <b>banal</b> remark about weather."),
+    ("cogent", "clear and convincing", "She made a <b>cogent</b> case."),
+    ("dearth", "a scarcity of something", "There is a <b>dearth</b> of evidence."),
+    ("ebullient", "cheerful and full of energy", "An <b>ebullient</b> welcome."),
+    ("fervid", "intensely enthusiastic", "A <b>fervid</b> supporter."),
+    ("garrulous", "excessively talkative", "Our <b>garrulous</b> neighbour."),
+    ("hackneyed", "overused and unoriginal", "A <b>hackneyed</b> phrase."),
+    ("impugn", "to call into question", "He did not <b>impugn</b> her motives."),
+    ("laconic", "using very few words", "A <b>laconic</b> reply."),
+    ("maudlin", "self-pityingly sentimental", "He turned <b>maudlin</b> after two."),
+    ("nascent", "just coming into existence", "A <b>nascent</b> industry."),
+]
+
+# FSRS-5 defaults. Any 19 plausible numbers would do; these are the ones Anki
+# ships, so a deck built here schedules the way a real one does.
+FSRS_PARAMS = [
+    0.4072,
+    1.1829,
+    3.1262,
+    15.4722,
+    7.2102,
+    0.5316,
+    1.0651,
+    0.0234,
+    1.616,
+    0.1544,
+    1.0824,
+    1.9813,
+    0.0953,
+    0.2975,
+    2.2042,
+    0.2407,
+    2.9466,
+    0.5034,
+    0.6567,
+]
+
+
+def _varint(value):
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        out.append(byte | (0x80 if value else 0))
+        if not value:
+            return bytes(out)
+
+
+def _packed_floats(field, values):
+    body = struct.pack("<%df" % len(values), *values)
+    return _varint(field << 3 | 2) + _varint(len(body)) + body
+
+
+def _float(field, value):
+    return _varint(field << 3 | 5) + struct.pack("<f", value)
+
+
+def deck_config_blob():
+    """A deck preset's protobuf, carrying only what the converter reads.
+
+    Hand-encoded because that is exactly what parse_deck_config does at the
+    other end -- it walks the wire format and skips what it does not know, so
+    a message carrying four known fields and nothing else exercises the same
+    path a real preset does.
+    """
+    return (
+        _packed_floats(1, [1.0, 10.0])  # learning steps, minutes
+        + _packed_floats(2, [10.0])  # relearning steps
+        + _packed_floats(5, FSRS_PARAMS)  # the FSRS-5 weight vector
+        + _float(37, 0.9)  # desired retention
+    )
+
+
+def build_collection(path, crt):
+    """A schema-18 collection holding one deck of Basic notes.
+
+    Only the tables and columns anki_to_deck.py and make_images.py actually
+    read. A fuller schema would be more faithful and no more useful: what is
+    under test is the converter, and the converter's whole view of a
+    collection is these queries.
+    """
+    db = sqlite3.connect(path)
+    db.executescript(
+        """
+        create table col (crt integer);
+        create table config (key text primary key, val blob);
+        create table decks (id integer primary key, name text, kind blob);
+        create table deck_config (id integer primary key, config blob);
+        create table notetypes (id integer primary key, name text);
+        create table fields (ntid integer, ord integer, name text);
+        create table templates (ntid integer, ord integer, name text);
+        create table notes (id integer primary key, mid integer, flds text);
+        create table cards (id integer primary key, nid integer, did integer,
+                            odid integer, ord integer, type integer, queue integer,
+                            due integer, ivl integer, reps integer, lapses integer,
+                            left integer, data text);
+        create table revlog (id integer primary key, cid integer, ease integer,
+                             type integer);
+        """
+    )
+    db.execute("insert into col (crt) values (?)", (crt,))
+    db.execute("insert into config (key, val) values ('rollover', '4')")
+
+    # DeckKind { normal { config_id: 1 } }, which is what deck_config_for walks.
+    kind = bytes([0x0A, 0x02, 0x08, 0x01])
+    db.execute(
+        "insert into decks (id, name, kind) values (?, ?, ?)",
+        (1, "Fixture\x1fVocabulary", kind),
+    )
+    db.execute(
+        "insert into deck_config (id, config) values (?, ?)", (1, deck_config_blob())
+    )
+
+    # A note type with no written profile, whose fields are named the way a
+    # real shared deck names them. That routes through generic_profile, which
+    # claims by name: Word -> headword, Definition -> meaning, Sentence ->
+    # sentence. The sentence slot is the one that matters here, because it is
+    # what carries the emphasis span test_deck.cpp checks the bounds of.
+    db.execute("insert into notetypes (id, name) values (1, 'Vocabulary')")
+    for ordinal, name in enumerate(["Word", "Definition", "Sentence"]):
+        db.execute(
+            "insert into fields (ntid, ord, name) values (1, ?, ?)", (ordinal, name)
+        )
+    db.execute("insert into templates (ntid, ord, name) values (1, 0, 'Card 1')")
+
+    # Card ids are milliseconds in a real collection, and card_order() in
+    # make_images.py reads them straight out of cards.dat as int64, so they
+    # have to be large and distinct.
+    base_id = (crt + 86400) * 1000
+    for i, (front, back, sentence) in enumerate(WORDS):
+        note_id = base_id + i * 2
+        card_id = base_id + i * 2 + 1
+        db.execute(
+            "insert into notes (id, mid, flds) values (?, 1, ?)",
+            (note_id, "\x1f".join([front, back, sentence])),
+        )
+        # A spread of states: new, learning, and reviewed cards with history.
+        # The reviewed ones arrive with NO stored memory state, which is the
+        # case current Anki produces and seed_memory_from_revlog exists for.
+        if i < 3:
+            state, queue, due, ivl, reps = 0, 0, i, 0, 0
+        elif i < 5:
+            state, queue, due, ivl, reps = 1, 1, crt + 3600 * (i + 1), 0, 1
+        else:
+            state, queue, due, ivl, reps = 2, 2, 30 + i, 10 + i, 4
+        db.execute(
+            """insert into cards (id, nid, did, odid, ord, type, queue, due, ivl,
+                                  reps, lapses, left, data)
+               values (?, ?, 1, 0, 0, ?, ?, ?, ?, ?, 0, 0, '')""",
+            (card_id, note_id, state, queue, due, ivl, reps),
+        )
+        for r in range(reps):
+            db.execute(
+                "insert into revlog (id, cid, ease, type) values (?, ?, ?, 1)",
+                ((crt + 86400 * (r + 1)) * 1000 + i, card_id, 3),
+            )
+    db.commit()
+    db.close()
+
+
+def convert(collection, out_dir):
+    """Run the real converter, in-process, so a traceback lands here."""
+    sys.path.insert(0, str(TOOLS))
+    argv = sys.argv
+    sys.argv = [
+        str(TOOLS / "anki_to_deck.py"),
+        str(collection),
+        "--deck",
+        "Fixture::Vocabulary",
+        "--name",
+        "FIXTURE",
+        "--out",
+        str(out_dir),
+    ]
+    try:
+        runpy.run_path(str(TOOLS / "anki_to_deck.py"), run_name="__main__")
+    finally:
+        sys.argv = argv
+
+
+class TinyImage:
+    """The duck type make_images.pack_bitmap wants: .size and .load().
+
+    PIL is what packs a real deck's photographs, and CI has no PIL. Rather
+    than reimplement the packing here -- which would put a second copy of the
+    format beside the one under test -- the pattern is generated and handed to
+    make_images.py's own packer, so the bytes in images.dat are written by the
+    same function that writes them for Mario's deck.
+    """
+
+    def __init__(self, width, height):
+        self.size = (width, height)
+        self.width = width
+        self.height = height
+
+    def load(self):
+        w, h = self.size
+
+        class Pixels:
+            def __getitem__(self, xy):
+                x, y = xy
+                # A diagonal, so a wrong stride shears visibly rather than
+                # producing another uniform block that still reads end to end.
+                return 0 if (x + y) % 7 < 3 else 255
+
+        del w, h
+        return Pixels()
+
+
+def write_images(out_dir, card_count, every):
+    """images.dat, through make_images.py's own packer and header writer."""
+    sys.path.insert(0, str(TOOLS))
+    import make_images
+
+    entries = []
+    blob = bytearray()
+    for i in range(card_count):
+        if i % every:
+            entries.append((0, 0, 0, 0))
+            continue
+        # Taller than one band, and deliberately not all one size.
+        #
+        # kImageBandRows is 16, so an image under 17 rows is read in a single
+        # readBand(firstRow=0) and the `firstRow * stride` arithmetic never
+        # runs. An 11-row fixture therefore let a stride off by one pass:
+        # checked by breaking StudyImages.cpp exactly that way, and watching
+        # this suite stay green. Every image here spans several bands, and
+        # widths that are and are not byte-aligned so the padding differs.
+        image = TinyImage(29 + i * 3, 37 + (i % 5) * 11)
+        packed, stride = make_images.pack_bitmap(image)
+        entries.append((len(blob), image.width, image.height, stride))
+        blob += packed
+
+    path = out_dir / "images.dat"
+    with open(path, "wb") as f:
+        f.write(make_images.MAGIC)
+        f.write(struct.pack("<HHI", make_images.VERSION, 0, len(entries)))
+        base = len(make_images.MAGIC) + 8 + len(entries) * 10
+        for offset, w, h, stride in entries:
+            f.write(struct.pack("<IHHH", base + offset if w else 0, w, h, stride))
+        f.write(blob)
+    return sum(1 for e in entries if e[1])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", required=True, type=pathlib.Path)
+    args = ap.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    collection = args.out / "collection.anki2"
+    if collection.exists():
+        collection.unlink()
+
+    # A fixed epoch, so day numbering is the same on every machine and every
+    # run. test_deck asserts day 10 plus an hour is still day 10, which a
+    # collection created "now" would answer identically and by luck.
+    crt = int(time.mktime((2024, 1, 1, 4, 0, 0, 0, 1, -1)))
+    build_collection(collection, crt)
+    convert(collection, args.out)
+    packed = write_images(args.out, len(WORDS), 3)
+    print("fixture: %d notes, %d with an image -> %s" % (len(WORDS), packed, args.out))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/host-tests/study/run.sh
+++ b/host-tests/study/run.sh
@@ -6,8 +6,14 @@
 #   host-tests/study/run.sh [path/to/converted/deck]
 #
 # The deck tests parse a deck produced by tools_local/study/anki_to_deck.py, so
-# what the converter writes is checked against what the firmware reads. They
-# skip with a note if no deck has been converted yet.
+# what the converter writes is checked against what the firmware reads.
+#
+# With no argument they used to SKIP, and nothing in check.sh or in CI has ever
+# passed one, so two of the five binaries below printed
+# "PASS (0 checks, 0 failures)" on every run this repo has had. They now get a
+# fixture built here: make_fixture.py writes a synthetic Anki collection and
+# runs the REAL converter over it, so the round trip happens rather than being
+# waited for. Pass a directory to point them at a real converted deck instead.
 set -e
 cd "$(dirname "$0")"
 # Keyed to this checkout, not just the suite name -- two worktrees sharing one
@@ -30,8 +36,19 @@ SRC=../../src/apps_local/study
   "$SRC/StudyImages.cpp" "$SRC/StudyDeck.cpp" "$SRC/StudyFsrs.cpp" test_images.cpp \
   -o "$BUILD_DIR/test_images"
 
+# The deck under test. An argument wins; otherwise build one. A failure here
+# is a failure of the suite: the tests below now REFUSE a missing deck rather
+# than skipping past it, so a fixture that cannot be built must be loud at the
+# point it cannot be built.
+DECK="${1:-}"
+if [ -z "$DECK" ]; then
+  DECK="$BUILD_DIR/fixture"
+  rm -rf "$DECK"
+  python3 make_fixture.py --out "$DECK"
+fi
+
 "$BUILD_DIR/test_fsrs"
-"$BUILD_DIR/test_deck" "$@"
+"$BUILD_DIR/test_deck" "$DECK"
 "$BUILD_DIR/test_scheduler"
 "$BUILD_DIR/test_stats"
-"$BUILD_DIR/test_images" "$@"
+"$BUILD_DIR/test_images" "$DECK"

--- a/host-tests/study/test_deck.cpp
+++ b/host-tests/study/test_deck.cpp
@@ -64,9 +64,17 @@ void run(const std::string& dir) {
   FileSource deckFile(dir + "/deck.dat");
   FileSource metaFile(dir + "/meta.dat");
   FileSource cardFile(dir + "/cards.dat");
+  // A missing deck is a FAILURE, not a skip. This used to print
+  //   SKIP: no converted deck at /tmp/studytest/mandarin
+  // indented by two spaces, so check.sh's "^SKIP" surfacing could not see it
+  // either, and the binary went on to print PASS (0 checks, 0 failures).
+  // Nothing in check.sh or CI has ever produced a deck here, so every run of
+  // this file for its whole life took this branch. run.sh now builds one with
+  // make_fixture.py; if that failed, this must say so rather than pass.
   if (!deckFile.ok() || !metaFile.ok() || !cardFile.ok()) {
-    std::printf("  SKIP: no converted deck at %s\n", dir.c_str());
-    std::printf("        generate one with tools_local/study/anki_to_deck.py\n");
+    check(false, "the converted deck exists");
+    std::printf("        no deck.dat/meta.dat/cards.dat under %s -- host-tests/study/run.sh\n", dir.c_str());
+    std::printf("        builds one with make_fixture.py; run the suite through it\n");
     return;
   }
 
@@ -163,6 +171,9 @@ void run(const std::string& dir) {
 int main(const int argc, char** argv) {
   std::printf("StudyDeck\n");
   run(argc > 1 ? argv[1] : "/tmp/studytest/mandarin");
-  std::printf("%s (%d checks, %d failures)\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
+  // "failed", not "failures": check.sh counts sub-suites by grepping for
+  // "checks, 0 failed", so the other spelling made every study binary
+  // invisible to it and the suite reported "ok (0 sub-suite(s))".
+  std::printf("%s %d checks, %d failed\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
   return failures == 0 ? 0 : 1;
 }

--- a/host-tests/study/test_fsrs.cpp
+++ b/host-tests/study/test_fsrs.cpp
@@ -162,6 +162,6 @@ int main() {
   testMonotonicity();
   testBounds();
   testFirstReview();
-  std::printf("%s (%d checks, %d failures)\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
+  std::printf("%s %d checks, %d failed\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
   return failures == 0 ? 0 : 1;
 }

--- a/host-tests/study/test_images.cpp
+++ b/host-tests/study/test_images.cpp
@@ -86,10 +86,14 @@ MemorySource buildOne(const uint16_t width, const uint16_t height, const uint16_
 }
 
 void testRealFile(const std::string& dir) {
+  // Same as test_deck.cpp: a missing images.dat is a failure. The SKIP that
+  // was here was indented two spaces, invisible to check.sh's "^SKIP"
+  // surfacing, and taken on every run because nothing ever produced the file.
   FileSource file(dir + "/images.dat");
   if (!file.ok()) {
-    std::printf("  SKIP: no images.dat at %s\n", dir.c_str());
-    std::printf("        make one with tools_local/study/make_images.py\n");
+    check(false, "images.dat exists");
+    std::printf("        no images.dat under %s -- host-tests/study/run.sh builds one\n", dir.c_str());
+    std::printf("        with make_fixture.py, through make_images.py's own packer\n");
     return;
   }
   study::StudyImages images;
@@ -181,6 +185,6 @@ int main(const int argc, char** argv) {
   std::printf("StudyImages\n");
   testRealFile(argc > 1 ? argv[1] : "/tmp/studytest/fresh");
   testRefusesCorruption();
-  std::printf("%s (%d checks, %d failures)\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
+  std::printf("%s %d checks, %d failed\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
   return failures == 0 ? 0 : 1;
 }

--- a/host-tests/study/test_scheduler.cpp
+++ b/host-tests/study/test_scheduler.cpp
@@ -258,6 +258,6 @@ int main() {
   testStepDelaysCrossMidnight();
   testFormatting();
   testNoStepsGraduatesImmediately();
-  std::printf("%s (%d checks, %d failures)\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
+  std::printf("%s %d checks, %d failed\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
   return failures == 0 ? 0 : 1;
 }

--- a/host-tests/study/test_stats.cpp
+++ b/host-tests/study/test_stats.cpp
@@ -193,6 +193,6 @@ int main() {
   testWindowAndEarlyExit();
   testFutureRecordsAreIgnored();
   testGarbageRecordsAreSkipped();
-  std::printf("%s (%d checks, %d failures)\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
+  std::printf("%s %d checks, %d failed\n", failures == 0 ? "PASS" : "FAIL", checks, failures);
   return failures == 0 ? 0 : 1;
 }

--- a/host-tests/toybattle/run.sh
+++ b/host-tests/toybattle/run.sh
@@ -29,3 +29,25 @@ python3 ../../tools_local/terrain-editor/selftest.py
 for board in ../../tools_local/terrain-editor/boards/*.json; do
   python3 ../../tools_local/terrain-editor/to_cpp.py --check "$board"
 done
+
+# The six instruments beside this file: COMPILED, never run.
+#
+# branching, exploit, montecarlo, tournament and tune are measurements, and
+# each one's header says so and says why it is not a test -- they take minutes
+# and assert almost nothing, because their job is to decide which opponent is
+# strongest rather than to defend one that shipped. mksave writes a save
+# parked at a UI state no tap script can reach, for looking at the Cursed
+# Cemetery prompt. All six drive about 1,400 lines against ToyBattleCore and
+# ToyBattleBrain, and until 2026-09-05 no gate anywhere compiled any of them
+# while CI enforced their formatting: a rename in the core would have left
+# them broken and silent, and the next person to reach for one would find out
+# by not being able to build it.
+#
+# Compiling is the whole of what they need. -fsyntax-only, all six in under a
+# second, at the same -Werror the tests use.
+echo "instruments (compile only: measurements, not tests)"
+for tool in branching exploit montecarlo tournament tune; do
+  "${CXX:-c++}" $CXXFLAGS -fsyntax-only "$tool.cpp"
+done
+"${CXX:-c++}" $CXXFLAGS -fsyntax-only mksave.cpp
+echo "  branching exploit montecarlo tournament tune mksave: compile"

--- a/host-tests/xkcd/test_core.cpp
+++ b/host-tests/xkcd/test_core.cpp
@@ -878,6 +878,6 @@ int main() {
   testCoverage();
   testGapWindowFitsTheDevice();
 
-  std::printf("%s  xkcd core: %d checks, %d failures\n", failures ? "FAIL" : "ok  ", checks, failures);
+  std::printf("%s  xkcd core: %d checks, %d failed\n", failures ? "FAIL" : "ok  ", checks, failures);
   return failures ? 1 : 0;
 }

--- a/host-tests/xkcd/test_layout.py
+++ b/host-tests/xkcd/test_layout.py
@@ -289,6 +289,6 @@ if __name__ == "__main__":
     test_unmeasurable_lettering_still_lays_out()
     test_turning_has_to_buy_something()
     print(
-        f"{'FAIL' if failures else 'ok  '}  xkcd layout: {checks} checks, {failures} failures"
+        f"{'FAIL' if failures else 'ok  '}  xkcd layout: {checks} checks, {failures} failed"
     )
     sys.exit(1 if failures else 0)

--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -384,7 +384,14 @@ for suite in host-tests/*/; do
     printf "  %-12s ok (%s sub-suite(s), %s)\n" "$name" "$passed" "$(since $T0)"
     # A check that did not run must not scroll past looking like one that
     # passed. Suites write SKIP to their own log, which nothing surfaced.
-    grep -E "^SKIP" "$LOGS/$name.log" | head -5 | sed 's/^/      /'
+    #
+    # NOT anchored at column zero. It was until 2026-09-05, and three of the
+    # six emitters indent theirs by two spaces -- so the mechanism built to
+    # stop a skip hiding was itself hiding half of them, in a block whose own
+    # comment is the sentence above. host-tests/checksh discovers every SKIP
+    # literal in the tree and asserts this pattern catches it, so the next
+    # indented one cannot repeat the trick.
+    grep -E "^[[:space:]]*SKIP" "$LOGS/$name.log" | head -5 | sed 's/^[[:space:]]*/      /'
   fi
 done
 


### PR DESCRIPTION
Two independent cold audits found the same four defects: gates that report green
whatever they find. All four are repaired here, and **each one was watched
failing on a deliberately constructed defect** before being called done. The
memory `verify-the-thing-not-its-silence` is about exactly this failure mode and
it shipped anyway, so a repaired gate nobody saw fail is the same defect wearing
a different shape.

Board card **#251**.

## 1. `host-tests/revealsweep` could not fail

`main()` looped the probes, printed `done` and `return 0` was the only return.
No failure counter existed anywhere in `sweep.cpp`, and it never emitted the
`N checks, M failed` line `scripts_local/check.sh` counts, so check.sh printed
`revealsweep ok (0 sub-suite(s))` regardless. The same-pixel/different-action
collision it exists to catch would have printed into a log nobody opens.

It now declares, per probe, the collisions that transition is **known** to have,
one line each with why, and fails on:

* a collision that is not on the list (a regression, or a new screen pair);
* a line on the list that no longer happens (a fix landed and the waiver
  outlived it -- a stale waiver is a door held open for the next regression);
* a probe whose declared **producer** is not registered on the FROM screen the
  fixture builds.

The compile-gate value is unchanged: `set -e`, sixteen `Screens.cpp` at
`-Wall -Wextra`.

**It immediately found three probes that had never measured what they claim.**
`minesweeper` and `sudoku` built an *unfinished* board and asked for the verdict
capsule, which is registered only on a settled one; `study` named
`studyui::ActionSync` where the SYNC door carries `ActionStudy` value 2. All
three producer checks printed *nothing at all*, which reads exactly like a
producer that collides with nothing. Fixtures fixed.

Seen red -- LOCK moved back to a full-width bar in `WavelengthScreens.cpp`,
reintroducing the bug Wavelength shipped:

```
   FROM registers 1 interactions:
      action 3/0  rect x=16 y=640 w=448 h=62  mask=0x7
   TO   registers 1 interactions:
      action 11/0  rect x=16 y=640 w=448 h=62  mask=0x7
   PRODUCER action 3/0 rect x=16 y=640 w=448 h=62 -> new screen answers at 9 of 9 probe points (e.g. action 11)
   FAIL: wavelength: DIAL (hold to lock) -> REVEAL (the score): the new screen answers at 0 of 9 points inside the producer (found 9)
   action 3/0  ->  action 11/0   100% of the source control (1792 of 1792 lattice pts)
      overlap box x[16..463] y[640..703]   stable at both text metrics
   FAIL: wavelength: DIAL (hold to lock) -> REVEAL (the score): a collision that is not written down: 3/0->11/0.
30 checks, 2 failed        (exit 1)
```

Green now: `30 checks, 0 failed`, where it counted zero.

## 2. `host-tests/study`'s deck round-trip had never run

`test_deck.cpp:67` and `test_images.cpp:90` bail with SKIP when no converted
deck exists, and nothing in check.sh or `crossplay-ci.yml` has ever produced
one. Both printed `PASS (0 checks, 0 failures)` for their entire lives.

`host-tests/study/make_fixture.py` (stdlib only, so CI can run it) writes a
synthetic **Anki collection** and runs the **real converter** over it:

```
make_fixture.py   ->  a schema-18 sqlite collection
anki_to_deck.py   ->  deck.dat / meta.dat / cards.dat     (the real converter)
StudyDeck.cpp     ->  reads them back                     (the real firmware)
```

Only the first step is ours, so the round trip these tests were written for
actually happens. `images.dat` goes through `make_images.py`'s own packer and
header writer, so the format stays single-sourced without needing PIL.
A missing deck is now a **hard failure**, not a skip.

`test_deck` 0 -> **33 checks**; `test_images` 0 -> **20 checks**.

Seen red, three ways.

Missing fixture (the old SKIP path):

```
StudyDeck
  FAIL: the converted deck exists
        no deck.dat/meta.dat/cards.dat under /tmp/no-such-deck -- host-tests/study/run.sh
        builds one with make_fixture.py; run the suite through it
FAIL 1 checks, 1 failed        (exit 1)
```

A converter bug (`anki_to_deck.py` emphasis span made 40 codepoints too long):

```
StudyDeck
  deck 'FIXTURE': 12 notes
  parsed 12/12 notes, 12 with sentences, 12 emphasised
  FAIL: every emphasis span lies inside its sentence
FAIL 33 checks, 1 failed        (exit 1)
```

A firmware bug (`StudyImages.cpp` stride off by one):

```
StudyImages
  12 entries
  4 entries carry an image
  FAIL: every image reads end to end, band by band
FAIL 20 checks, 1 failed        (exit 1)
```

**That third one is why the deliberate-defect discipline is not ceremony.** The
first version of the fixture used 11-row images; `kImageBandRows` is 16, so
`readBand(firstRow=0)` read the whole thing in one go, the `firstRow * stride`
arithmetic never ran, and the broken stride passed. The fixture's images now
span several bands, at widths that are and are not byte-aligned. A probe whose
correct behaviour matches the symptom proves nothing.

## 3. The SKIP detector was mis-anchored

`check.sh` surfaced skips with `grep -E "^SKIP"`, anchored at column zero, two
lines under a comment reading *"A check that did not run must not scroll past
looking like one that passed."* Three of six emitters indent theirs by two
spaces, so the mechanism built to stop a skip hiding could not see half of them
-- including the two study ones above, which were checks that had never run.

The pattern now tolerates indentation. **The real fix is the detector test**:
`host-tests/checksh` does not assert a pattern, it **discovers** every SKIP
string literal in the tree by reading the suites' source, and asserts check.sh's
own grep -- lifted from the file, not copied -- matches each one. A future
indented SKIP adds itself to that list rather than hiding.

Seen red, with the old anchored pattern restored:

```
FAIL checksh  check.sh's SKIP surfacing cannot see '  SKIP v1.12.20/v1.12.21 not in this clone; the real-range checks did not run' from host-tests/autorelease/run.sh
      (checked 7 SKIP literals across the tree)
79 checks, 1 failed
```

`host-tests/autorelease/` is untouched here -- that emitter belongs to
`wt/cigaps`. The detector catching it is the point.

## 4. `host-tests/toybattle`'s six scripts: compiled, never run

Per-script decision, and it is the same for all six: **wire in as a compile
gate, do not run, do not delete.**

| script | what it is | decision |
|---|---|---|
| `branching` | measures how wide the move list gets per board | compile only |
| `exploit` | plays a hand-written region-racer against the shipped brain | compile only |
| `montecarlo` | flat Monte Carlo vs the heuristic brain | compile only |
| `tournament` | competes the opponent policies, prints a tier list | compile only |
| `tune` | dumps self-play positions for fitting the evaluation | compile only |
| `mksave` | writes a save parked at a UI state no tap script can reach | compile only |

Five are **measurements** and each header says so and says why it is not a test:
they take minutes and assert almost nothing, because their job is to decide
which opponent is strongest rather than to defend one that already shipped.
`mksave` is a QA fixture writer, built for the Cursed Cemetery prompt that needs
a stocked discard *and* a placement on a grave.

Deleting instruments Mario used to make brain-tuning decisions is the wrong cut.
What was actually wrong is that **no gate compiled ~1,400 lines of them while CI
enforced their formatting**, so a rename in the core would leave them broken and
silent until the next person reached for one. `-fsyntax-only`, all six, in under
a second, at the same `-Werror` the tests use.

Seen red -- `kMaxCandidatesShipped` renamed in `ToyBattleBrain.h` (a constant
only the instruments use, so all three test binaries and both terrain checks
still passed):

```
branching.cpp:115:24: error: no member named 'kMaxCandidatesShipped' in namespace 'toybattle::detail'
  115 |   const int headroom = detail::kMaxCandidatesShipped - worstOverall;
5 errors generated.        (exit 1)
```

## Also: three more suites that reported zero sub-suites

Auditing every suite for a failure path turned up no other gate that *cannot*
fail. But `seasalt`, `xkcd` and `study` all printed a summary line check.sh
cannot count (`N checks passed`, `checks, N failures`), so three suites that
*can* fail reported `ok (0 sub-suite(s))`. Normalised to the counted wording.
`seasalt`'s `0 failed` is not a literal standing in for a count: `CHECK()` calls
`std::exit(1)` on the first failure, so that line is only ever reached with none.

## Not verified

No hardware. Nothing in this diff reaches a device image.
