### PR TITLE
autorelease: the tip check asks what MOVED, not what the commit called itself

### DIFF
--- a/.github/workflows/crossplay-autorelease.yml
+++ b/.github/workflows/crossplay-autorelease.yml
@@ -12,8 +12,11 @@
 #
 # One at a time: the concurrency group queues a second green run behind a
 # release in progress instead of cancelling either, so merges that land while
-# one release builds collapse into the next. A tip that moved since CI ran is
-# left alone; the CI run for the new tip will bring its own release.
+# one release builds collapse into the next. A tip that moved since CI ran by
+# anything a build or a release can see is left alone; the CI run for the new
+# tip will bring its own release. A tip that moved only by commits neither can
+# see -- CI's own emulator rebuild, which CI is configured never to run for --
+# releases from the tip, because otherwise nothing ever would.
 #
 # The brake is the repository variable RELEASE_HOLD=1. While it is set this
 # job says so and does nothing.
@@ -68,16 +71,62 @@ jobs:
           fi
           tip="$(git rev-parse HEAD)"
           if [ "$tip" != "$VERIFIED" ]; then
-            # CI's own emulator rebuild commits to xteink right after a merge and
-            # is pushed with the workflow token, so no CI run ever comes for it.
-            # A tip that moved only by such commits is the verified commit plus
-            # site/ bytes no device sees: release from it. Anything else moved
-            # the tip for real and its own run brings its own release.
-            if git log --format=%s "$VERIFIED..$tip" | grep -vq '^chore: emulator rebuilt'; then
-              echo "xteink moved past the commit CI verified ($VERIFIED -> $tip); the run for the new tip releases it."
+            # THE TIP MOVED, and whether that matters is a question about what
+            # the gap CONTAINS. It was asked about commit SUBJECTS until
+            # 2026-09-05:
+            #
+            #   git log --format=%s "$VERIFIED..$tip" | grep -vq '^chore: emulator rebuilt'
+            #
+            # That string is a copy of the message crossplay-emulator.yml
+            # happens to write. crossplay-ci.yml carries
+            # `paths-ignore: site/emulator/**`, so no CI run ever comes for an
+            # emulator commit and no run ever will -- which made that one grep
+            # the only thing that ever let a release out from a tip whose last
+            # commit is one. Rename the message, or add a second path to
+            # paths-ignore, and every release stops: no error, no red job,
+            # nothing to notice by but the absence of tags. It was wrong in the
+            # other direction too, because it believed a subject about its own
+            # content: a commit SAYING "chore: emulator rebuilt" while carrying
+            # src/ would have been released with nothing having verified it.
+            #
+            # So ask scripts_local/device-build-needed.sh, which is where this
+            # repository writes down what a path can reach, and ask it about
+            # BOTH of its columns -- the gap can be inert on either one alone
+            # and still not be inert:
+            #
+            #   builds  can anything in the gap change what a device build
+            #           produces, or whether it can run? If it can, CI's verdict
+            #           on $VERIFIED is not a verdict on $tip. This is the
+            #           column that catches scripts_local/ and .gitignore, which
+            #           ship nothing and decide whether a build succeeds.
+            #   ships   can anything in the gap change what a release DELIVERS?
+            #           This is the column that catches
+            #           .github/workflows/crossplay-release.yml, which builds and
+            #           uploads the assets a person downloads: `quiet` there,
+            #           never `yes`, so the builds column alone cannot see it.
+            #
+            # Both must answer no, which is exit 1. Every other exit refuses: 0
+            # is yes, 2 is a path in no row of the table, 3 is `quiet`, and the
+            # tool's fail-safes already answer 0 or 2 for a range it cannot
+            # resolve.
+            #
+            # $VERIFIED must be an ANCESTOR of the tip first. --range diffs from
+            # the merge base, so a $VERIFIED that is not in the tip's history
+            # would be compared against some older common ancestor and could
+            # answer "nothing changed" about a history CI never saw.
+            if ! git merge-base --is-ancestor "$VERIFIED" "$tip"; then
+              echo "$VERIFIED is not in the history of $tip: CI verified something this tip does not contain. Not releasing."
               echo "go=false" >> "$GITHUB_OUTPUT"; exit 0
             fi
