### PR TITLE
Stop committing the browser emulator: publish it to a release, fetch it in Vercel's build

### DIFF
--- a/.github/workflows/crossplay-ci.yml
+++ b/.github/workflows/crossplay-ci.yml
@@ -19,8 +19,12 @@ on:
     branches: [xteink]
     # CI's OWN emulator rebuild is not a change to test, and running it costs
     # a whole release cycle. After every merge, crossplay-emulator.yml commits
-    # site/emulator/{BUILT_FROM,crossplay.js,crossplay.wasm} back to xteink --
-    # three files, no byte of which reaches a device. That push started a
+    # site/emulator-manifest.json back to xteink -- one ~1KB pointer at the
+    # browser build, no byte of which reaches a device. (It used to commit
+    # site/emulator/{BUILT_FROM,crossplay.js,crossplay.wasm} instead, which is
+    # why that path is here too; those files are now published to a GitHub
+    # release, and both paths stay ignored so an old branch behaves the same.)
+    # That push started a
     # SECOND CrossPlay run which cancelled the merge's own run, so every merge
     # cost two full builds and the first was always thrown away. Seen
     # 2026-09-04: merge 52b2a677 at 17:02:13, emulator commit eb79a542 at
@@ -33,8 +37,14 @@ on:
     # moved only by emulator rebuilds releases from the tip. The assumption
     # stopped being true; this restores it explicitly rather than by relying
     # on a token's side effect.
+    #
+    # BOTH PATHS, and they must track what crossplay-emulator.yml actually
+    # commits: the day the rebuild started writing a file outside
+    # site/emulator/, this filter stopped covering it and the double-run came
+    # straight back. host-tests/bugflow asserts the two files still agree.
     paths-ignore:
       - 'site/emulator/**'
+      - 'site/emulator-manifest.json'
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/crossplay-emulator.yml
+++ b/.github/workflows/crossplay-emulator.yml
@@ -1,16 +1,35 @@
-# Rebuild the browser emulator after a merge, and commit it.
+# Rebuild the browser emulator after a merge, and publish it.
 #
-# site/emulator/ is a committed build artefact, and both sides of every merge
-# used to conflict on it, which is the whole reason the integration tree
-# needed a single occupant. This job does that rebuild on GitHub after every
-# push to xteink whose sources are newer than the artefact
-# (scripts_local/emulator-stale.sh, the same test check.sh applies), and
-# commits the result as "chore: emulator rebuilt for <sha>".
+# site/emulator/ is a build artefact, and both sides of every merge used to
+# conflict on it, which is the whole reason the integration tree needed a
+# single occupant. This job does that rebuild on GitHub after every push to
+# xteink whose sources are newer than the artefact
+# (scripts_local/emulator-stale.sh, the same test check.sh applies).
+#
+# IT NO LONGER COMMITS THE BYTES. It used to, and that cost 111 revisions of
+# crossplay.wasm, ~357MB of history and about 20MB a day forever -- paid for by
+# every clone and every CI checkout in the fork, for a ~104MB working tree in a
+# ~497MB repository. The wasm now goes to the `emulator` GitHub release under a
+# content-addressed name, and the only thing committed is the ~1KB pointer
+# site/emulator-manifest.json. site/fetch-emulator.mjs is site/vercel.json's
+# buildCommand and puts the files back during Vercel's build; a fetch that
+# fails or arrives with the wrong bytes fails that build, so the previous
+# deployment keeps serving rather than a broken one replacing it.
+# tools_local/site/publish_emulator.py owns both halves and explains the shape.
+#
+# The commit is still called "chore: emulator rebuilt for <sha>". Do not
+# reword that: crossplay-autorelease.yml matches the subject to tell an
+# emulator rebuild from a real merge that moved the tip past what CI verified,
+# and a rename there silently stops every release.
 #
 # The commit is pushed with the workflow's own token, so it starts no CI run
 # of its own: it changes nothing a device build sees, and the next real merge's
 # CI covers it. One at a time, rebased before push, so two quick merges make
 # two commits in order rather than a conflict.
+#
+# What this job CANNOT see is whether the live site ends up serving what it
+# published. crossplay-site-live.yml asks the origin that, after this finishes
+# and again once a day.
 name: CrossPlay emulator
 
 on:
@@ -97,16 +116,39 @@ jobs:
           python3 tools_local/wasm/build.py
           git status --short site/emulator
 
-      - name: Commit and push the artefact
+      # Upload BEFORE committing, and never the other way round. A manifest on
+      # xteink naming assets that were never uploaded is a Vercel build that
+      # fails on every deploy until someone notices; assets uploaded with no
+      # manifest pointing at them are four unreferenced files on a release.
+      - name: Publish the artefact to the emulator release
+        if: steps.stale.outputs.stale == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 tools_local/site/publish_emulator.py
+
+      - name: Commit and push the manifest
         if: steps.stale.outputs.stale == 'true'
         run: |
           git config user.name "crossplay-release[bot]"
           git config user.email "crossplay-release@users.noreply.github.com"
-          git add site/emulator
+          # The pointer, and only the pointer. site/emulator/ itself is still
+          # tracked at the revision it was frozen at (the fallback described in
+          # site/README.md), and the rebuild has just rewritten those files in
+          # this runner's tree -- so they are restored, both to keep them out of
+          # the commit and because `git pull --rebase` below refuses to run with
+          # unstaged changes in the tree.
+          git add site/emulator-manifest.json
+          git checkout -- site/emulator
           if git diff --cached --quiet; then
-            echo "The rebuild produced identical bytes; nothing to commit."
-            exit 0
+            # The manifest carries built_from, which build.py stamps with the
+            # revision it compiled -- a different commit every time this job
+            # runs. So an unchanged manifest cannot mean "a rebuild produced
+            # identical bytes"; it means the rebuild or the publish did not
+            # happen. Committing nothing would leave the artefact reading stale
+            # forever and check.sh red on the deploy branch, so this is loud.
+            echo "::error::the manifest did not change, so nothing was published."
+            exit 1
           fi
-          git commit -m "chore: emulator rebuilt for $(git rev-parse --short HEAD)" -m "Rebuilt by crossplay-emulator.yml after a push to xteink."
+          git commit -m "chore: emulator rebuilt for $(git rev-parse --short HEAD)" -m "Rebuilt by crossplay-emulator.yml after a push to xteink. The bytes are on the emulator release; this is the pointer to them."
           git pull --rebase origin xteink
           git push origin HEAD:xteink

--- a/.github/workflows/crossplay-site-live.yml
+++ b/.github/workflows/crossplay-site-live.yml
@@ -1,0 +1,81 @@
+# Does the live site actually serve the emulator?
+#
+# THE HOLE THIS FILLS. Since the emulator stopped being committed
+# (crossplay-emulator.yml) the browser demo reaches production through three
+# things that can each fail silently: the assets are uploaded to a GitHub
+# release, a ~1KB manifest is committed, and Vercel's build runs
+# site/fetch-emulator.mjs to put them back. Nothing about the page's own HTML
+# changes if any of that breaks. The homepage renders, the hero sits there, and
+# the first thing the README offers a stranger 404s -- with every check in the
+# fork green, because every check in the fork looks at the repository and this
+# is a question about an origin.
+#
+# So this asks the origin. Twice over:
+#
+#   * after every emulator rebuild, waiting up to twelve minutes for Vercel to
+#     deploy the manifest that was just pushed;
+#   * once a day regardless, because the ways this breaks later (an asset
+#     deleted, a Vercel build setting changed by hand, a project unlinked) are
+#     not tied to a push and would otherwise wait for the next firmware merge
+#     to be discovered.
+#
+# It reads the expected hashes out of site/emulator-manifest.json on xteink, so
+# it cannot drift from what was published, and it takes the site's address from
+# index.html's own og:url rather than keeping a second copy of the hostname.
+name: CrossPlay site live
+
+on:
+  workflow_run:
+    workflows: ["CrossPlay emulator"]
+    types: [completed]
+  schedule:
+    # 07:20 UTC. Off the hour, because the hour is when every scheduled job on
+    # GitHub queues at once.
+    - cron: "20 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: crossplay-site-live
+  cancel-in-progress: false
+
+jobs:
+  emulator:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The branch the site deploys from, not whatever a workflow_run event
+          # would otherwise hand us.
+          ref: xteink
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # Only needed for one branch of the check: a body handed back still
+      # brotli-encoded has to be decoded before it can be recognised.
+      - run: pip install brotli
+
+      - name: Is the emulator live?
+        run: |
+          set -uo pipefail
+          # Held to the manifest as it was when this run started. A rebuild
+          # that lands while the poll is running would otherwise make this fail
+          # for having waited on a commit that is no longer the tip.
+          cp site/emulator-manifest.json "$RUNNER_TEMP/expected.json"
+          if python3 tools_local/site/verify_live_emulator.py \
+               --manifest "$RUNNER_TEMP/expected.json" --timeout 720; then
+            exit 0
+          fi
+          git fetch --quiet --depth 1 origin xteink
+          if ! git diff --quiet FETCH_HEAD -- site/emulator-manifest.json; then
+            echo "::warning::A newer emulator was published while this check was waiting, so the deploy it was watching for was superseded. That rebuild's own run checks it, and the daily run checks it regardless."
+            exit 0
+          fi
+          echo "::error::The live site is not serving the emulator that site/emulator-manifest.json publishes. The browser demo on the front page is down. The step log above names which files and what to look at."
+          exit 1

--- a/.github/workflows/crossplay-site-live.yml
+++ b/.github/workflows/crossplay-site-live.yml
@@ -72,8 +72,25 @@ jobs:
                --manifest "$RUNNER_TEMP/expected.json" --timeout 720; then
             exit 0
           fi
-          git fetch --quiet --depth 1 origin xteink
-          if ! git diff --quiet FETCH_HEAD -- site/emulator-manifest.json; then
+          # The one way out of a failure that is not a failure: a newer emulator
+          # landed while this was polling, so it waited for a deploy that had
+          # already been replaced.
+          #
+          # WRITTEN TO FAIL CLOSED, because it is an excuse and excuses are
+          # where a check quietly stops checking. `! git diff --quiet` would
+          # have taken this branch on a fetch that never ran and on a bad ref --
+          # git diff answers >1 for an error and `!` reads that as "differs" --
+          # so a network blip would have turned a dead front page into a green
+          # run. Only an exit of exactly 1, after a fetch that succeeded, means
+          # the manifest really moved.
+          superseded=no
+          if git fetch --quiet --depth 1 origin xteink; then
+            git diff --quiet FETCH_HEAD -- site/emulator-manifest.json
+            [ $? -eq 1 ] && superseded=yes
+          else
+            echo "could not fetch origin/xteink to check for a newer emulator; treating the failure above as real."
+          fi
+          if [ "$superseded" = yes ]; then
             echo "::warning::A newer emulator was published while this check was waiting, so the deploy it was watching for was superseded. That rebuild's own run checks it, and the daily run checks it regardless."
             exit 0
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -43,13 +43,28 @@ sdkconfig.x4pro
 # fork-local: simulator screenshots and logs (scripts_local/)
 qa-artifacts/
 