-            echo "xteink moved past $VERIFIED only by emulator rebuilds; releasing from $tip."
+            set +e
+            bash scripts_local/device-build-needed.sh --range "$VERIFIED..$tip"; gap_builds=$?
+            bash scripts_local/device-build-needed.sh --range "$VERIFIED..$tip" --ships; gap_ships=$?
+            set -e
+            if [ "$gap_builds" -ne 1 ] || [ "$gap_ships" -ne 1 ]; then
+              echo "xteink moved past the commit CI verified ($VERIFIED -> $tip) by something a device build or a release can see (builds=$gap_builds, ships=$gap_ships); the run for the new tip releases it."
+              echo "go=false" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+            echo "xteink moved past $VERIFIED only by commits no device build and no release can see; releasing from $tip."
           fi
           # A merge nobody can receive anything different from (docs, site,
           # tooling, the workspace's own machinery) is not a release: no bump,

--- a/host-tests/ci/run.sh
+++ b/host-tests/ci/run.sh
@@ -173,6 +173,161 @@ publish "a tag pushed with RELEASE_TOKEN is not dispatched again"      true  0
 publish "a tag pushed with the workflow token is dispatched once"      false 1
 publish "no flag at all (no secret, older text) still dispatches once" ""    1
 
+# -- the tip check must ask what MOVED, not what the commit called itself -----
+#
+# The gate refuses to release when xteink has moved past the commit CI
+# verified, and it has to: releasing a tip nothing verified is exactly the
+# thing it exists to stop. But this workflow carries
+# `paths-ignore: site/emulator/**` (above), so the emulator rebuild that
+# crossplay-emulator.yml commits after every merge gets NO CI run and never
+# will. If the gate refuses on that commit, the tip is stuck behind a run that
+# cannot exist, and the only thing that ever releases anything again is an
+# unrelated push -- which is why the stall heals itself often enough to read as
+# weather rather than as a deadlock.
+#
+# It was excused by `git log --format=%s | grep -vq '^chore: emulator rebuilt'`:
+# a copy of a string that lives in another workflow file, deciding a question
+# about content by reading a subject line. Both halves are asserted here, and
+# each one is a different way for that to be wrong:
+#
+#   a gap that reaches nothing releases WHATEVER its commits are titled, so
+#   renaming the emulator commit cannot silently stop every release;
+#   a gap that reaches something refuses WHATEVER it titles itself, so a commit
+#   claiming to be an emulator rebuild cannot carry src/ past the gate.
+#
+# EXECUTED, against real repositories and the real classification table, for
+# the reason at the top of this file.
+#
+# THE EXTRACTOR BELOW IS A COPY, and it should not survive contact with the
+# branch that collapses the other three into a `lift_step` helper (board #235,
+# wt/cigaps). The two changes do not overlap textually, so git will merge them
+# without a word and leave this here as a fourth copy. Whoever lands second:
+# delete the heredoc and write
+#   lift_step "$AYML" 'Decide whether to release' >"$WORK/gate.sh"
+python3 - "$AYML" 'Decide whether to release' >"$WORK/gate.sh" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+i = next(i for i, l in enumerate(lines) if l.strip() == '- name: ' + sys.argv[2])
+j = next(j for j in range(i, len(lines)) if lines[j].strip() == 'run: |')
+body, indent = [], None
+for l in lines[j + 1:]:
+    if not l.strip():
+        body.append('')
+        continue
+    cur = len(l) - len(l.lstrip())
+    if indent is None:
+        indent = cur
+    if cur < indent:
+        break
+    body.append(l[indent:])
+print('\n'.join(body))
+PY
+[ -s "$WORK/gate.sh" ] || { echo "FAIL could not extract the gate step from crossplay-autorelease.yml"; exit 1; }
+
+# One fixture repository, rebuilt per case. The classification table is the
+# REAL one -- the whole point is that the gate reads it rather than restating
+# it -- and release-needed.sh is a stub that always says yes, so what this
+# measures is the tip check alone. Whether a range warrants a release at all is
+# host-tests/autorelease's subject and is answered by the same table.
+gate_repo() {  # <path>  -> a repo whose HEAD is the base, with the table in it
+  rm -rf "$1"; mkdir -p "$1/scripts_local"
+  cp "$HERE/../../scripts_local/device-build-needed.sh" "$1/scripts_local/"
+  printf '#!/bin/sh\necho "reaches a user: yes (stubbed)"\nexit 0\n' >"$1/scripts_local/release-needed.sh"
+  mkdir -p "$1/src"; echo 'int base;' >"$1/src/base.cpp"
+  ( cd "$1" && git init -q -b xteink && git config user.email t@t && git config user.name t \
+    && git add -A && git commit -qm "base" ) >/dev/null 2>&1
+}
+gate_commit() {  # <repo> <path> <subject>
+  mkdir -p "$(dirname "$1/$2")"; echo "$(date +%s%N)" >>"$1/$2"
+  ( cd "$1" && git add -A && git commit -qm "$3" ) >/dev/null 2>&1
+}
+gate_expect() {  # <label> <repo> <VERIFIED> <true|false wanted go> <substring wanted in the log>
+  local label="$1" repo="$2" verified="$3" want="$4" msg="$5" got
+  : >"$WORK/gh_output"
+  ( cd "$repo" && GITHUB_OUTPUT="$WORK/gh_output" VERIFIED="$verified" HOLD="" \
+      bash -eo pipefail "$WORK/gate.sh" ) >"$WORK/out" 2>&1
+  got="$(grep -o 'go=[a-z]*' "$WORK/gh_output" | tail -1 | cut -d= -f2)"
+  checks=$((checks + 1))
+  if [ "$got" != "$want" ]; then
+    failed=$((failed + 1))
+    echo "FAIL ci-autorelease  $label: gate said go=${got:-<nothing>}, wanted go=$want"
+    sed 's/^/       /' "$WORK/out"
+    return
+  fi
+  checks=$((checks + 1))
+  if ! grep -q "$msg" "$WORK/out"; then
+    failed=$((failed + 1))
+    echo "FAIL ci-autorelease  $label: right answer, wrong reason -- the log never says '$msg'"
+    sed 's/^/       /' "$WORK/out"
+  fi
+}
+
+G="$WORK/gate-repo"
+
+# (1) The tip has not moved. Nothing to excuse; the gate never reaches the
+#     comparison at all.
+gate_repo "$G"
+gate_expect "an unmoved tip releases" "$G" "$(git -C "$G" rev-parse HEAD)" true "reaches a user"
+
+# (2) The tip moved by an emulator rebuild and nothing else. This is the case
+#     no CI run can ever arrive for.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" site/emulator/crossplay.wasm "chore: emulator rebuilt for $V"
+gate_expect "a tip that moved only by an emulator rebuild releases" "$G" "$V" true \
+  "only by commits no device build and no release can see"
+
+# (3) The tip moved by real firmware. The protection, unchanged: nothing
+#     verified src/ at this tip, so nothing releases it.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" src/apps_local/Sudoku.cpp "fix(sudoku): the givens survive a rotate"
+gate_expect "a tip that moved by firmware refuses" "$G" "$V" false \
+  "moved past the commit CI verified"
+
+# (4) The same firmware change, TITLED as an emulator rebuild. The subject grep
+#     released this; the table cannot be talked to.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" src/apps_local/Sudoku.cpp "chore: emulator rebuilt for $V"
+gate_expect "a firmware commit calling itself an emulator rebuild still refuses" "$G" "$V" false \
+  "moved past the commit CI verified"
+
+# (5) The same emulator rebuild under any other name. The subject grep refused
+#     this forever, silently, from the first time somebody reworded the commit
+#     crossplay-emulator.yml writes.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" site/emulator/crossplay.wasm "build(site): wasm refreshed"
+gate_expect "an emulator rebuild under another name still releases" "$G" "$V" true \
+  "only by commits no device build and no release can see"
+
+# (6) The gap builds but does not ship, and the gap ships but does not build.
+#     One column would answer no to each of these; the gate asks both.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" scripts_local/check.sh "gate: trim the cache harder"
+gate_expect "a gap that breaks a build but ships nothing refuses" "$G" "$V" false \
+  "moved past the commit CI verified"
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" .github/workflows/crossplay-release.yml "ci: publish the merged image"
+gate_expect "a gap that changes what the release publishes refuses" "$G" "$V" false \
+  "moved past the commit CI verified"
+
+# (7) A path in no row of the table. The tool refuses to classify it and the
+#     gate must inherit that refusal rather than reading it as "inert".
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" brandnew/thing.c "feat: a directory nobody has classified"
+gate_expect "an unclassified path in the gap refuses" "$G" "$V" false \
+  "moved past the commit CI verified"
+
+# (8) A verified commit that is not in the tip's history at all. --range diffs
+#     from the merge base, so without the ancestry check this could answer
+#     "nothing changed" about a history CI never saw.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+( cd "$G" && git checkout -q -b sideline && mkdir -p src && echo 'int side;' >src/side.cpp \
+  && git add -A && git commit -qm "feat: on a branch of its own" ) >/dev/null 2>&1
+SIDE="$(git -C "$G" rev-parse HEAD)"
+( cd "$G" && git checkout -q xteink ) >/dev/null 2>&1
+gate_commit "$G" site/emulator/crossplay.wasm "chore: emulator rebuilt for $V"
+gate_expect "a verified commit outside the tip's history refuses" "$G" "$SIDE" false \
+  "is not in the history of"
+
 # The two stack-checked device envs build in ONE pio run invocation.
 #
 # pio run wipes the whole .pio/build root on every invocation