-# The browser build's output is deliberately NOT ignored. It is generated (by
-# tools_local/wasm/build.py, from tracked sources) and it is 9MB, both of which
-# argue for ignoring it -- but Vercel has no Emscripten, so a git-connected
-# deploy that cannot see these files ships a site whose headline feature 404s.
-# Committing it is the cheaper failure mode. If the history size ever becomes
-# the problem, ignore it again and deploy with `cd site && vercel` instead,
-# which uploads the working directory rather than the commit.
+# The browser build's output is no longer committed on every rebuild, and the
+# history size is why: 111 revisions of site/emulator/crossplay.wasm, ~357MB of
+# blobs, 56 of those revisions in one week. The repository reached ~497MB on
+# GitHub for a ~104MB checkout and grew about 20MB a day, forever, paid for by
+# every clone and every CI checkout in the fork.
+#
+# Ignoring it outright is still not an option, and that is what this note used
+# to say: Vercel has no Emscripten, so a git-connected deploy that cannot see
+# these files ships a site whose headline feature 404s. So the bytes go to a
+# GitHub release instead and the repository keeps a ~1KB pointer:
+#
+#   tools_local/site/publish_emulator.py   uploads, and writes the manifest
+#   site/emulator-manifest.json            the pointer, committed per rebuild
+#   site/fetch-emulator.mjs                vercel.json's buildCommand, fetches
+#   .github/workflows/crossplay-site-live.yml   asks the live site if it worked
+#
+# The files under site/emulator/ ARE still tracked, frozen at the last revision
+# CI ever committed, and they are deliberately not ignored yet: they are the
+# fallback that keeps the demo up if the new path is not picked up, and an
+# ignore rule would be inert over tracked files anyway. Removing them from the
+# index is a separate change, to be made once a Vercel build log shows the
+# fetch running, and it is also where the history rewrite belongs.
 
 # Tool cache. It holds an account id and an email address and has no business
 # in a public repo.

--- a/docs/games-at-scale.md
+++ b/docs/games-at-scale.md
@@ -20,9 +20,11 @@ Measured against the source, not assumed. Everything here was verified.
   with tap scripts that were never saved, plus `og.png`, which is a Playwright
   composite built _from_ `games.png` (`site/make-og.py:54`). `site/assets/post/`
   holds four more.
-- **`site/emulator/crossplay.{js,wasm,data}` is checked in**, last built
-  2026-08-07. It is the real firmware, so when it is stale the page lets people
-  _play_ an old version.
+- **`site/emulator/crossplay.{js,wasm,data}` is no longer committed** (it was
+  when this was written, at ~20MB of history a day). CI publishes it to the
+  `emulator` GitHub release and commits `site/emulator-manifest.json`; see
+  site/README.md. It is the real firmware, so when it is stale the page lets
+  people _play_ an old version.
 - **`.claude/skills/` is committed** and reaches every worktree (all 9 trees
   carry 6 files).
 - **`crossplay-ci.yml` fires on push to `xteink` and on every pull request**, and

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -263,9 +263,16 @@ echo "the emulator rebuild's commit subject, spelled in two workflows"
 # files, so this is the link.
 AR="$HERE/../../.github/workflows/crossplay-autorelease.yml"
 EM="$HERE/../../.github/workflows/crossplay-emulator.yml"
-subject="$(grep -oE "grep -vq '\^[^']+'" "$AR" | sed -E "s/.*'\^//; s/'$//")"
+# COMMENT LINES DROPPED FIRST. A subject match that has been replaced by
+# something better is usually left in the file as the comment explaining what it
+# replaced, and a check that reads it there goes on passing while guarding a
+# dead line -- which is worse than going red, because it looks like coverage.
+subject="$(grep -vE '^[[:space:]]*#' "$AR" | grep -oE "grep -vq '\^[^']+'" | sed -E "s/.*'\^//; s/'$//")"
 if [ -z "$subject" ]; then
-  bad "crossplay-autorelease.yml no longer matches an emulator-rebuild subject at all"
+  # Not a failure. It means the gate stopped settling a question about content
+  # by reading a title, which is the right direction; there is then no subject
+  # for crossplay-emulator.yml to keep in step with.
+  ok "crossplay-autorelease.yml no longer keys off the commit subject, so there is nothing here to keep in step"
 else
   ok "autorelease matches the subject '$subject'"
   grep -q -- "-m \"$subject" "$EM" \

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -244,6 +244,60 @@ grep -qx "src" <<< "$PATHS" && grep -qx "tools_local/wasm" <<< "$PATHS" \
   && ok "--paths names the source list" || bad "--paths is missing sources"
 grep -q 'emulator-stale.sh' "$HERE/../../scripts_local/check.sh" && ok "check.sh asks the shared script" || bad "check.sh still carries its own staleness test"
 
+# The artefact is now a POINTER, not the bytes. crossplay-emulator.yml publishes
+# the wasm to a GitHub release and commits site/emulator-manifest.json; the bytes
+# under site/emulator/ are frozen at the last revision that was ever committed
+# and never move again. A staleness test that only watched the directory would
+# therefore call every rebuild stale forever, and check.sh fails on stale on the
+# deploy branch -- a permanently red gate on the branch that matters most.
+( cd "$E" && sleep 1 && echo c > src/a.cpp && git add -A && git commit -qm "source moved again" )
+bash "$STALE" "$E" >/dev/null && ok "a source change after a rebuild reads stale again" || bad "stale not detected after a rebuild"
+( cd "$E" && sleep 1 && echo '{"files":[]}' > site/emulator-manifest.json && git add -A && git commit -qm "chore: emulator rebuilt" )
+bash "$STALE" "$E" >/dev/null && bad "a manifest-only rebuild still reads stale, so the deploy branch's gate is permanently red" || ok "a manifest-only rebuild reads fresh"
+
+echo "the emulator rebuild's commit subject, spelled in two workflows"
+# crossplay-autorelease.yml tells an emulator rebuild from a real merge that
+# moved the tip past what CI verified by MATCHING THE SUBJECT. Reword it in
+# crossplay-emulator.yml and every release silently stops: the gate decides the
+# tip moved, declines, and says so in a log nobody reads. Nothing links the two
+# files, so this is the link.
+AR="$HERE/../../.github/workflows/crossplay-autorelease.yml"
+EM="$HERE/../../.github/workflows/crossplay-emulator.yml"
+subject="$(grep -oE "grep -vq '\^[^']+'" "$AR" | sed -E "s/.*'\^//; s/'$//")"
+if [ -z "$subject" ]; then
+  bad "crossplay-autorelease.yml no longer matches an emulator-rebuild subject at all"
+else
+  ok "autorelease matches the subject '$subject'"
+  grep -q -- "-m \"$subject" "$EM" \
+    && ok "crossplay-emulator.yml still commits under that subject" \
+    || bad "crossplay-emulator.yml's commit subject no longer starts with '$subject', so autorelease will read every rebuild as a moved tip and stop releasing"
+fi
+
+echo "what the rebuild commits, against what CI ignores"
+# crossplay-ci.yml's paths-ignore exists so the rebuild's own push does not
+# start a second CrossPlay run -- one that CANCELS the merge's run and takes
+# the autorelease with it, because a cancelled run is not a success. That cost
+# two full builds per merge on 2026-09-04. The filter names paths; the rebuild
+# picks them. Nothing links the two, and the failure is a doubled build and a
+# skipped release, neither of which says why.
+CI="$HERE/../../.github/workflows/crossplay-ci.yml"
+added="$(grep -oE '^ *git add [^|&;]+' "$EM" | sed -E 's/^ *git add //' | tr -s ' ' '\n' | grep -v '^$' | sort -u)"
+if [ -z "$added" ]; then
+  bad "crossplay-emulator.yml stages nothing; the check cannot tell what CI must ignore"
+else
+  ok "the rebuild stages: $(printf '%s' "$added" | tr '\n' ' ')"
+  ignored="$(sed -n '/paths-ignore:/,/^  [a-z_]*:/p' "$CI" | grep -oE "'[^']+'" | tr -d "'")"
+  for path in $added; do
+    match=no
+    for pat in $ignored; do
+      case "$path" in ${pat%/\*\*}|${pat%/\*\*}/*|$pat) match=yes;; esac
+    done
+    [ "$match" = yes ] \
+      && ok "crossplay-ci.yml ignores $path" \
+      || bad "crossplay-emulator.yml commits $path and crossplay-ci.yml's paths-ignore does not cover it, so every rebuild starts a second CI run that cancels the merge's own and skips the release"
+  done
+fi
+
 echo
 echo "$((PASS+FAIL)) checks, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/host-tests/site/fetch_emulator.js
+++ b/host-tests/site/fetch_emulator.js
@@ -1,0 +1,208 @@
+// site/fetch-emulator.mjs, run for real against a local server.
+//
+// This script is the only thing standing between "the emulator was published"
+// and "the emulator is on the site". It runs on Vercel, once per deploy, in a
+// place nobody watches, and the deploy is green whatever it prints. So the
+// case worth testing is not the happy one -- it is every way it can come back
+// WITHOUT the right bytes, because each of those, if it exited zero, would
+// publish a homepage whose headline feature 404s with no check anywhere red.
+//
+// Six cases, five of which are failures:
+//   * a correct download lands the bytes
+//   * a file already on disk with the right hash is not downloaded again
+//   * an asset that comes back corrupted is REFUSED and not written
+//   * an asset that 404s is refused
+//   * a manifest naming a path outside emulator/ is refused
+//   * a manifest with no files at all is refused, rather than "0 files, done"
+//
+// The server is in this process and the script under test is a child, so
+// everything here is async: spawnSync would block this process's event loop,
+// the server would never answer the request the child had already made, and
+// the whole suite would hang until a timeout with no output. (It did. Twice is
+// the number of times that costs a session, so it is written down here.)
+//
+//   node host-tests/site/fetch_emulator.js <repo root>
+
+const { createHash } = require("node:crypto");
+const { spawn } = require("node:child_process");
+const http = require("node:http");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const ROOT = process.argv[2] || path.join(__dirname, "..", "..");
+const SCRIPT = path.join(ROOT, "site", "fetch-emulator.mjs");
+
+let failed = 0;
+const ok = (m) => console.log(`  ok   ${m}`);
+const bad = (m) => {
+  failed++;
+  console.log(`  FAIL ${m}`);
+};
+
+const sha256 = (b) => createHash("sha256").update(b).digest("hex");
+
+// The assets the server hands out, and the manifest entries describing them.
+// Derived from the bytes rather than typed, so a test cannot assert a hash the
+// script was never going to compute.
+const BODIES = {
+  "aaa-crossplay.js": Buffer.from("// pretend module\n"),
+  "bbb-crossplay.wasm": Buffer.from([0x00, 0x61, 0x73, 0x6d, 1, 0, 0, 0]),
+};
+const entry = (name, asset) => ({
+  name,
+  asset,
+  sha256: sha256(BODIES[asset]),
+  sha256_raw: sha256(BODIES[asset]),
+  bytes: BODIES[asset].length,
+  bytes_raw: BODIES[asset].length,
+});
+
+let served = 0;
+let corrupt = new Set();
+let missing = new Set();
+
+const server = http.createServer((req, res) => {
+  const name = decodeURIComponent(req.url.replace(/^\//, ""));
+  served++;
+  if (missing.has(name) || !(name in BODIES)) {
+    res.writeHead(404).end("no such asset");
+    return;
+  }
+  const body = corrupt.has(name)
+    ? Buffer.concat([BODIES[name], Buffer.from("tampered")])
+    : BODIES[name];
+  res.writeHead(200, { "Content-Length": body.length }).end(body);
+});
+
+function run(manifest, { seed } = {}) {
+  // The script resolves the manifest and the output directory against its own
+  // location, so a copy in a scratch directory is a complete, isolated run.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "fetchemu-"));
+  fs.copyFileSync(SCRIPT, path.join(dir, "fetch-emulator.mjs"));
+  fs.writeFileSync(
+    path.join(dir, "emulator-manifest.json"),
+    JSON.stringify(manifest, null, 2),
+  );
+  if (seed) {
+    fs.mkdirSync(path.join(dir, "emulator"), { recursive: true });
+    for (const [name, body] of Object.entries(seed)) {
+      fs.writeFileSync(path.join(dir, "emulator", name), body);
+    }
+  }
+  served = 0;
+  return new Promise((resolve) => {
+    const child = spawn("node", [path.join(dir, "fetch-emulator.mjs")], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "";
+    child.stdout.on("data", (d) => (out += d));
+    child.stderr.on("data", (d) => (out += d));
+    child.on("close", (code) =>
+      resolve({
+        code,
+        out,
+        requests: served,
+        read: (name) => {
+          try {
+            return fs.readFileSync(path.join(dir, "emulator", name));
+          } catch {
+            return null;
+          }
+        },
+      }),
+    );
+  });
+}
+
+async function main() {
+  const base = `http://127.0.0.1:${server.address().port}/`;
+  const good = {
+    base,
+    built_from: "0000000000000000000000000000000000000000",
+    files: [
+      entry("crossplay.js", "aaa-crossplay.js"),
+      entry("crossplay.wasm", "bbb-crossplay.wasm"),
+    ],
+  };
+
+  // 1. the happy path really does land the bytes
+  let r = await run(good);
+  r.code === 0
+    ? ok("a correct manifest fetches and exits 0")
+    : bad(`a correct manifest exited ${r.code}: ${r.out}`);
+  const landed = r.read("crossplay.wasm");
+  landed && sha256(landed) === good.files[1].sha256
+    ? ok("the wasm on disk is the wasm the manifest names")
+    : bad("the wasm was not written, or was written wrong");
+
+  // 2. a file already correct is not downloaded again. This is the path the
+  //    committed fallback takes today, and it is also what lets a local
+  //    serve.py work offline after one build, so it is asserted rather than
+  //    assumed.
+  r = await run(good, {
+    seed: {
+      "crossplay.js": BODIES["aaa-crossplay.js"],
+      "crossplay.wasm": BODIES["bbb-crossplay.wasm"],
+    },
+  });
+  r.code === 0 && r.requests === 0
+    ? ok("files already correct on disk are not re-downloaded")
+    : bad(
+        `expected 0 requests and exit 0, got ${r.requests} requests and exit ${r.code}`,
+      );
+
+  // 3. THE ONE THAT MATTERS. Wrong bytes must not be written and must not exit
+  //    0: a corrupted wasm deploys green and dies in the browser, where no
+  //    check in this repository can see it.
+  corrupt = new Set(["bbb-crossplay.wasm"]);
+  r = await run(good);
+  r.code !== 0
+    ? ok("a corrupted download exits non-zero")
+    : bad(
+        "a corrupted download exited 0 -- the site would deploy a broken emulator",
+      );
+  r.read("crossplay.wasm") === null
+    ? ok("a corrupted download writes nothing")
+    : bad("a corrupted download left bytes on disk");
+  /wrong contents/.test(r.out)
+    ? ok("it says which file and what it expected")
+    : bad(`the failure does not name the problem: ${r.out}`);
+  corrupt = new Set();
+
+  // 4. a missing asset -- the manifest landed but the upload did not
+  missing = new Set(["bbb-crossplay.wasm"]);
+  r = await run(good);
+  r.code !== 0
+    ? ok("an asset that 404s exits non-zero")
+    : bad("a missing asset exited 0");
+  missing = new Set();
+
+  // 5. the manifest comes from git, not from a stranger, but it still names
+  //    filesystem paths and may not name one outside emulator/.
+  const escape = JSON.parse(JSON.stringify(good));
+  escape.files[0].name = "../../index.html";
+  r = await run(escape);
+  r.code !== 0 && /outside emulator/.test(r.out)
+    ? ok("a manifest naming a path outside emulator/ is refused")
+    : bad(`a path escape was not refused (exit ${r.code}): ${r.out}`);
+
+  // 6. an empty list is the quiet catastrophe: nothing to do, nothing fetched,
+  //    exit 0, and a site with no emulator at all.
+  r = await run({ base, built_from: "x", files: [] });
+  r.code !== 0
+    ? ok("a manifest with no files is refused rather than trivially satisfied")
+    : bad(
+        "an empty manifest exited 0, which would deploy a site with no emulator",
+      );
+}
+
+server.listen(0, "127.0.0.1", () => {
+  main()
+    .catch((err) => bad(`the harness itself failed: ${err.stack}`))
+    .finally(() => {
+      server.close();
+      console.log(`${failed} failed`);
+      process.exit(0);
+    });
+});

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -410,5 +410,116 @@ else
   bad "site/inbox/fixture.json is missing, so the inbox cannot be looked at without a passphrase"
 fi
 
+# -- the emulator, which is no longer in the repository -----------------------
+#
+# site/emulator/ is 3.7MB of generated wasm that used to be committed on every
+# firmware merge (111 revisions, ~357MB of history, ~20MB a day). It is now
+# published to a GitHub release by tools_local/site/publish_emulator.py, pointed
+# at by site/emulator-manifest.json, and pulled back in during Vercel's build by
+# site/fetch-emulator.mjs. Three files that never see each other, on the path to
+# the front page's headline feature, and every way they can disagree deploys
+# green and 404s in a browser.
+MANIFEST="$ROOT/site/emulator-manifest.json"
+FETCH="$ROOT/site/fetch-emulator.mjs"
+VERCEL="$ROOT/site/vercel.json"
+for f in "$MANIFEST" "$FETCH" "$VERCEL"; do
+  [ -f "$f" ] || { echo "FAIL site  missing $f"; exit 1; }
+done
+
+# vercel.json is the only thing that makes the fetch run at all. Two properties:
+# the command must name a script that is really there, and an outputDirectory
+# must be declared -- an Output Directory override left on and empty in the
+# Vercel dashboard SKIPS the build step entirely, and declaring one here is what
+# takes that decision away from a setting nobody can see from the repository.
+build_cmd="$(sed -nE 's/.*"buildCommand": *"([^"]*)".*/\1/p' "$VERCEL")"
+if [ -z "$build_cmd" ]; then
+  bad "site/vercel.json has no buildCommand, so nothing fetches the emulator and the demo 404s"
+else
+  ok
+  script="$(printf '%s' "$build_cmd" | awk '{print $NF}')"
+  [ -f "$ROOT/site/$script" ] \
+    && ok || bad "vercel.json's buildCommand runs '$script' and site/$script does not exist"
+fi
+grep -q '"outputDirectory"' "$VERCEL" \
+  && ok || bad "site/vercel.json declares no outputDirectory; a dashboard override can then skip the build step and the emulator is never fetched"
+
+# .vercelignore exists to keep laptop-only tooling off a public URL, and both
+# halves of the fetch look exactly like that. Ignoring either leaves the build
+# unable to find the file it was told to run.
+VIGNORE="$ROOT/site/.vercelignore"
+if [ -f "$VIGNORE" ]; then
+  for needed in "$(basename "$MANIFEST")" "$(basename "$FETCH")"; do
+    if grep -qE "^[^#]*$(printf '%s' "$needed" | sed 's/\./\\./g')" "$VIGNORE"; then
+      bad ".vercelignore excludes $needed, so Vercel's build cannot see it and the emulator never reaches the site"
+    else
+      ok
+    fi
+  done
+  # *.mjs or *.json as a blanket rule takes them both out just as effectively.
+  grep -qE '^[^#]*\*\.(mjs|json)' "$VIGNORE" \
+    && bad ".vercelignore excludes all .mjs or .json, which removes the build command or the manifest it reads" \
+    || ok
+fi
+
+# The manifest and the script that reads it, on the field names. Read out of the
+# script rather than listed here, so a rename on either side fails this instead
+# of failing a deploy.
+# The KEY, not the local name it is destructured into: `built_from: builtFrom`
+# asks the manifest for built_from and nothing else.
+fields="$(sed -nE 's/.*const \{ ([^}]*) \} = manifest.*/\1/p' "$FETCH" | tr ',' '\n' \
+  | sed -E 's/ *:.*//; s/^ *//; s/ *$//' | grep -v '^$' | sort -u)"
+entry_fields="$(sed -nE 's/.*const \{ ([^}]*) \} = file;.*/\1/p' "$FETCH" | tr ',' '\n' \
+  | sed -E 's/^ *//; s/ *$//; s/^([A-Za-z0-9_]+):.*/\1/' | grep -v '^$' | sort -u)"
+if [ -z "$fields" ] || [ -z "$entry_fields" ]; then
+  bad "cannot tell which manifest fields fetch-emulator.mjs reads; the check has stopped checking"
+else
+  ok
+  if man_bad="$(python3 - "$MANIFEST" "$fields" "$entry_fields" <<'PY' 2>&1
+import json, sys
+m = json.load(open(sys.argv[1]))
+top = [f for f in sys.argv[2].split() if f]
+per = [f for f in sys.argv[3].split() if f]
+for f in top:
+    if f not in m:
+        print(f"fetch-emulator.mjs reads manifest.{f} and the manifest has no such key")
+files = m.get("files") or []
+if not files:
+    print("the manifest names no files, so a deploy would fetch nothing and still be green")
+for e in files:
+    for f in per:
+        if f not in e:
+            print(f"fetch-emulator.mjs reads entry.{f} and {e.get('name', '?')} has no such key")
+if not str(m.get("base", "")).endswith("/"):
+    print("manifest base does not end in '/', so new URL(asset, base) drops the last path segment")
+PY
+  )"; then
+    if [ -z "$man_bad" ]; then ok; else while IFS= read -r line; do bad "$line"; done <<< "$man_bad"; fi
+  else
+    bad "the emulator manifest could not be checked:"
+    while IFS= read -r line; do echo "      $line"; done <<< "$man_bad"
+  fi
+fi
+
+# The pre-compression contract, which the manifest now rides on: everything
+# under site/emulator/ is served with Content-Encoding: br, so publish and fetch
+# both hash brotli bytes. Either half of that removed alone ships a wasm no
+# browser can decode, with nothing on the wire wrong until the decoder gives up.
+grep -q '"emulator"' "$ROOT/tools_local/site/precompress.py" \
+  && ok || bad "precompress.py no longer compresses site/emulator/, but vercel.json still promises brotli for it"
+grep -q '"/emulator/(.\*)"' "$VERCEL" || grep -q '/emulator/' "$VERCEL" \
+  && ok || bad "vercel.json no longer sets Content-Encoding for /emulator/, but the files are stored brotli"
+
+# And the script itself, run for real against a local server -- including the
+# case that matters, bytes that arrive corrupted. Status checked as well as
+# output, for the reason spelled out in the shelf block above.
+if fetch_out="$(node "$HERE/fetch_emulator.js" "$ROOT" 2>&1)"; then
+  ok
+  n_fail="$(printf '%s\n' "$fetch_out" | grep -c '^  FAIL' || true)"
+  [ "$n_fail" -eq 0 ] && ok || { while IFS= read -r line; do bad "fetch_emulator: $line"; done < <(printf '%s\n' "$fetch_out" | grep '^  FAIL'); }
+else
+  bad "fetch_emulator.js could not run, so site/fetch-emulator.mjs went unchecked:"
+  while IFS= read -r line; do echo "      $line"; done <<< "$fetch_out"
+fi
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -1014,12 +1014,14 @@ if true; then
   if bash "$REPO/scripts_local/emulator-stale.sh" "$REPO" >/dev/null 2>&1; then
     echo
     echo "browser artifact is STALE"