### PR DESCRIPTION
## What

`crossplay-autorelease.yml`'s gate refuses to release when `xteink` has moved
past the commit CI verified. It must: releasing a tip nothing verified is the
thing it exists to stop.

It excused the one gap it has to excuse -- CI's own emulator rebuild, which
`crossplay-ci.yml`'s `paths-ignore: site/emulator/**` guarantees no CI run will
ever arrive for -- by grepping commit **subjects** for the literal
`^chore: emulator rebuilt`.

That string is a copy of a message written in `crossplay-emulator.yml`, two
files away, and it settles a question about content by reading a title. Wrong
in both directions:

- **Reword that commit, or add a second path to `paths-ignore`, and every
  release stops.** No error, no red job, nothing to notice by but the absence of
  tags -- and it unsticks itself on the next unrelated push, so it reads as
  weather rather than as a deadlock. Two trees are editing
  `crossplay-emulator.yml` this week (`wt/cigaps`, `wt/wasmdeploy`), and card
  #238 proposes stopping the emulator commit entirely.
- **A commit _saying_ `chore: emulator rebuilt` while carrying `src/` was
  released** with nothing having verified it.

So it asks `scripts_local/device-build-needed.sh --range` instead, which is
where this repository already writes down what a path can reach, and it asks
**both** columns, because a gap can be inert on either one alone and still not
be inert:

| column   | question                                                                                                                                | what only this column catches                                                                            |
| -------- | --------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
| `builds` | can the gap change what a device build produces, or whether it runs? If it can, CI's verdict on `VERIFIED` is not a verdict on the tip. | `scripts_local/`, `.gitignore` -- ship nothing, decide whether a build succeeds                          |
| `ships`  | can the gap change what a release **delivers**?                                                                                         | `.github/workflows/crossplay-release.yml` -- `quiet` there, never `yes`, so `builds` alone cannot see it |

Both must answer no (exit 1). Every other exit refuses: 0 is yes, 2 is a path in
no row of the table, 3 is `quiet`, and the tool's own fail-safes already answer
0 or 2 for a range it cannot resolve. `VERIFIED` must be an **ancestor** of the
tip first -- `--range` diffs from the merge base, so a `VERIFIED` outside the
tip's history would be compared against some older common ancestor and could
answer "nothing changed" about a history CI never saw.

## Proof

Eight cases in `host-tests/ci`, lifted from the yaml and executed against real
repositories and the real classification table, in the pattern already used
there for the publish step. `33 checks, 0 failed`.

Seen red under two mutations, each confirmed to have changed the file first:

- **restoring the subject grep** -> `30 checks, 3 failed`: a firmware commit
  titled as an emulator rebuild releases; an emulator rebuild under any other
  name refuses; a verified commit outside the tip's history releases.