-    echo "  site/emulator/ was built at $(git log -1 --format=%h\ %s -- site/emulator | cut -c1-58)"
+    echo "  the browser artefact was last published at $(git log -1 --format=%h\ %s -- site/emulator site/emulator-manifest.json | cut -c1-58)"
     # shellcheck disable=SC2086
     echo "  but $(git log -1 --format=%h\ %s -- $EMU_SOURCES | cut -c1-58) came after it"
     echo "  the live page would ship code older than this branch. Rebuild:"
     echo "    pio run -e simulator_x4_pro -t compiledb"
     echo "    source ../.emsdk/emsdk_env.sh && python3 tools_local/wasm/build.py"
+    echo "  then publish it -- the bytes are no longer committed, only the pointer:"
+    echo "    python3 tools_local/site/publish_emulator.py"
     echo "  anything the page previews is running that older firmware."
     if [ "${CHECK_OUTER_BRANCH:-$(git branch --show-current 2>/dev/null)}" = "$DEPLOY_BRANCH" ]; then
       FAILED=1

--- a/scripts_local/device-build-needed.sh
+++ b/scripts_local/device-build-needed.sh
@@ -159,13 +159,19 @@ classify() {
     # devices, merges the images and uploads the assets a person downloads;
     # PR #42's fix for the missing bootloader lived here.
     #
-    # Checked rather than assumed, over all eight workflow files: it is the
-    # only one carrying softprops/action-gh-release, the only action in the
-    # tree that writes a GitHub release. The rest either verify
-    # (crossplay-ci.yml, ci.yml, pr-formatting-check.yml), schedule
+    # Checked rather than assumed, over every workflow file (nine since
+    # crossplay-site-live.yml): it is the only one carrying
+    # softprops/action-gh-release, the action that writes the release a person
+    # downloads. crossplay-emulator.yml does now write to a release too, via
+    # `gh release upload` -- but to the `emulator` prerelease, which carries no
+    # firmware and which /releases/latest excludes by definition, so nobody's
+    # updater can ever see it. The rest either verify
+    # (crossplay-ci.yml, ci.yml, pr-formatting-check.yml, crossplay-site-live.yml), schedule
     # (crossplay-autorelease.yml decides WHEN, never what), or rebuild the
-    # website (crossplay-emulator.yml, which commits site/emulator/ -- the
-    # website deploys continuously and is not part of a release). Upstream's
+    # website (crossplay-emulator.yml, which publishes the browser build to the
+    # `emulator` release and commits the pointer to it -- the website deploys
+    # continuously and is not part of a release; that release carries no
+    # firmware and nobody's updater looks at it). Upstream's
     # release.yml and release_candidate.yml do upload, but to
     # actions/upload-artifact: files attached to a workflow RUN, which nobody's
     # updater ever asks for. Both are `on: workflow_dispatch` and nothing else

--- a/scripts_local/emulator-stale.sh
+++ b/scripts_local/emulator-stale.sh
@@ -12,7 +12,13 @@
 set -uo pipefail
 
 SOURCES=(src lib assets_local tools_local/wasm platformio.sim.ini freeink-sdk)
-ARTEFACT=site/emulator
+# Two paths, because the artefact stopped being one thing. The bytes in
+# site/emulator/ are frozen at the last revision that was ever committed and no
+# longer move; what a rebuild now commits is the pointer beside them,
+# site/emulator-manifest.json (see tools_local/site/publish_emulator.py). Miss
+# it and every rebuild reads as stale forever, which is the failure this test
+# exists to report.
+ARTEFACTS=(site/emulator site/emulator-manifest.json)
 
 # --paths: print the source list, one per line, for callers that want to name
 # what moved (check.sh's message) without spelling the list a second time.
@@ -23,7 +29,7 @@ fi
 cd "${1:-$(dirname "$0")/..}" || exit 2
 
 src_ts="$(git log -1 --format=%ct -- "${SOURCES[@]}" 2>/dev/null || echo 0)"
-art_ts="$(git log -1 --format=%ct -- "$ARTEFACT" 2>/dev/null || echo 0)"
+art_ts="$(git log -1 --format=%ct -- "${ARTEFACTS[@]}" 2>/dev/null || echo 0)"
 if [ "${src_ts:-0}" -gt "${art_ts:-0}" ]; then
   echo "stale (sources $(date -u -r "$src_ts" +%FT%TZ 2>/dev/null || echo "$src_ts"), emulator $(date -u -r "$art_ts" +%FT%TZ 2>/dev/null || echo "$art_ts"))"
   exit 0

--- a/site/.vercelignore
+++ b/site/.vercelignore
@@ -3,6 +3,13 @@
 # scripts on a public URL for no reason.
 #
 # Keep this in step with site/README.md: every script it documents belongs here.
+#
+# TWO DELIBERATE EXCEPTIONS, both of which look exactly like things that belong
+# in this list and would break every deploy if added. fetch-emulator.mjs IS the
+# build command (see vercel.json), and emulator-manifest.json is the file it
+# reads; ignoring either leaves the build unable to find it and the emulator
+# unable to reach the site. They are two more public files on a public
+# repository's site, which is the whole cost.
 *.py
 README.md
 # sim-shot capture recipes: replay scripts for regenerating the screenshots,

--- a/site/README.md
+++ b/site/README.md
@@ -29,8 +29,9 @@ Two properties worth keeping if you edit it:
   project root is `site/`. Changing the project root without changing this
   path silently stops every deploy.
 
-The emulator rebuild CI commits after a firmware merge DOES touch `site/`, so
-it still deploys. That is correct: the page really did change.
+The emulator rebuild CI commits after a firmware merge DOES touch `site/` --
+it writes `site/emulator-manifest.json` -- so it still deploys. That is correct:
+the page really did change.
 
 ## Before it deploys
 
@@ -54,8 +55,11 @@ fork network rather than the branch GitHub reports. The API rejects
 and getting it wrong makes every push a preview while the live domain
 silently keeps serving the last manual deploy.
 
-Point Vercel at this directory as the project root. There is nothing to build,
-so the framework preset is **Other** and the build command is empty.
+Point Vercel at this directory as the project root; the framework preset is
+**Other**. There is one build step and it does not build the site: it downloads
+the browser emulator, which is no longer committed. `vercel.json` carries the
+command, the output directory and an empty install command, and **How the
+emulator reaches production** below says why each of the three is there.
 
 `vercel.json` sets `Cross-Origin-Opener-Policy: same-origin` and
 `Cross-Origin-Embedder-Policy: require-corp`. Those are there for the in-browser
@@ -85,7 +89,8 @@ which is how a page that "used to load in under a second" starts taking
 minutes for everyone who is not near the region you last tested from.
 
 So `site/emulator/`, `site/pyodide/` and `site/study/NotoSansCJK.otf` are
-committed as brotli, with `Content-Encoding: br` declared for those paths in
+stored as brotli -- the last two committed that way, the emulator published
+that way (see below) -- with `Content-Encoding: br` declared for those paths in
 `vercel.json`; Vercel sees an encoded body and passes it through (34.3s ->
 0.99s, decoding byte-identically). `tools_local/site/precompress.py` does the
 compressing, `tools_local/wasm/build.py` and `fetch_pyodide.py` call it so a
@@ -129,6 +134,97 @@ file was correct. The only reach into a cache that refuses to revalidate is a
 different URL, so both pages load `assets/emulator.js?v=2`. The HTML itself
 revalidates, which is what makes that work. Keep the query on both pages until
 2027, and bump it rather than removing it if this ever recurs.
+
+## How the emulator reaches production
+
+`site/emulator/` is 3.7MB of generated wasm that changes on every firmware
+merge. It used to be committed, and the arithmetic is the whole story: 111
+distinct revisions of `crossplay.wasm`, ~357MB of blobs, 56 revisions and 159MB
+in one week, in a repository whose checkout is ~104MB and whose clone was ~497MB
+and rising by ~20MB a day. Every clone and every CI checkout in the fork paid
+for it.
+
+It cannot simply be ignored either, and `.gitignore` said so for months: **Vercel
+has no Emscripten**, so a deploy that cannot see these files ships a site whose
+headline feature 404s. The browser demo is the first thing the README offers a
+stranger, before install instructions.
+
+So the bytes go where a clone does not follow, and the repository keeps a
+pointer. Four files, in the order they run:
+
+|                                             |                                                                                                                |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `tools_local/site/publish_emulator.py`      | uploads each file to the **`emulator`** GitHub release under a content-addressed name, and writes the manifest |
+| `site/emulator-manifest.json`               | ~1KB, committed. Names the assets, their sha256s, and the source revision                                      |
+| `site/fetch-emulator.mjs`                   | `vercel.json`'s `buildCommand`. Downloads them during the build and verifies every hash                        |
+| `.github/workflows/crossplay-site-live.yml` | asks the live origin whether it worked                                                                         |
+
+`.github/workflows/crossplay-emulator.yml` drives the first two after every push
+to `xteink` whose sources are newer than the artefact.
+
+**`vercel.json` cannot carry comments, so its three build keys are explained
+here.** All three were added together and none of them is decoration:
+
+- `"buildCommand": "node fetch-emulator.mjs"` — the fetch itself. `node` and not
+  `curl` or `python3`: only Node is on Vercel's documented build image.
+- `"outputDirectory": "."` — Preset "Other" already resolves the output to `.`
+  when there is no `public/`, so this changes nothing about what is served. It
+  is here because an **Output Directory override left on and empty in the Vercel
+  dashboard skips the build step entirely**, and that setting is invisible from
+  the repository. Declaring one takes the decision away from it.
+- `"installCommand": ""` — there is no `package.json`, so there is nothing to
+  install and no reason to let Vercel guess a package manager.
+
+**Three things that are load-bearing, each of which has an obvious-looking
+wrong version:**
+
+- **Asset names are the content's hash, and old assets are never replaced.** A
+  rolling filename updated in place would break every redeploy of an older
+  commit — Vercel's Redeploy button and its rollbacks both rebuild an old tree,
+  whose manifest would name bytes that no longer exist under that name.
+- **A failed fetch fails the build, deliberately.** A failed Vercel build
+  promotes nothing, so the previous deployment keeps serving. A broken publish
+  must cost a stale site, never a broken one — and it must never be survivable,
+  because a green deploy with no emulator is invisible to every check that looks
+  at the repository.
+- **The files are published brotli and hashed brotli.** Everything under
+  `emulator/` is served with `Content-Encoding: br` for the reason spelled out
+  above, so `publish_emulator.py` refuses to publish anything that is not, and
+  the manifest carries both the encoded and the decoded hash.
+
+**Rebuilding by hand** is unchanged, and it no longer produces something to
+commit:
+
+```bash
+pio run -e simulator_x4_pro -t compiledb
+source ../.emsdk/emsdk_env.sh && python3 tools_local/wasm/build.py
+```
+
+The files land in `site/emulator/` and `serve.py` picks them up. Do not commit
+them; land the source change and let CI publish.
+
+**If you only want to look at the page**, you do not need Emscripten at all --
+fetch the published build the same way Vercel does:
+
+```bash
+node site/fetch-emulator.mjs
+```
+
+If you do need to publish one by hand:
+
+```bash
+python3 tools_local/site/publish_emulator.py            # upload + rewrite the manifest
+python3 tools_local/site/verify_live_emulator.py        # and then ask the live site
+```
+
+**The files under `site/emulator/` are still tracked**, frozen at the last
+revision CI ever committed. They are the fallback for the one failure the build
+cannot catch — a `buildCommand` that never runs at all — and while they are
+there, a fetch finds the right hashes on disk only until the next rebuild
+changes the manifest. Removing them from the index is a separate change, and the
+live check above is what says it is safe to make: it compares the origin against
+the manifest, so a fallback being served instead of the published bytes shows up
+as a failure with the reason named.
 
 ## The Install button
 
@@ -281,7 +377,10 @@ demonstrates an old version:
 pio run -e simulator_x4_pro -t compiledb && source ../.emsdk/emsdk_env.sh && python3 tools_local/wasm/build.py
 ```
 
-It is checked in because Vercel does not have Emscripten.
+**It is not committed any more.** It used to be, and that cost 111 revisions of
+`crossplay.wasm`, ~357MB of history and about 20MB a day forever, on a
+repository whose working tree is ~104MB. See **How the emulator reaches
+production** below before changing anything about how it is built or shipped.
 
 ## Assets
 

--- a/site/emulator-manifest.json
+++ b/site/emulator-manifest.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "Written by tools_local/site/publish_emulator.py; read by site/fetch-emulator.mjs during Vercel's build. The bytes live on the GitHub release below rather than in git. Do not hand-edit.",
+  "base": "https://github.com/ma-r-s/crossplay/releases/download/emulator/",
+  "built_from": "0c40258024d276b3fe99ed26083ae82158dca14a",
+  "files": [
+    {
+      "name": "BUILT_FROM",
+      "asset": "162b6dc49013f729-BUILT_FROM",
+      "sha256": "162b6dc49013f72902f1176622cab5bf734e15020fd35c7386e9f1f8efb2e934",
+      "sha256_raw": "19db0effa8dc92a06d7f62d3918b0d312b28a374de11c4f5c09df8a957f462ad",
+      "bytes": 39,
+      "bytes_raw": 41
+    },
+    {
+      "name": "crossplay.data",
+      "asset": "b9a8d054c0de7e94-crossplay.data",
+      "sha256": "b9a8d054c0de7e94ff5514bd91b37ecc845e71dd7acd438adbe33a7d240f6aea",
+      "sha256_raw": "b26a36936ee4a9937fc7a0d1fa5bfb423c821f3ff8bb93b30de5bb89f51c3531",
+      "bytes": 968270,
+      "bytes_raw": 3642431
+    },
+    {
+      "name": "crossplay.js",
+      "asset": "a86e56eb7139af96-crossplay.js",
+      "sha256": "a86e56eb7139af96d28a7fc6f52806a57c1b3a6feb9a5507dd5ac7e0b4a91443",
+      "sha256_raw": "cef775578b52a8cf13510b153825fdd7cd2b65dedbb533a91e2dd9e9d1c44a2b",
+      "bytes": 28767,
+      "bytes_raw": 113289
+    },
+    {
+      "name": "crossplay.wasm",
+      "asset": "9b1257f4be868a0b-crossplay.wasm",
+      "sha256": "9b1257f4be868a0b9c1d914b9dbce1e104902e3e0d19772f98ca494d4cffe967",
+      "sha256_raw": "85c429e909a921824a9f4b6eaa0a4ad8be33586e95e52117c54b88c1e4a4a08e",
+      "bytes": 2913791,
+      "bytes_raw": 5484350
+    }
+  ]
+}

--- a/site/fetch-emulator.mjs
+++ b/site/fetch-emulator.mjs
@@ -1,0 +1,154 @@
+// Put site/emulator/ back before the site is served.
+//
+// This is site/vercel.json's buildCommand. It runs on Vercel, in this
+// directory, with nothing installed -- so it uses only what the build image
+// guarantees: node, and node's own fetch and crypto. (curl is not on Vercel's
+// documented package list for the build image, and python3 is not guaranteed
+// either. This is the one thing that is.)
+//
+// WHY. The emulator is 3.7MB of generated wasm that changes on every firmware
+// merge, and it used to be committed -- 111 revisions of crossplay.wasm, ~357MB
+// of history, ~20MB a day and rising, paid for by every clone and every CI
+// checkout. It cannot simply be ignored either: Vercel has no Emscripten, so a
+// deploy that cannot see these files ships a site whose headline feature 404s,
+// which is the reason .gitignore spared them for months. So the bytes live on a
+// GitHub release, the repository keeps ./emulator-manifest.json, and this puts
+// the two back together during the build.
+// tools_local/site/publish_emulator.py is the other half.
+//
+// THE FAILURE MODE THIS IS WRITTEN AROUND. If a fetch quietly did nothing, the
+// deploy would succeed and the demo would 404, and nothing anywhere would
+// notice. So every path out of here that is not "the right bytes are on disk"
+// exits non-zero, which fails the Vercel build, which leaves the PREVIOUS
+// deployment serving. A broken emulator publish must cost a stale site, never
+// a broken one.
+//
+//   node fetch-emulator.mjs           # from site/
+//
+// Verified end to end by host-tests/site/fetch_emulator.js, which includes the
+// case that matters: bytes that arrive corrupted must be REFUSED, not written.
+
+import { createHash } from "node:crypto";
+import { readFile, writeFile, mkdir, rename, rm } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const MANIFEST = path.join(HERE, "emulator-manifest.json");
+const OUT = path.join(HERE, "emulator");
+const ATTEMPTS = 3;
+
+const sha256 = (buf) => createHash("sha256").update(buf).digest("hex");
+
+async function hashOnDisk(file) {
+  try {
+    return sha256(await readFile(file));
+  } catch {
+    return null; // absent, unreadable: both mean "fetch it"
+  }
+}
+
+async function download(url) {
+  let last;
+  for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, { redirect: "follow" });
+      if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+      return Buffer.from(await res.arrayBuffer());
+    } catch (err) {
+      last = err;
+      // A release asset 404s permanently; a network blip does not. Retrying a
+      // 404 costs ten seconds and tells the log the same thing three times,
+      // which is cheaper than distinguishing them wrongly.
+      if (attempt < ATTEMPTS) {
+        console.warn(`    attempt ${attempt} failed (${err.message}); retrying`);
+        await new Promise((r) => setTimeout(r, 2000 * attempt));
+      }
+    }
+  }
+  throw last;
+}
+
+async function main() {
+  let manifest;
+  try {
+    manifest = JSON.parse(await readFile(MANIFEST, "utf8"));
+  } catch (err) {
+    throw new Error(
+      `cannot read ${path.basename(MANIFEST)}: ${err.message}\n` +
+        "It is written by tools_local/site/publish_emulator.py and committed. " +
+        "Without it there is no way to know which emulator this commit wants.",
+    );
+  }
+  const { base, files, built_from: builtFrom } = manifest;
+  if (!base) {
+    throw new Error("the manifest has no `base`, so there is nowhere to fetch from.");
+  }
+  if (!Array.isArray(files) || files.length === 0) {
+    throw new Error(
+      "the manifest names no files. Nothing to fetch is not success: it would " +
+        "leave the site with no emulator and this build green. Refusing.",
+    );
+  }
+
+  console.log(`emulator: ${files.length} file(s), built from ${builtFrom ?? "unknown"}`);
+  await mkdir(OUT, { recursive: true });
+
+  let fetched = 0;
+  let kept = 0;
+  for (const file of files) {
+    const { name, asset, sha256: want, bytes } = file;
+    if (!name || !asset || !want) {
+      throw new Error(`manifest entry is incomplete: ${JSON.stringify(file)}`);
+    }
+    const target = path.join(OUT, name);
+    // Never let a name out of the manifest escape the directory it names.
+    if (path.relative(OUT, target).startsWith("..") || path.isAbsolute(name)) {
+      throw new Error(`manifest names a file outside emulator/: ${name}`);
+    }
+
+    // A copy already on disk with the right hash needs nothing. That is the
+    // normal case locally (someone just built it) and, until the committed
+    // copies are removed, the fast path here too.
+    if ((await hashOnDisk(target)) === want) {
+      console.log(`  ${name}  already correct`);
+      kept++;
+      continue;
+    }
+
+    const url = new URL(asset, base).toString();
+    console.log(`  ${name}  <- ${url}`);
+    const body = await download(url);
+    const got = sha256(body);
+    if (got !== want) {
+      // The whole point. Wrong bytes are worse than no bytes: they deploy
+      // green and break in a browser, which no check here would ever see.
+      throw new Error(
+        `${name} downloaded with the wrong contents.\n` +
+          `      expected sha256 ${want}\n` +
+          `      got               ${got}\n` +
+          `      (${body.length} bytes; the manifest says ${bytes})`,
+      );
+    }
+    // Written aside and moved, so a build killed mid-download cannot leave a
+    // truncated wasm that hashes to nothing and is served anyway.
+    const tmp = `${target}.partial`;
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(tmp, body);
+    await rename(tmp, target);
+    await rm(tmp, { force: true });
+    fetched++;
+  }
+
+  console.log(`emulator ready: ${fetched} downloaded, ${kept} already present`);
+}
+
+main().catch((err) => {
+  console.error("\nEMULATOR FETCH FAILED -- refusing to deploy a site without it.");
+  console.error(`  ${err.message}`);
+  console.error(
+    "\nThe previous deployment keeps serving. Fix the publish " +
+      "(tools_local/site/publish_emulator.py) or the manifest, then redeploy.",
+  );
+  process.exit(1);
+});

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
+  "buildCommand": "node fetch-emulator.mjs",
+  "installCommand": "",
+  "outputDirectory": ".",
   "headers": [
     {
       "source": "/(.*)",

--- a/tools_local/site/publish_emulator.py
+++ b/tools_local/site/publish_emulator.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Publish site/emulator/ as GitHub release assets and write the manifest.
+
+WHY THIS EXISTS. site/emulator/ used to be committed. It is 3.7MB that changes
+on every firmware merge, and crossplay-emulator.yml committed a fresh copy after
+each one: 111 blob revisions of crossplay.wasm alone, ~357MB of history, 56 of
+those revisions in one week. The repository reached ~497MB on GitHub for a
+~104MB checkout and grew about 20MB a day, forever, which every clone and every
+CI checkout in the fork pays for.
+
+Ignoring the directory is not on its own an option, and .gitignore said so for
+months: Vercel has no Emscripten, so a git-connected deploy that cannot see
+these files ships a site whose headline feature 404s. The browser demo is the
+first thing the README offers a stranger.
+
+So the bytes go somewhere a clone does not follow -- a GitHub release asset --
+and the repository keeps a pointer instead:
+
+    site/emulator-manifest.json     ~1KB, one commit per rebuild
+
+`site/fetch-emulator.mjs` reads that manifest during Vercel's build and puts the
+files back before the site is served. A download that fails or arrives with the
+wrong bytes fails the build, so a broken fetch leaves the PREVIOUS deployment
+serving rather than shipping a 404.
+
+    python3 tools_local/site/publish_emulator.py                # upload + write
+    python3 tools_local/site/publish_emulator.py --dry-run      # write only
+
+THREE THINGS ABOUT THE DESIGN, each of which is load-bearing:
+
+  * Asset names are CONTENT-ADDRESSED (`<sha256[:16]>-crossplay.wasm`). A
+    rolling name updated in place would break every redeploy of an older
+    commit -- Vercel's Redeploy button and its rollbacks both rebuild an old
+    tree, whose manifest names bytes that no longer exist under that name. With
+    a content address, an old manifest keeps resolving as long as the asset is
+    there, and a rebuild that changes nothing uploads nothing.
+
+  * The manifest records `built_from`, the source revision, and it is what makes
+    the commit non-empty. scripts_local/emulator-stale.sh compares the last
+    commit touching the artefact against the last one touching its sources, and
+    that comparison is unsatisfiable when a rebuild produces identical bytes --
+    the same reason site/emulator/BUILT_FROM was invented. The revision always
+    changes, so the manifest always changes, so the gate can always be met.
+
+  * The files are verified to BE brotli before they are published. They are
+    served with `Content-Encoding: br` (see site/vercel.json and
+    tools_local/site/precompress.py), and publishing raw bytes behind that
+    header ships a wasm no browser can decode -- with no error anywhere,
+    because nothing on the wire is wrong until the decoder gives up.
+"""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SITE = REPO / "site"
+EMU = SITE / "emulator"
+MANIFEST = SITE / "emulator-manifest.json"
+
+# The rolling release the assets hang off. Not `v*`, deliberately:
+# crossplay-release.yml triggers on `push: tags: v*` and a version-shaped tag
+# here would build and publish a whole firmware release for a wasm rebuild.
+TAG = "emulator"
+RELEASE_TITLE = "Browser emulator assets"
+RELEASE_NOTES = (
+    "Build outputs for the browser demo on crossplay.ma-r-s.com, published here "
+    "rather than committed so the repository stops growing ~20MB a day.\n\n"
+    "Every asset is named by the sha256 of its contents. `site/emulator-manifest.json` "
+    "on `xteink` says which ones the live site is currently built from, and "
+    "`site/fetch-emulator.mjs` is what downloads them during Vercel's build.\n\n"
+    "Nothing here is firmware. Do not flash any of it."
+)
+
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, capture_output=True, text=True, **kw)
+
+
+def brotli_or_die():
+    try:
+        import brotli  # noqa: F401
+
+        return brotli
+    except ImportError:
+        sys.exit(
+            "the brotli module is missing: uv pip install --python"
+            " .venv-study/bin/python brotli"
+        )
+
+
+def sources():
+    """Every file in site/emulator/, whatever it is called.
+
+    Deliberately not a list of three names. build.py decides what it writes,
+    and a fourth output added there would otherwise be published by nobody and
+    404 in the browser -- the exact shape of bug this repository keeps paying
+    for. Whatever the build leaves in the directory is what ships.
+    """
+    if not EMU.is_dir():
+        sys.exit(
+            f"{EMU} does not exist -- build the emulator first:\n"
+            "  pio run -e simulator_x4_pro -t compiledb\n"
+            "  source ../.emsdk/emsdk_env.sh && python3 tools_local/wasm/build.py"
+        )
+    files = sorted(p for p in EMU.rglob("*") if p.is_file())
+    if not files:
+        sys.exit(f"{EMU} is empty -- nothing to publish")
+    return files
+
+
+def describe(path, brotli):
+    """One manifest entry: what it is called, what it hashes to, how big it is.
+
+    Two hashes, not one. `sha256` is of the bytes as stored and as uploaded --
+    brotli -- and is what the Vercel-side fetch verifies, because that is what
+    it downloads. `sha256_raw` is of the decoded bytes, and is what the
+    live-site check falls back to: `curl --compressed` hands back a decoded
+    body, and a check that only knew the encoded hash would report the live
+    site broken on a detail of its own request headers.
+    """
+    data = path.read_bytes()
+    try:
+        raw = brotli.decompress(data)
+    except Exception:
+        sys.exit(
+            f"{path.relative_to(SITE)} is not brotli, and site/vercel.json serves\n"
+            "site/emulator/ with Content-Encoding: br. Publishing it would ship bytes\n"
+            "no browser can decode, silently. Run:\n"
+            "  python3 tools_local/site/precompress.py"
+        )
+    return {
+        "name": str(path.relative_to(EMU)),
+        "asset": f"{hashlib.sha256(data).hexdigest()[:16]}-{path.name}",
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "sha256_raw": hashlib.sha256(raw).hexdigest(),
+        "bytes": len(data),
+        "bytes_raw": len(raw),
+    }
+
+
+def built_from(brotli):
+    """The revision the artefact was built from, taken from the artefact.
+
+    site/emulator/BUILT_FROM is written by tools_local/wasm/build.py at link
+    time and says what it compiled. `git rev-parse HEAD` here says only when
+    somebody ran this script, which is the same answer in CI (build and publish
+    are one job) and a wrong one anywhere else -- publishing an unchanged
+    artefact from a feature branch would stamp it with that branch's commit and
+    claim a rebuild that never happened.
+
+    It is also what makes the manifest change on every rebuild, which is what
+    lets scripts_local/emulator-stale.sh ever be satisfied. HEAD is the fallback
+    and nothing more.
+    """
+    stamp = EMU / "BUILT_FROM"
+    if stamp.is_file():
+        data = stamp.read_bytes()
+        try:
+            data = brotli.decompress(data)
+        except Exception:
+            pass  # not compressed yet; the file is plain text either way
+        text = data.decode("utf-8", "replace").strip()
+        if text:
+            return text
+    return run(["git", "rev-parse", "HEAD"], cwd=REPO).stdout.strip() or "unknown"
+
+
+def repo_slug(explicit):
+    if explicit:
+        return explicit
+    p = run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        cwd=REPO,
+    )
+    slug = p.stdout.strip()
+    if not slug:
+        sys.exit("could not work out the repository; pass --repo owner/name")
+    return slug
+
+
+def ensure_release(slug):
+    """Make the rolling release if it is not there, and never not as a prerelease.
+
+    `--prerelease` is not tidiness. GitHub defines /releases/latest as the most
+    recent release that is neither a prerelease nor a draft, and three separate
+    things ask exactly that question -- checked, not assumed, over every
+    api.github.com call in the tree:
+
+      * src/network/OtaUpdater.cpp -- every device in the field, looking for a
+        firmware update;
+      * site/assets/install.js -- the Install button's "Latest release";
+      * the board's release watcher (server/board/supabase/migrations).
+
+    Published as an ordinary release this one becomes "latest" for all three,
+    and it contains no firmware at all. Nothing downstream would say so: a
+    device would be offered an update whose asset does not exist, and the site
+    would print a tag its own validator then refuses.
+    """
+    if run(["gh", "release", "view", TAG, "--repo", slug]).returncode == 0:
+        return
+    print(f"creating the {TAG} release on {slug}")
+    p = run(
+        [
+            "gh",
+            "release",
+            "create",
+            TAG,
+            "--repo",
+            slug,
+            "--title",
+            RELEASE_TITLE,
+            "--notes",
+            RELEASE_NOTES,
+            "--prerelease",
+        ]
+    )
+    if p.returncode != 0:
+        sys.exit(f"could not create the {TAG} release:\n{p.stdout}{p.stderr}")
+
+
+def existing_assets(slug):
+    p = run(["gh", "release", "view", TAG, "--repo", slug, "--json", "assets"])
+    if p.returncode != 0:
+        return set()
+    try:
+        return {a["name"] for a in json.loads(p.stdout).get("assets", [])}
+    except (json.JSONDecodeError, KeyError):
+        return set()
+
+
+def upload(slug, path, asset_name, already, workdir):
+    """Upload one file under its content-addressed name.
+
+    gh takes the name from the file, so the file is linked under the asset name
+    first. Skipped when the release already carries that name: the name IS the
+    content, so a byte-identical rebuild uploads nothing and an existing asset
+    is never clobbered -- which is what keeps older manifests resolving.
+    """
+    if asset_name in already:
+        print(f"  {asset_name}  already published")
+        return
+    staged = workdir / asset_name
+    staged.write_bytes(path.read_bytes())
+    p = run(["gh", "release", "upload", TAG, str(staged), "--repo", slug])
+    if p.returncode != 0:
+        sys.exit(f"upload of {asset_name} failed:\n{p.stdout}{p.stderr}")
+    print(f"  {asset_name}  uploaded ({path.stat().st_size // 1024} KB)")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", help="owner/name; asked of gh when omitted")
+    ap.add_argument(
+        "--server",
+        default="https://github.com",
+        help="GitHub server URL (github.server_url in Actions)",
+    )
+    ap.add_argument(
+        "--dry-run", action="store_true", help="write the manifest, upload nothing"
+    )
+    args = ap.parse_args()
+
+    brotli = brotli_or_die()
+    # Listed ONCE and carried. Globbing a second time to pair with the entries
+    # would let a directory that changed in between silently misalign the zip,
+    # and the result -- an asset uploaded under another file's content hash --
+    # is exactly the failure the hashes exist to prevent.
+    paths = sources()
+    files = [describe(p, brotli) for p in paths]
+    slug = repo_slug(args.repo)
+
+    if not args.dry_run:
+        ensure_release(slug)
+        already = existing_assets(slug)
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            work = pathlib.Path(tmp)
+            for entry, path in zip(files, paths):
+                upload(slug, path, entry["asset"], already, work)
+
+    manifest = {
+        "_comment": (
+            "Written by tools_local/site/publish_emulator.py; read by "
+            "site/fetch-emulator.mjs during Vercel's build. The bytes live on the "
+            "GitHub release below rather than in git. Do not hand-edit."
+        ),
+        # Derived, never typed: the same fetch that would break if this were
+        # wrong is the site's headline feature.
+        "base": f"{args.server.rstrip('/')}/{slug}/releases/download/{TAG}/",
+        "built_from": built_from(brotli),
+        "files": files,
+    }
+    MANIFEST.write_text(json.dumps(manifest, indent=2) + "\n")
+    total = sum(f["bytes"] for f in files)
+    print(
+        f"wrote {MANIFEST.relative_to(REPO)} -- {len(files)} files, {total // 1024} KB"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools_local/site/verify_live_emulator.py
+++ b/tools_local/site/verify_live_emulator.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Does the LIVE site serve the emulator this commit says it should?
+
+The emulator is no longer committed. It is published as a GitHub release asset
+(tools_local/site/publish_emulator.py), pointed at by site/emulator-manifest.json,
+and pulled back in by site/fetch-emulator.mjs during Vercel's build. Three moving
+parts where there used to be one, and every one of them can fail in a way that
+looks like nothing:
+
+  * the manifest lands but the assets were never uploaded;
+  * Vercel skips the build step entirely (a dashboard Output Directory override
+    left on and empty does exactly that), so the fetch never runs and whatever
+    is in git is served instead;
+  * the fetch runs, downloads something, and the page still gets last week's.
+
+Nothing about the site's own HTML changes in any of those cases. The homepage
+renders, the hero sits there, and the demo 404s or runs old firmware. So this
+asks the live origin directly, and it is the only check in the fork that can
+tell the difference.
+
+    python3 tools_local/site/verify_live_emulator.py                 # host from index.html
+    python3 tools_local/site/verify_live_emulator.py https://host    # or say it
+    python3 tools_local/site/verify_live_emulator.py --timeout 720   # wait for a deploy
+
+Exit 0 only when every file in the manifest is served and hashes correctly.
+Anything else is exit 1 with the reason named.
+
+TWO HASHES, AND WHY. The files are stored and served already brotli-compressed
+with `Content-Encoding: br` (see site/README.md -- edge compression on a
+multi-megabyte binary streams at 35 KB/s and it is not optional). So the bytes
+that come back depend on what the client asked for and on whether an
+intermediary decoded them. Comparing against only one of the two hashes would
+report a healthy site broken on a detail of this script's own request headers.
+Both are in the manifest; either one matching is a pass, and neither matching
+is a real failure that no amount of header negotiation explains.
+"""
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+SITE = REPO / "site"
+MANIFEST = SITE / "emulator-manifest.json"
+INDEX = SITE / "index.html"
+UA = "crossplay-live-check"
+
+
+def canonical_host():
+    """The site's own og:url, rather than a hostname typed in here twice.
+
+    site/set-host.py writes it and the page publishes it; a check with its own
+    copy of the address is a check that keeps passing against the wrong site
+    after a move.
+    """
+    try:
+        text = INDEX.read_text(encoding="utf-8", errors="replace")
+    except OSError as err:
+        sys.exit(f"cannot read {INDEX}: {err}")
+    m = re.search(r'property="og:url"\s+content="([^"]+)"', text)
+    if not m:
+        sys.exit(
+            "site/index.html carries no og:url, so this check cannot work out "
+            "which site to ask. Pass the origin as an argument."
+        )
+    return m.group(1).rstrip("/")
+
+
+def get(url, method="GET", timeout=60):
+    req = urllib.request.Request(url, method=method, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=timeout) as res:
+        return res.status, dict(res.headers), (res.read() if method == "GET" else b"")
+
+
+def looks_deployed(url, entry):
+    """A cheap HEAD: is a body of the right SIZE there yet?
+
+    Only ever used to decide whether it is worth downloading megabytes to hash
+    them. It is not the verdict -- a right-sized wrong file passes this and
+    fails the real check below, which is the correct order for a probe that
+    must not become the answer.
+    """
+    try:
+        status, headers, _ = get(url, method="HEAD", timeout=30)
+    except (urllib.error.URLError, OSError):
+        return False
+    if status != 200:
+        return False
+    length = headers.get("Content-Length")
+    if length is None:
+        return True  # no length to judge by; let the hash decide
+    return int(length) in (entry["bytes"], entry["bytes_raw"])
+
+
+def verify(url, entry):
+    """Download it and hash it. Returns None on success, else why not."""
+    try:
+        status, headers, body = get(url)
+    except urllib.error.HTTPError as err:
+        return f"HTTP {err.code}"
+    except (urllib.error.URLError, OSError) as err:
+        return f"unreachable ({err})"
+    if status != 200:
+        return f"HTTP {status}"
+    if not body:
+        return "empty body"
+
+    got = hashlib.sha256(body).hexdigest()
+    if got == entry["sha256"]:
+        return None  # served exactly the bytes that were published
+    if got == entry["sha256_raw"]:
+        return None  # something decoded it on the way; still the right file
+
+    # Encoded on the wire and we were handed it undecoded by a client that did
+    # not ask: decode and compare, so the verdict is about the FILE and not
+    # about content negotiation.
+    if headers.get("Content-Encoding", "").lower() == "br":
+        try:
+            import brotli
+
+            if (
+                hashlib.sha256(brotli.decompress(body)).hexdigest()
+                == entry["sha256_raw"]
+            ):
+                return None
+        except ImportError:
+            pass
+        except Exception:
+            return (
+                f"served with Content-Encoding: br and is NOT brotli "
+                f"({len(body)} bytes). The page will fail to decode it."
+            )
+    return (
+        f"wrong contents ({len(body)} bytes, sha256 {got[:16]}...; "
+        f"expected {entry['sha256'][:16]}... encoded or "
+        f"{entry['sha256_raw'][:16]}... decoded)"
+    )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument(
+        "origin", nargs="?", help="https://host; taken from index.html when omitted"
+    )
+    ap.add_argument(
+        "--manifest",
+        type=pathlib.Path,
+        default=MANIFEST,
+        help="the manifest to hold the site to",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=0,
+        help="seconds to wait for a deploy to appear (default: do not wait)",
+    )
+    ap.add_argument("--interval", type=int, default=20, help="seconds between polls")
+    args = ap.parse_args()
+
+    try:
+        manifest = json.loads(args.manifest.read_text())
+    except (OSError, json.JSONDecodeError) as err:
+        sys.exit(f"cannot read {args.manifest}: {err}")
+    files = manifest.get("files") or []
+    if not files:
+        sys.exit(
+            f"{args.manifest} names no files; there is nothing to verify and "
+            "that is itself the bug."
+        )
+
+    origin = (args.origin or canonical_host()).rstrip("/")
+    print(
+        f"asking {origin} for the emulator built from {manifest.get('built_from', '?')}"
+    )
+    urls = {f["name"]: f"{origin}/emulator/{f['name']}" for f in files}
+
+    # Wait for the deploy, judged on the biggest file only. Polling every file
+    # would download ~4MB a round for no more information.
+    if args.timeout > 0:
+        biggest = max(files, key=lambda f: f["bytes"])
+        deadline = time.time() + args.timeout
+        while not looks_deployed(urls[biggest["name"]], biggest):
+            if time.time() >= deadline:
+                print(
+                    f"\n{biggest['name']} never appeared at the published size "
+                    f"within {args.timeout}s."
+                )
+                break
+            print(f"  waiting for {biggest['name']} ...")
+            time.sleep(args.interval)
+
+    bad = []
+    for f in files:
+        why = verify(urls[f["name"]], f)
+        if why is None:
+            print(f"  ok   {f['name']}")
+        else:
+            print(f"  FAIL {f['name']}: {why}")
+            bad.append(f["name"])
+
+    if bad:
+        print(
+            f"\n{origin} is NOT serving the emulator this commit publishes "
+            f"({', '.join(bad)}).\n"
+            "The demo on the front page is the first thing a stranger is offered, "
+            "so this is a live outage of the headline feature.\n"
+            "Look at, in order:\n"
+            "  1. the newest Vercel deployment's build log -- did "
+            "`node fetch-emulator.mjs` run, and did it succeed?\n"
+            "  2. the `emulator` release on GitHub -- are the assets "
+            "site/emulator-manifest.json names actually there?\n"
+            "  3. Vercel Project Settings -> Build -- an Output Directory "
+            "override left on and empty SKIPS the build step entirely."
+        )
+        return 1
+    print(
+        f"\n{origin} serves the emulator from the manifest. {len(files)} file(s) checked."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools_local/site/verify_live_emulator.py
+++ b/tools_local/site/verify_live_emulator.py
@@ -73,9 +73,16 @@ def canonical_host():
 
 
 def get(url, method="GET", timeout=60):
+    """status, headers, body, and the URL it ENDED at.
+
+    The last one matters: urllib follows redirects silently, and a preview
+    deployment redirects every path to a login page. Without the final URL the
+    only evidence of that is a body that hashes wrong.
+    """
     req = urllib.request.Request(url, method=method, headers={"User-Agent": UA})
     with urllib.request.urlopen(req, timeout=timeout) as res:
-        return res.status, dict(res.headers), (res.read() if method == "GET" else b"")
+        body = res.read() if method == "GET" else b""
+        return res.status, dict(res.headers), body, res.url
 
 
 def looks_deployed(url, entry):
@@ -87,7 +94,7 @@ def looks_deployed(url, entry):
     must not become the answer.
     """
     try:
-        status, headers, _ = get(url, method="HEAD", timeout=30)
+        status, headers, _, _ = get(url, method="HEAD", timeout=30)
     except (urllib.error.URLError, OSError):
         return False
     if status != 200:
@@ -101,7 +108,7 @@ def looks_deployed(url, entry):
 def verify(url, entry):
     """Download it and hash it. Returns None on success, else why not."""
     try:
-        status, headers, body = get(url)
+        status, headers, body, final = get(url)
     except urllib.error.HTTPError as err:
         return f"HTTP {err.code}"
     except (urllib.error.URLError, OSError) as err:
@@ -110,6 +117,20 @@ def verify(url, entry):
         return f"HTTP {status}"
     if not body:
         return "empty body"
+
+    # A protected preview answers every path with a login page, 200 and all.
+    # Reported as a hash mismatch that reads exactly like a broken emulator --
+    # which is what it did the first time this was pointed at one, over four
+    # files, convincingly. Name the real cause instead: this is not a verdict
+    # about the artefact and must not be mistaken for one.
+    ctype = headers.get("Content-Type", "").lower()
+    if ctype.startswith("text/html"):
+        via = f" (ended at {final})" if final and final != url else ""
+        return (
+            f"an HTML page came back instead of the file{via}. This origin is "
+            "behind Vercel's deployment protection, so nothing here can read it; "
+            "point this at production, or check the deployment's build log instead."
+        )
 
     got = hashlib.sha256(body).hexdigest()
     if got == entry["sha256"]:

--- a/tools_local/wasm/build.py
+++ b/tools_local/wasm/build.py
@@ -414,6 +414,17 @@ def main():
             sys.exit("pre-compression failed; do not commit site/emulator as-is")
         print("pre-compressed for the site")
 
+    # And say what to do with it. These files are NOT committed any more: they
+    # go to the `emulator` GitHub release and the repository keeps the ~1KB
+    # pointer beside them. Printing it here is the difference between that being
+    # a rule in site/README.md and a rule anyone hits.
+    print(
+        "\nsite/emulator/ is not committed. To publish it:\n"
+        "  python3 tools_local/site/publish_emulator.py   # uploads, rewrites the manifest\n"
+        "Landing a source change is normally enough -- crossplay-emulator.yml does\n"
+        "this on xteink by itself."
+    )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What this stops

`site/emulator/crossplay.wasm` has **111 distinct blob revisions** in history,
~357MB raw, **56 revisions and 159MB of that in the last seven days**. The
repository is ~497MB on GitHub for a ~104MB checkout and grows about **20MB a
day, forever**, because `crossplay-emulator.yml` did `git add site/emulator` and
pushed after every push to `xteink`. Every clone and every CI checkout in the
fork pays for it.

Part one of two: **stop the growth without breaking the site.** No history is
rewritten here.

## Why it is not a one-line .gitignore

`.gitignore` carried the reason in writing: **Vercel has no Emscripten**, so a
git-connected deploy that cannot see those files ships a site whose headline
feature 404s. The browser demo is the first thing the README offers a stranger,
before install instructions.

## The path chosen, and why the others lost

The bytes go where a clone does not follow, and the repository keeps a pointer:

| file                                        | job                                                                                                            |
| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
| `tools_local/site/publish_emulator.py`      | uploads each file to the **`emulator`** GitHub release under a content-addressed name, and writes the manifest |
| `site/emulator-manifest.json`               | ~1KB, committed once per rebuild                                                                               |
| `site/fetch-emulator.mjs`                   | `vercel.json`'s `buildCommand`; downloads them during the build and verifies every sha256                      |
| `.github/workflows/crossplay-site-live.yml` | asks the live origin whether it actually worked                                                                |

**Deploying from CI with the Vercel CLI** lost on blast radius: it needs a token,
it needs the git integration turned **off** by hand in a dashboard nobody can see
from the repository (leave it on and every push ships a site with no emulator),
and it loses preview deploys on pull requests. **A GitHub Actions artifact** lost
because downloading one needs auth and it expires after 90 days, so a redeploy of
anything older than a quarter fails.

This one needs **no secret at all** — the repository is public, so a release
asset is a plain unauthenticated GET — and changes nothing about how the site is
deployed. `vercel.json` gains three keys (JSON cannot carry comments, so they are
explained in `site/README.md`):

- `"buildCommand": "node fetch-emulator.mjs"` — `node`, not `curl` or `python3`:
  only Node is on Vercel's documented build image.
- `"outputDirectory": "."` — the preset already resolves to this, so it changes
  nothing about what is served. It is here because an Output Directory override
  left **on and empty** in the Vercel dashboard skips the build step entirely,
  and that setting is invisible from the repository.
- `"installCommand": ""` — there is no `package.json`.

## Four things that are load-bearing

- **Asset names are the sha256 of their contents, and existing assets are never
  replaced.** A rolling filename updated in place would break every redeploy of
  an older commit, which is what Vercel's Redeploy button and its rollbacks both
  are.
- **A fetch that fails, or arrives with the wrong bytes, fails the Vercel
  build.** A failed build promotes nothing, so the previous deployment keeps
  serving. A broken publish costs a **stale** site, never a broken one.
- **`crossplay-ci.yml`'s `paths-ignore` had to grow the manifest path.** It
  carried `site/emulator/**` so the rebuild's own push does not start a second
  `CrossPlay` run — one that **cancels the merge's own run** and takes the
  autorelease with it, which cost two full builds per merge on 2026-09-04.
  Moving what the rebuild commits _out_ of `site/emulator/` walks straight back
  into that, and nothing would have said why. `host-tests/bugflow` now asserts
  that everything the rebuild stages is covered by that filter.
- **The `emulator` release is a prerelease and must stay one.** GitHub defines
  `/releases/latest` as the newest non-prerelease, and three things ask exactly
  that: `src/network/OtaUpdater.cpp` (every device in the field), the site's
  Install button, and the board's release watcher. Published as an ordinary
  release it becomes "latest" for all three while containing no firmware at all.
  Checked over every `api.github.com` call in the tree, not assumed.

## The committed emulator files are STILL IN THE TREE

**Deliberately, and unchanged.** The diff touches no binary.

There is one failure this cannot catch from inside the repository — a
`buildCommand` that never runs at all — and while `site/emulator/` is tracked
that failure serves a **stale** demo instead of **no** demo. The
`outputDirectory` key exists to take that decision away from the invisible
dashboard setting.

**Removing them from the index is the next change**, and it is where the history
rewrite belongs. The live check below is what says it is safe to make: it
compares the origin against the manifest, so a fallback being served _instead of_
the published bytes shows up as a failure with the reason named, rather than as
silence.

What this means for the first rebuild after merge: the committed copies match
this manifest exactly today, so the fetch finds them already correct and
downloads nothing. The **next** emulator rebuild publishes new assets and a new
manifest, and that is the deploy that exercises the whole path for real.

## It has now run on Vercel

This PR's own preview deployment is the proof, and its build log says so:

```
Running "git diff --quiet HEAD^ HEAD ./"
Running "vercel build"
Skipping "install" command...
emulator: 4 file(s), built from 0c40258024d276b3fe99ed26083ae82158dca14a
BUILT_FROM  already correct
crossplay.data  already correct
crossplay.js  already correct
crossplay.wasm  already correct
emulator ready: 0 downloaded, 4 already present
Build Completed in /vercel/output [505ms]
Deployment completed
```

Five things that were assumptions before that log existed:

- `vercel.json`'s `buildCommand` **runs**, whatever the dashboard holds. That was
  the single largest risk in this change.
- `"installCommand": ""` is honoured — "Skipping install command".
- `"outputDirectory": "."` produces a deployment that completes.
- The manifest parses and all four hashes verify.
- **`api/` still deploys.** `vercel inspect` lists `api/board-config`,
  `api/firmware`, `api/inbox` and `api/report` as functions on the preview — the
  identical set the current production deployment builds. The Install button and
  the inbox are untouched.

**The Vercel check on this PR is currently red, and it is not this change.** The
second push to the branch hit the account's deployment rate limit ("retry in 24
hours") — the same limit `site/README.md` documents from 2026-09-04, and the
reason `ignoreCommand` exists. The deployment that matters is the first one,
above, which is Ready. (Checked rather than assumed: `xteink`'s branch
protection carries no `required_status_checks` at all — only "no force pushes"
and "no deletion" — so nothing here blocks a merge mechanically. Whether a red
Vercel check should is a judgement, and this one is a rate limit.)

Not proven by that log: the download itself, because the `emulator` release does
not exist yet and the committed copies satisfied the hashes — which is the
fallback behaving as designed. The download mechanism was proven separately from
node against a real release asset on this repository (302 to
`release-assets.githubusercontent.com`, bytes returned; a missing asset 404s,
which this script treats as a failure).

## Verification, because this project keeps being bitten by automation that fails green

- `tools_local/site/verify_live_emulator.py` **was run against production.** It
  passes on the live site today (4 files, hashes match, exit 0) and fails, exit
  1, naming the file, when a hash is altered.
- `.github/workflows/crossplay-site-live.yml` runs it after every emulator
  rebuild and **once a day regardless**, because the ways this breaks later (an
  asset deleted, a build setting changed by hand) are not tied to a push. It
  reads the hashes out of the manifest and the address out of `index.html`'s own
  `og:url`, so it cannot drift from what was published.
- `host-tests/site/fetch_emulator.js` runs `fetch-emulator.mjs` for real against
  a local HTTP server over six cases, five of them failures: corrupted bytes, a
  404, a path escape, an empty manifest, and a file already correct on disk.
  Confirmed red (3 failures) with the hash guard removed.
- `host-tests/site/run.sh` asserts `vercel.json` still has a `buildCommand`
  naming a script that exists and an `outputDirectory`; that the manifest carries
  every field `fetch-emulator.mjs` reads, with the field names **extracted from
  the script** rather than listed; and that `.vercelignore` excludes neither half
  of the fetch — both look exactly like the laptop-only tooling that file exists
  to strip, and ignoring either breaks every deploy.
- `host-tests/bugflow` asserts a manifest-only rebuild reads fresh, that
  `crossplay-emulator.yml` still commits under the subject
  `crossplay-autorelease.yml` matches, and that everything the rebuild stages is
  covered by `crossplay-ci.yml`'s `paths-ignore`.

Every new check above was confirmed red under mutation before it was kept.

## The three commits after the first

All three are fixes to this change's own guards, found by using them.

- **`fix(site): name the auth wall, not the emulator, when a preview refuses`.**
  Pointed at this PR's preview, the live check reported all four files as "wrong
  contents", with hashes, convincingly — and the files were fine: Vercel's
  deployment protection answers every path with a 200 and a login page, and
  urllib had followed the redirect silently. A probe whose wrong answer is
  indistinguishable from the symptom it exists to detect is worse than no probe.
  It now names the cause and says where to look instead.
- **`test(bugflow): read the autorelease subject match from live lines only`.**
  #87 replaces that subject grep and leaves the old line in the file as a
  comment. Read as written, the new check would have gone on passing while
  guarding a commented line. Comment lines are dropped first, and a file with no
  live subject grep is an explicit pass with the reason said out loud. Verified
  in both worlds, so the merge order of #86 and #87 does not matter.
- **`ci(site-live): make the one excuse fail closed`.** The live check has
  exactly one way out of a failure that is not a failure — a newer emulator
  landed mid-poll — and it was written `if ! git diff --quiet`. `git diff
  --quiet` answers 128 for an error, and `!` reads that as "differs", so a failed
  fetch or a bad ref would have excused a real failure and reported a dead front
  page as green. The fetch must now succeed and the diff must answer exactly 1.
  Confirmed against a real repository at 0, 1 and 128.

## The gate

`./scripts_local/check.sh --committed`, verifying HEAD `fe672f29`, both device
envs built:

```
all green. logs in /var/folders/5p/mb_8f4454r14f7wfq5y_2ct40000gn/T//xteink-check-d2a193e2
```

84 host-suite results, zero `FAILED` lines, `encoding ok`, and
`gh_release_x4pro`+`gh_release_sticky` in 222s (flash 77.6% / 76.3%). Not a
withheld verdict and not a device-builds-skipped one: the tree was at the
`xteink` tip when it ran.

## What Mario has to do by hand

**No secret. No token. Nothing before merge.** The `emulator` release is created
by `publish_emulator.py` on its first run, using the workflow's own token.

One thing to _look at_ after the first emulator rebuild lands: that deployment's
Vercel build log should show `node fetch-emulator.mjs` downloading rather than
skipping. `crossplay-site-live.yml` goes red if the result never reaches
production.

## Not verified

The publish half has not run on a GitHub runner: `gh release create` for the
`emulator` prerelease and the asset upload first happen on merge. The live check
covers the outcome, and a failure leaves the previous deployment serving.