- **disabling the refusal** -> `28 checks, 5 failed`, including both protection
  cases.

And against the real repository, the two decisions this morning actually faced:

```
VERIFIED=0c40258024d276b3fe99ed26083ae82158dca14a, tip=f140e297
  device builds: not needed (3 changed path(s) ..., none of which reach a device image)
  reaches a user: no (nothing in ... changes the firmware or what a release publishes)
  xteink moved past 0c40258024... only by commits no device build and no release can see; releasing from f140e297...
  -> go=true          (production released v1.12.24 from this state)

VERIFIED=f91e90e4a81bf5d7f0e461dfb86c9cd28b5d2913, tip=f140e297
  device builds: needed (lib/I18n/translations/english.yaml can reach a device image)
  reaches a user: yes (lib/I18n/translations/english.yaml)
  xteink moved past the commit CI verified (...) by something a device build or a release can see (builds=0, ships=0)
  -> go=false         (production refused this one, run 33950800004)
```

`./scripts_local/check.sh --committed` on 993a9b7d, verbatim last line:

```
HOST GREEN, DEVICE BUILDS SKIPPED (gh_release_x4pro gh_release_sticky) -- nothing in this diff reaches a device image, so none was built. logs in /var/folders/5p/mb_8f4454r14f7wfq5y_2ct40000gn/T//xteink-check-56179207
```

The run before this one said `VERDICT WITHHELD (behind origin)` and exited 0; the
branch was rebased onto `45b089f8` and the gate re-run rather than read as a pass.

## Not verified

This is a GitHub Actions step and only ever runs on a runner. The shapes are
executed here against fixtures and against the real history; the live pipeline
is verified only by the next release it cuts.

## Found on the way, not fixed here

- **#258** `crossplay-ci.yml`'s `cancel-in-progress: false` still loses a
  queued run: GitHub keeps at most ONE pending run per group. Run 33949978314
  (`8cf1adcb`) never started a job and was cancelled at 06:39:22, two seconds
  after `0c402580` was pushed. A cancelled run is not a success, so the
  autorelease never fires for that commit. `crossplay-ci.yml` is owned by
  `wt/cigaps` (#235), so it is reported rather than changed.
- **#259** the release watcher cannot see this class of stall at all: an
  autorelease that runs, exits 0 and releases nothing looks identical to a
  healthy one. Every rule in `docs/workflow/events.md` is about a release that
  _started_.
- `scripts_local/release_notes.py:138` carries the same
  `"chore: emulator rebuilt"` literal. Its failure mode is a stray bullet on the
  release page rather than a stopped pipeline, so it is left alone here.

## Merge note

`host-tests/ci/run.sh`'s step extractor is a fourth copy of the same python
heredoc. `wt/cigaps` (board #235) collapses the other three into a `lift_step`
helper, and the two changes do not overlap textually -- git will merge them
silently and leave the copy behind. Whichever lands second should delete the
heredoc and write `lift_step "$AYML" 'Decide whether to release' >"$WORK/gate.sh"`.
A comment in the file says the same thing.
