### PR TITLE
site: the study wizard's Next button, a top bar that fits a phone, and three tests that could not fail

### DIFF
--- a/host-tests/site/css_selectors.py
+++ b/host-tests/site/css_selectors.py
@@ -1,0 +1,51 @@
+"""Print every selector in a stylesheet, one per line, with comments and
+:not() contents removed.
+
+WHY THIS FILE EXISTS. run.sh checks that each class assets/topnav.js writes has
+a rule in styles.css to land on. It used to do that by grepping the whole
+stylesheet for the class name, and a COMMENT answered yes: styles.css contains
+the sentence " * .has-menu is added by assets/topnav.js". A reviewer renamed
+.has-menu to .hazmenu in all four of its real rules, left the comment and the
+:not(.has-menu) fallback alone, and the suite reported 176 checks and 0
+failures -- with the bug fully restored: the toggle stays display:none at 320px
+and the panel cannot be opened at all. A check a comment can satisfy is not a
+check.
+
+:not() contents are stripped for the same reason in miniature. A class named
+only inside :not() is a class being EXCLUDED, not styled: the mutation above
+left `.topbar:not(.has-menu) .topnav a[href="#shelf"]` in place, so scoping the
+search to selectors alone would still have passed on it.
+
+    python3 host-tests/site/css_selectors.py <file.css>
+"""
+
+import pathlib
+import re
+import sys
+
+if len(sys.argv) < 2:
+    sys.exit("usage: css_selectors.py <file.css>")
+
+css = pathlib.Path(sys.argv[1]).read_text()
+css = re.sub(r"/\*.*?\*/", "", css, flags=re.S)
+
+# Walk the text and take what sits before each "{". At-rules (@media, and the
+# prelude of @supports) are preludes rather than selectors, so they are dropped;
+# their inner blocks are reached the same way on the next pass.
+out = []
+buf = []
+for ch in css:
+    if ch == "{":
+        sel = " ".join("".join(buf).split())
+        buf = []
+        if sel and not sel.startswith("@"):
+            out.append(sel)
+    elif ch in "};":
+        buf = []
+    else:
+        buf.append(ch)
+
+for sel in out:
+    # Drop what :not(...) excludes, one nesting level, which is all this
+    # stylesheet uses.
+    print(re.sub(r":not\([^)]*\)", "", sel))

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -410,5 +410,149 @@ else
   bad "site/inbox/fixture.json is missing, so the inbox cannot be looked at without a passphrase"
 fi
 
+# -- the top bar's narrow-screen menu -----------------------------------------
+#
+# Below 720px five labels do not share a line. The stylesheet used to answer
+# that by hiding THE SHELF and PLAY NEARBY -- the two links that lead to what
+# the site is for -- and keeping ANKI DECKS, which then wrapped to two 49px
+# lines inside a 50px bar at 320, 390 and 414; /study/ did the same with
+# INSTALL THE FIRMWARE. The links live in a panel now, opened by a button that
+# assets/topnav.js wires and styles.css positions.
+#
+# Same failure shape as the orientation attribute at the top of this file: the
+# script writes classes the stylesheet has to know, and neither file imports
+# the other. A rename on either side is a bar with a button that opens nothing
+# on the width where the button is the only navigation there is.
+TOPNAV="$ROOT/site/assets/topnav.js"
+SP_HTML="$ROOT/site/study/index.html"
+[ -f "$TOPNAV" ] || { echo "FAIL site  missing $TOPNAV"; exit 1; }
+
+# Every class the script writes must mean something to the stylesheet.
+nav_classes="$(grep -oE 'classList\.(add|toggle)\("[a-z-]+"' "$TOPNAV" | grep -oE '"[a-z-]+"' | tr -d '"' | sort -u)"
+if [ -z "$nav_classes" ]; then
+  bad "topnav.js writes no classes at all, so the bar can never open"
+else
+  ok
+  for c in $nav_classes; do
+    grep -q "\.$c" "$CSS" && ok || bad "topnav.js writes .$c and styles.css has no rule for it"
+  done
+fi
+# ...and the control it looks for must be one the stylesheet can show and both
+# pages actually carry.
+for sel in topnav-toggle topnav; do
+  grep -q "\.$sel" "$TOPNAV" && ok || bad "topnav.js never looks for .$sel"
+  grep -q "\.$sel" "$CSS" && ok || bad "styles.css has no .$sel rule"
+done
+for p in "$HTML" "$SP_HTML"; do
+  rel="${p#"$ROOT"/}"
+  grep -q 'class="topnav-toggle"' "$p" && ok || bad "$rel has no .topnav-toggle button, so its narrow bar has no navigation"
+  grep -qE 'src="/?assets/topnav\.js"' "$p" && ok || bad "$rel does not load assets/topnav.js, so its menu button opens nothing"
+  # aria-controls has to name something on the page, or the button announces a
+  # relationship to an element that is not there.
+  ctl="$(grep -oE 'aria-controls="[A-Za-z0-9_-]+"' "$p" | head -1 | sed -E 's/.*="//; s/"//')"
+  if [ -z "$ctl" ]; then
+    bad "$rel's menu button has no aria-controls"
+  else
+    ok
+    grep -q "id=\"$ctl\"" "$p" && ok || bad "$rel's menu button controls #$ctl and no such element exists"
+  fi
+done
+# A bar is one line high. Without this the label wraps inside it and the fix is
+# only half applied: the panel is right and the wide bar is still two lines at
+# any width where a label is long enough.
+awk '/^\.topnav a \{/,/^}/' "$CSS" | grep -q 'white-space: *nowrap' \
+  && ok || bad ".topnav a does not set white-space: nowrap, so a long label wraps inside the bar again"
+# The old rule hid the two product links outright. It may only survive as the
+# no-script fallback, which is what :not(.has-menu) scopes it to.
+if grep -q 'a\[href="#shelf"\]' "$CSS"; then
+  grep -q 'topbar:not(\.has-menu) .topnav a\[href="#shelf"\]' "$CSS" \
+    && ok || bad "styles.css hides the #shelf link without scoping it to :not(.has-menu), so it is gone from the menu too"
+else
+  ok
+fi
+
+# -- the study page's own account of where Pyodide comes from ------------------
+#
+# study/worker.js loads the runtime from the first base that answers, and the
+# page's footer tells the reader where that is. The footer said "served from
+# this site" while the worker had asked jsDelivr first since 2026-08-25 --
+# nothing renders wrong, the page is simply not true. Read the host out of the
+# worker so the claim cannot drift from the code again.
+WORKER="$ROOT/site/study/worker.js"
+[ -f "$WORKER" ] || { echo "FAIL site  missing $WORKER"; exit 1; }
+first_base="$(awk '/PYODIDE_BASES = \[/,/\]/' "$WORKER" | grep -oE '"[^"]+"' | head -1 | tr -d '"')"
+if [ -z "$first_base" ]; then
+  bad "study/worker.js lists no Pyodide base at all"
+else
+  ok
+  case "$first_base" in
+    http*)
+      # Remote first: the page must name that host and must not claim otherwise.
+      host="$(printf '%s' "$first_base" | sed -E 's|https?://||; s|/.*||')"
+      label="$(printf '%s' "$host" | awk -F. '{print $(NF-1)}')"
+      grep -qi "$label" "$SP_HTML" \
+        && ok || bad "worker.js loads Pyodide from $host first and study/index.html never says so"
+      grep -qi "served from this site" "$SP_HTML" \
+        && bad "study/index.html still says Pyodide is served from this site, and worker.js asks $host first" || ok
+      ;;
+    *)
+      # Same-origin first: then "served from this site" is the true claim.
+      grep -qi "served from this site" "$SP_HTML" \
+        && ok || bad "worker.js loads Pyodide from this site first and study/index.html does not say so"
+      ;;
+  esac
+fi
+
+# -- the report form's version placeholder ------------------------------------
+#
+# It read 1.12.9 while the site was shipping 1.12.23: a number typed into the
+# file, right the day it was written and eleven releases stale by the time
+# anyone looked. It is asked for now, from the same release the Install button
+# reads. Nothing here can check the answer -- that needs the network -- but it
+# can check that no literal has been typed back in, and that the field is
+# still filled from somewhere.
+ver_ph="$(grep -oE 'id="report-version"[^>]*placeholder="[^"]*"' "$REPORTJS" | grep -oE 'placeholder="[^"]*"' | sed -E 's/placeholder="//; s/"//')"
+if printf '%s' "$ver_ph" | grep -qE '[0-9]+\.[0-9]+'; then
+  bad "report.js hardcodes a firmware version ($ver_ph) as the placeholder again; it is asked for, not typed"
+else
+  ok
+fi
+grep -q 'releases/latest' "$REPORTJS" \
+  && ok || bad "report.js no longer asks for the latest release, so the version field has no placeholder at all"
+grep -q 'REPO' "$REPORTJS" \
+  && ok || bad "report.js has no repository to ask"
+
+# -- the study wizard's steps stay in normal flow ------------------------------
+#
+# .wiz-step was position:absolute inside a min-height:0 row, so a step taller
+# than the window was cropped by it rather than growing the page. At 1440x900
+# the step-2 "Next" button hung 29 of its 45 pixels below the cut and
+# document.elementFromPoint at the button's own centre returned the footer; at
+# 1280x720 none of it was on screen and scrollHeight equalled innerHeight, so
+# the page reported nothing more to see.
+#
+# THIS CHECK CANNOT SEE THAT. Whether a control is reachable is a browser
+# question and it was answered in one: elementFromPoint at the centre, then a
+# real click, at 1440x900 and 1280x720, before and after. What it can see is
+# the mechanism -- that the step is in flow and the page is allowed to grow --
+# and that is the thing whose quiet return would bring the rest back with it.
+SCSS="$ROOT/site/study/study.css"
+[ -f "$SCSS" ] || { echo "FAIL site  missing $SCSS"; exit 1; }
+awk '/^\.wiz-step \{/,/^}/' "$SCSS" | grep -qE 'position: *absolute' \
+  && bad ".wiz-step is position:absolute again; a step taller than the window is cropped by the row instead of growing the page" || ok
+awk '/^\.study-body \{/,/^}/' "$SCSS" | grep -qE 'overflow: *hidden' \
+  && bad ".study-body clips again, so a step that does not fit reports no scrollable height and the page looks finished" || ok
+awk '/^\.study-body \{/,/^}/' "$SCSS" | grep -qE '^ *height: *100vh' \
+  && bad ".study-body is height:100vh again; it has to be a minimum or a tall step cannot push the page" || ok
+awk '/^\.wizard \{/,/^}/' "$SCSS" | grep -qE 'min-height: *calc' \
+  && ok || bad ".wizard no longer sets a min-height, so a short step stops filling the window"
+# The emulator's cap is the only thing left sizing the panel now that the box
+# does not crop it, so it has to be a token rather than a number buried in a
+# calc that nobody can check against anything.
+grep -q -- '--preview-chrome:' "$SCSS" \
+  && ok || bad "study.css has no --preview-chrome token; the preview's cap is a bare number again"
+awk '/^\.study-preview-frame \{/,/^}/' "$SCSS" | grep -q -- 'var(--preview-chrome)' \
+  && ok || bad ".study-preview-frame does not use --preview-chrome, so the token and the cap have drifted"
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -427,28 +427,41 @@ TOPNAV="$ROOT/site/assets/topnav.js"
 SP_HTML="$ROOT/site/study/index.html"
 [ -f "$TOPNAV" ] || { echo "FAIL site  missing $TOPNAV"; exit 1; }
 
-# Every class the script writes must mean something to the stylesheet.
+# Selectors only, comments and :not() contents stripped -- see css_selectors.py.
+# Grepping the whole stylesheet for a class name used to be answered YES by the
+# sentence " * .has-menu is added by assets/topnav.js" in a comment, and a
+# reviewer restored the original bug in full with this check still green.
+if ! css_sels="$(python3 "$HERE/css_selectors.py" "$CSS" 2>&1)"; then
+  bad "css_selectors.py could not run, so the menu's classes went unchecked:"
+  while IFS= read -r line; do echo "      $line"; done <<< "$css_sels"
+  css_sels=""
+fi
+[ -n "$css_sels" ] && ok || bad "styles.css yielded no selectors at all"
+
 nav_classes="$(grep -oE 'classList\.(add|toggle)\("[a-z-]+"' "$TOPNAV" | grep -oE '"[a-z-]+"' | tr -d '"' | sort -u)"
 if [ -z "$nav_classes" ]; then
   bad "topnav.js writes no classes at all, so the bar can never open"
 else
   ok
   for c in $nav_classes; do
-    grep -q "\.$c" "$CSS" && ok || bad "topnav.js writes .$c and styles.css has no rule for it"
+    if printf '%s\n' "$css_sels" | grep -qE "\.$c([^A-Za-z0-9_-]|\$)"; then
+      ok
+    else
+      bad "topnav.js writes .$c and no styles.css SELECTOR uses it (a comment does not count)"
+    fi
   done
 fi
 # ...and the control it looks for must be one the stylesheet can show and both
 # pages actually carry.
 for sel in topnav-toggle topnav; do
   grep -q "\.$sel" "$TOPNAV" && ok || bad "topnav.js never looks for .$sel"
-  grep -q "\.$sel" "$CSS" && ok || bad "styles.css has no .$sel rule"
+  printf '%s\n' "$css_sels" | grep -qE "\.$sel([^A-Za-z0-9_-]|\$)" \
+    && ok || bad "styles.css has no .$sel selector"
 done
 for p in "$HTML" "$SP_HTML"; do
   rel="${p#"$ROOT"/}"
   grep -q 'class="topnav-toggle"' "$p" && ok || bad "$rel has no .topnav-toggle button, so its narrow bar has no navigation"
   grep -qE 'src="/?assets/topnav\.js"' "$p" && ok || bad "$rel does not load assets/topnav.js, so its menu button opens nothing"
-  # aria-controls has to name something on the page, or the button announces a
-  # relationship to an element that is not there.
   ctl="$(grep -oE 'aria-controls="[A-Za-z0-9_-]+"' "$p" | head -1 | sed -E 's/.*="//; s/"//')"
   if [ -z "$ctl" ]; then
     bad "$rel's menu button has no aria-controls"
@@ -457,11 +470,35 @@ for p in "$HTML" "$SP_HTML"; do
     grep -q "id=\"$ctl\"" "$p" && ok || bad "$rel's menu button controls #$ctl and no such element exists"
   fi
 done
-# A bar is one line high. Without this the label wraps inside it and the fix is
-# only half applied: the panel is right and the wide bar is still two lines at
-# any width where a label is long enough.
-awk '/^\.topnav a \{/,/^}/' "$CSS" | grep -q 'white-space: *nowrap' \
-  && ok || bad ".topnav a does not set white-space: nowrap, so a long label wraps inside the bar again"
+
+# nowrap has to be SCOPED to the bar the script has taken over. Unscoped it made
+# the no-script bar worse rather than leaving it alone: links still inline and no
+# longer allowed to wrap ran to x=339 past a 320px viewport, and .topbar is
+# position:fixed, so there was no scrollbar to reach the last one with. Wrapping
+# is ugly and reachable; overflowing a fixed bar is neither.
+nowrap_sels="$(python3 - "$CSS" <<'PYEOF'
+import pathlib, re, sys
+css = re.sub(r"/\*.*?\*/", "", pathlib.Path(sys.argv[1]).read_text(), flags=re.S)
+for m in re.finditer(r"([^{}]+)\{([^{}]*)\}", css):
+    sel, decls = m.group(1).strip(), m.group(2)
+    # A DESCENDANT of .topnav -- the links. .topnav-toggle is a different class
+    # and its nowrap is unconditional on purpose: the button is one short word
+    # and it only exists at all where the menu does.
+    if re.search(r"white-space\s*:\s*nowrap", decls) and re.search(r"\.topnav(?![\w-])\s+\S", sel):
+        print(" ".join(sel.split()))
+PYEOF
+)"
+if [ -z "$nowrap_sels" ]; then
+  bad "nothing stops a .topnav label wrapping inside the bar"
+else
+  ok
+  while IFS= read -r sel; do
+    case "$sel" in
+      *has-menu*) ok ;;
+      *) bad "\`$sel\` sets nowrap without .has-menu, so the no-script bar overflows a fixed bar instead of wrapping" ;;
+    esac
+  done <<< "$nowrap_sels"
+fi
 # The old rule hid the two product links outright. It may only survive as the
 # no-script fallback, which is what :not(.has-menu) scopes it to.
 if grep -q 'a\[href="#shelf"\]' "$CSS"; then
@@ -470,6 +507,14 @@ if grep -q 'a\[href="#shelf"\]' "$CSS"; then
 else
   ok
 fi
+# Escape hides the panel with display:none, which drops focus on BODY and makes
+# the next Tab restart at the top of the document, so the toggle has to be given
+# it back. Only the call can be checked here; that it lands on the button, and
+# that clicking the WORDMARK (an anchor in the bar but outside the panel) closes
+# the panel too, were measured in a browser at 390x844 and cannot be asserted
+# from a file.
+grep -q 'btn\.focus()' "$TOPNAV" \
+  && ok || bad "topnav.js never returns focus to the toggle, so Escape drops the caret on BODY"
 
 # -- the study page's own account of where Pyodide comes from ------------------
 #
@@ -487,7 +532,6 @@ else
   ok
   case "$first_base" in
     http*)
-      # Remote first: the page must name that host and must not claim otherwise.
       host="$(printf '%s' "$first_base" | sed -E 's|https?://||; s|/.*||')"
       label="$(printf '%s' "$host" | awk -F. '{print $(NF-1)}')"
       grep -qi "$label" "$SP_HTML" \
@@ -496,63 +540,115 @@ else
         && bad "study/index.html still says Pyodide is served from this site, and worker.js asks $host first" || ok
       ;;
     *)
-      # Same-origin first: then "served from this site" is the true claim.
       grep -qi "served from this site" "$SP_HTML" \
         && ok || bad "worker.js loads Pyodide from this site first and study/index.html does not say so"
       ;;
   esac
 fi
 
+# -- one release request per page ---------------------------------------------
+#
+# The Install button names the version and the report form uses it as the
+# version field's placeholder. Both used to ask GitHub themselves, which put two
+# identical requests on every front-page load against an unauthenticated limit
+# of 60 an hour per IP -- the very limit install.js's own comment gives as the
+# reason it asks from the visitor's browser at all. assets/release.js is the one
+# asker now; a caller that goes back to fetching for itself is the regression.
+RELEASE="$ROOT/site/assets/release.js"
+[ -f "$RELEASE" ] || { echo "FAIL site  missing $RELEASE"; exit 1; }
+grep -q 'releases/latest' "$RELEASE" && ok || bad "release.js does not ask for the latest release"
+helper="$(grep -oE 'window\.[A-Za-z]+ = function' "$RELEASE" | head -1 | sed -E 's/window\.//; s/ = function//')"
+if [ -z "$helper" ]; then
+  bad "release.js publishes no function, so nothing can call it"
+else
+  ok
+  for f in "$REPORTJS" "$INSTALL"; do
+    rel="${f#"$ROOT"/}"
+    grep -q "$helper" "$f" && ok || bad "$rel does not call window.$helper, so it is not sharing the request"
+    grep -q 'releases/latest' "$f" \
+      && bad "$rel asks GitHub for the release itself again; one page load must not spend two of the sixty" || ok
+  done
+fi
+# Every page carrying either caller has to load the helper, and load it first.
+for p in "$HTML" "$REPORTPAGE"; do
+  rel="${p#"$ROOT"/}"
+  if grep -qE 'src="/?assets/(report|install)\.js"' "$p"; then
+    ok
+    grep -qE 'src="/?assets/release\.js"' "$p" \
+      && ok || bad "$rel loads a script that needs window.$helper and never loads assets/release.js"
+    rl="$(grep -nE 'src="/?assets/release\.js"' "$p" | head -1 | cut -d: -f1)"
+    cl="$(grep -nE 'src="/?assets/(report|install)\.js"' "$p" | head -1 | cut -d: -f1)"
+    if [ -n "$rl" ] && [ -n "$cl" ] && [ "$rl" -lt "$cl" ]; then
+      ok
+    else
+      bad "$rel loads assets/release.js after the script that uses it"
+    fi
+  else
+    ok
+  fi
+done
+
 # -- the report form's version placeholder ------------------------------------
 #
 # It read 1.12.9 while the site was shipping 1.12.23: a number typed into the
 # file, right the day it was written and eleven releases stale by the time
-# anyone looked. It is asked for now, from the same release the Install button
-# reads. Nothing here can check the answer -- that needs the network -- but it
-# can check that no literal has been typed back in, and that the field is
-# still filled from somewhere.
-ver_ph="$(grep -oE 'id="report-version"[^>]*placeholder="[^"]*"' "$REPORTJS" | grep -oE 'placeholder="[^"]*"' | sed -E 's/placeholder="//; s/"//')"
-if printf '%s' "$ver_ph" | grep -qE '[0-9]+\.[0-9]+'; then
-  bad "report.js hardcodes a firmware version ($ver_ph) as the placeholder again; it is asked for, not typed"
-else
+# anyone looked. It is asked for now. Nothing here can check the answer -- that
+# needs the network -- but it can check that no literal has been typed back in.
+#
+# Every placeholder in the file is scanned, not the one attribute after an id.
+# The first version of this check grepped `id="report-version"[^>]*placeholder=`
+# and a reviewer put the attribute in FRONT of the id, restored 1.12.9, and got
+# zero failures; renaming the id emptied the capture and passed just as quietly.
+ph_bad="$(python3 - "$REPORTJS" <<'PYEOF'
+import pathlib, re, sys
+src = pathlib.Path(sys.argv[1]).read_text()
+tags = re.findall(r"<input\b[^>]*>", src)
+if not any(re.search(r'name="version"', t) for t in tags):
+    print("report.js draws no version field at all")
+for value in re.findall(r'placeholder="([^"]*)"', src):
+    if re.fullmatch(r"v?\d+(\.\d+)+", value.strip()):
+        print(f'report.js hardcodes the version "{value}" as a placeholder again; it is asked for, not typed')
+PYEOF
+)"
+if [ -z "$ph_bad" ]; then
   ok
+else
+  while IFS= read -r line; do bad "$line"; done <<< "$ph_bad"
 fi
-grep -q 'releases/latest' "$REPORTJS" \
-  && ok || bad "report.js no longer asks for the latest release, so the version field has no placeholder at all"
-grep -q 'REPO' "$REPORTJS" \
-  && ok || bad "report.js has no repository to ask"
 
 # -- the study wizard's steps stay in normal flow ------------------------------
 #
-# .wiz-step was position:absolute inside a min-height:0 row, so a step taller
-# than the window was cropped by it rather than growing the page. At 1440x900
-# the step-2 "Next" button hung 29 of its 45 pixels below the cut and
-# document.elementFromPoint at the button's own centre returned the footer; at
-# 1280x720 none of it was on screen and scrollHeight equalled innerHeight, so
-# the page reported nothing more to see.
-#
-# THIS CHECK CANNOT SEE THAT. Whether a control is reachable is a browser
-# question and it was answered in one: elementFromPoint at the centre, then a
-# real click, at 1440x900 and 1280x720, before and after. What it can see is
-# the mechanism -- that the step is in flow and the page is allowed to grow --
-# and that is the thing whose quiet return would bring the rest back with it.
+# Properties, not spellings, and the class names come out of the markup. The
+# first version of this check forbade three exact declarations and a reviewer
+# reintroduced the identical breakage through three others with nothing
+# reported; renaming .wiz-step emptied its awk range and passed all three at
+# once. study_layout.py says at length what it does and does not see -- the one
+# thing it cannot see is whether the button can be clicked, which is a browser
+# question that was answered in a browser. Status checked as well as output.
+if layout_bad="$(python3 "$HERE/study_layout.py" "$ROOT" 2>&1)"; then
+  if [ -z "$layout_bad" ]; then
+    ok
+  else
+    while IFS= read -r line; do bad "$line"; done <<< "$layout_bad"
+  fi
+else
+  bad "study_layout.py could not run, so the wizard's layout went unchecked:"
+  while IFS= read -r line; do echo "      $line"; done <<< "$layout_bad"
+fi
+# The emulator's cap is the only thing sizing the panel now that the box does
+# not crop it, so it has to be a token that can be found and reasoned about
+# rather than a number buried in a calc.
 SCSS="$ROOT/site/study/study.css"
-[ -f "$SCSS" ] || { echo "FAIL site  missing $SCSS"; exit 1; }
-awk '/^\.wiz-step \{/,/^}/' "$SCSS" | grep -qE 'position: *absolute' \
-  && bad ".wiz-step is position:absolute again; a step taller than the window is cropped by the row instead of growing the page" || ok
-awk '/^\.study-body \{/,/^}/' "$SCSS" | grep -qE 'overflow: *hidden' \
-  && bad ".study-body clips again, so a step that does not fit reports no scrollable height and the page looks finished" || ok
-awk '/^\.study-body \{/,/^}/' "$SCSS" | grep -qE '^ *height: *100vh' \
-  && bad ".study-body is height:100vh again; it has to be a minimum or a tall step cannot push the page" || ok
-awk '/^\.wizard \{/,/^}/' "$SCSS" | grep -qE 'min-height: *calc' \
-  && ok || bad ".wizard no longer sets a min-height, so a short step stops filling the window"
-# The emulator's cap is the only thing left sizing the panel now that the box
-# does not crop it, so it has to be a token rather than a number buried in a
-# calc that nobody can check against anything.
 grep -q -- '--preview-chrome:' "$SCSS" \
   && ok || bad "study.css has no --preview-chrome token; the preview's cap is a bare number again"
 awk '/^\.study-preview-frame \{/,/^}/' "$SCSS" | grep -q -- 'var(--preview-chrome)' \
   && ok || bad ".study-preview-frame does not use --preview-chrome, so the token and the cap have drifted"
+# A step change has to arrive at the top of itself. The page is the scroll
+# container now; the step box was, and its scrollTop reset went dead with it.
+# That the reset lands on a step CHANGE and not a redraw was measured in a
+# browser; only its presence can be checked here.
+grep -q 'window.scrollTo' "$ROOT/site/study/study.js" \
+  && ok || bad "study.js never resets the page scroll, so a step arrives at the previous step's offset"
 
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/host-tests/site/study_layout.py
+++ b/host-tests/site/study_layout.py
@@ -1,0 +1,137 @@
+"""The study wizard's steps must stay in normal flow, and the page must be
+allowed to grow.
+
+WHAT WENT WRONG. `.wiz-step` was `position: absolute` inside a `min-height: 0`
+row and `.study-body` clamped the page to `100vh` with `overflow: hidden`, so a
+step taller than the window was cropped by the row instead of growing the page.
+At 1440x900 the step-2 "Next" button hung 29 of its 45 pixels below the cut and
+`document.elementFromPoint` at the button's own centre returned the footer; at
+1280x720 none of it was on screen while `scrollHeight` equalled `innerHeight`,
+so the page reported nothing more to see and read as finished.
+
+WHAT THIS FILE CANNOT SEE, said plainly: whether a control is reachable. That
+is a browser question and it was answered in one -- elementFromPoint at the
+centre, then a real click, at both window heights, in two browsers. Nothing
+here can do that, and a static assertion pretending to would be a check that
+cannot fail.
+
+WHAT IT DOES SEE is the mechanism, and it checks PROPERTIES rather than
+spellings, because the first version of this check forbade three exact
+declarations and a reviewer restored the identical breakage through three it
+did not name (`overflow: clip` on the body, `height: calc(...)` on the wizard,
+`overflow: hidden` on the step container) with zero failures reported. Any
+`overflow` at all on these three boxes clips; any `height` on the outer two
+stops the page growing. So the whole property is refused, not a wording of it.
+
+The class names are read out of study/index.html rather than written here, and
+a class whose rule block is MISSING is a failure rather than an empty range
+that passes: renaming `.wiz-step` used to empty the awk range and satisfy all
+three checks at once.
+
+Prints one line per problem and nothing when there are none.
+
+    python3 host-tests/site/study_layout.py <repo-root>
+"""
+
+import pathlib
+import re
+import sys
+
+if len(sys.argv) < 2:
+    sys.exit("usage: study_layout.py <repo-root>")
+
+root = pathlib.Path(sys.argv[1])
+html = (root / "site/study/index.html").read_text()
+css = (root / "site/study/study.css").read_text()
+problems = []
+
+
+def say(msg):
+    problems.append(msg)
+
+
+# -- the names, taken from the markup ----------------------------------------
+
+m = re.search(r"<body[^>]*\bclass=\"([^\"]+)\"", html)
+body_class = m.group(1).split()[0] if m else None
+if not body_class:
+    say("study/index.html's <body> carries no class, so its page rules cannot be found")
+
+m = re.search(r"<main[^>]*\bclass=\"([^\"]+)\"", html)
+wizard_class = m.group(1).split()[-1] if m else None
+if not wizard_class:
+    say("study/index.html has no <main> with a class, so the wizard cannot be found")
+
+# The steps are the <section>s that share a class. Take the class every one of
+# them carries, minus the state class only the current one has.
+step_classes = [set(c.split()) for c in re.findall(r"<section[^>]*\bclass=\"([^\"]+)\"", html)]
+step_class = None
+if len(step_classes) >= 2:
+    shared = set.intersection(*step_classes)
+    if len(shared) == 1:
+        step_class = shared.pop()
+if not step_class:
+    say("study/index.html's step <section>s share no single class, so the step rule cannot be found")
+
+# Their common parent's class is the step container.
+container_class = None
+if step_class:
+    m = re.search(r"<div[^>]*\bclass=\"([^\"]*)\"[^>]*>\s*(?:<!--.*?-->\s*)*<section[^>]*\bclass=\"[^\"]*\b"
+                  + re.escape(step_class) + r"\b", html, flags=re.S)
+    if m:
+        container_class = m.group(1).split()[0]
+if not container_class:
+    say("study/index.html's steps have no classed <div> around them, so the step container cannot be found")
+
+
+# -- their rule blocks -------------------------------------------------------
+
+
+def block(cls):
+    """The declarations of the top-level `.cls { ... }` rule, or None."""
+    m = re.search(r"(?m)^\." + re.escape(cls) + r"\s*\{(.*?)^\}", css, flags=re.S)
+    if not m:
+        return None
+    return re.sub(r"/\*.*?\*/", "", m.group(1), flags=re.S)
+
+
+def props(decls):
+    return {p.strip().lower() for p in re.findall(r"(?m)^\s*([a-z-]+)\s*:", decls)}
+
+
+def check(cls, must, must_not_exact, must_not_prefix, label):
+    if not cls:
+        return
+    decls = block(cls)
+    if decls is None:
+        say(f"study.css has no `.{cls}` rule, and study/index.html says that is the {label}")
+        return
+    have = props(decls)
+    for p in must:
+        if p not in have:
+            say(f".{cls} ({label}) no longer sets {p}")
+    for p in must_not_exact:
+        if p in have:
+            say(f".{cls} ({label}) sets {p}, which is what cropped the step instead of growing the page")
+    for prefix in must_not_prefix:
+        hit = sorted(p for p in have if p == prefix or p.startswith(prefix + "-"))
+        if hit:
+            say(f".{cls} ({label}) sets {', '.join(hit)}; any of them clips a step that does not fit")
+    return decls
+
+
+check(body_class, {"min-height"}, {"height"}, {"overflow"}, "page body")
+check(wizard_class, {"min-height"}, {"height"}, set(), "wizard")
+cont = check(container_class, {"display", "grid-template-rows"}, set(), {"overflow"}, "step container")
+check(step_class, {"grid-area"}, {"position"}, {"overflow"}, "step")
+
+if cont is not None:
+    if not re.search(r"display\s*:\s*grid", cont):
+        say(f".{container_class} (step container) is not display:grid, so the steps cannot share one cell")
+    rows = re.search(r"grid-template-rows\s*:([^;]*)", cont)
+    if rows and "minmax(0" in rows.group(1).replace(" ", ""):
+        say(f".{container_class} (step container) sizes its row with minmax(0, ...), which lets it be "
+            "shorter than the step again -- the clip under another name")
+
+for line in problems:
+    print(line)

--- a/site/README.md
+++ b/site/README.md
@@ -311,6 +311,59 @@ by `tools_local/site/build_esptool.sh`. Edit the script, never the file. At
 presses Install; it sits under the ~1MB line where `precompress.py` starts
 mattering, and does not want a `Content-Encoding` of its own.
 
+## The top bar on a phone
+
+Five labels do not share one line at 320px, and the bar is one line high. Until
+2026-09-05 the stylesheet answered that below 720px by hiding `THE SHELF` and
+`PLAY NEARBY` -- the two links that lead to what the site is for -- and keeping
+`ANKI DECKS`, which then wrapped to two 49px lines inside a 50px bar at 320,
+390 and 414 anyway. `/study/` did the same with `INSTALL THE FIRMWARE`.
+
+So below 720px the bar carries the wordmark and a `Menu` button, and every link
+moves into a panel under it with a line each. Three files have to agree and
+none of them imports another:
+
+- `index.html` and `study/index.html` carry the `.topnav-toggle` button, give
+  the `<nav>` the id its `aria-controls` names, and load the script;
+- `assets/topnav.js` adds `.has-menu` to the bar and toggles `.is-open` on the
+  nav;
+- `styles.css` decides what those two classes mean.
+
+`.has-menu` comes from the script rather than the markup on purpose: a page
+whose scripts did not run keeps the plain inline bar instead of a button that
+opens nothing. `host-tests/site/run.sh` checks every class the script writes
+against the stylesheet, both pages against the script, and `aria-controls`
+against the element it names.
+
+The breakpoint lives only in `styles.css`. The script closes the panel by
+asking whether the button still has an `offsetParent`, not by comparing a width
+it would have to keep in step.
+
+## The study wizard is one step at a time, not one screen
+
+`study/study.css` sizes the wizard to the window when the step fits and lets
+the page scroll when it does not. It used to clamp to `100vh` and clip:
+`.wiz-step` was `position: absolute` inside a `min-height: 0` row, so a step
+taller than the window was cropped by the row rather than growing the page.
+At 1440x900 the step-2 `Next` button hung 29 of its 45 pixels below the cut --
+`document.elementFromPoint` at the button's own centre returned `.wiz-foot` --
+and at 1280x720 none of it was on screen while `scrollHeight` equalled
+`innerHeight`, so the page reported nothing more to see and looked finished
+with the form cut mid-select.
+
+The steps stack in one grid cell now and stay in flow. Two consequences worth
+knowing before editing:
+
+- The emulator panel's height is capped by `--preview-chrome`, not by the box
+  around it. That cap used to be irrelevant, because the box cropped the panel
+  first; it is now the only thing sizing it, which is why the number moved from
+  12.5rem to the 14rem the chrome actually measures. Too large costs a short
+  page scroll rather than silently trimming the device.
+- Reachability is a browser question. The suite checks the mechanism -- that
+  the step is in flow and the page may grow -- and cannot see whether a control
+  can be clicked. That is measured with `elementFromPoint` and a real click at
+  the widths in question, the way the bug was found.
+
 ## The rules this page follows
 
 `docs/identity.md` governs the copy and the look, and it is worth reading before

--- a/site/README.md
+++ b/site/README.md
@@ -331,13 +331,46 @@ none of them imports another:
 
 `.has-menu` comes from the script rather than the markup on purpose: a page
 whose scripts did not run keeps the plain inline bar instead of a button that
-opens nothing. `host-tests/site/run.sh` checks every class the script writes
-against the stylesheet, both pages against the script, and `aria-controls`
-against the element it names.
+opens nothing. **`white-space: nowrap` is scoped to `.topbar.has-menu` for the
+same reason.** Unscoped it made the no-script bar worse rather than leaving it
+alone: links still inline and no longer allowed to wrap, the last one running
+to x=339 past a 320px viewport, and `.topbar` is `position: fixed`, so there
+was no scrollbar to reach it with. Wrapping is ugly and reachable; overflowing
+a fixed bar is neither.
+
+The close listener is on the **bar**, not the panel. The wordmark is an anchor
+inside `.topbar` and outside `.topnav`, so a listener on the panel alone let it
+jump the page and leave the panel covering the heading it had jumped to. Escape
+hands focus back to the toggle, because `display: none` on the nav drops the
+caret on `BODY` and the next Tab restarts at the top of the document; a close
+caused by a click or a jump deliberately does not, since the person is already
+somewhere else.
+
+`host-tests/site/run.sh` checks both pages against the script, `aria-controls`
+against the element it names, and every class the script writes against the
+stylesheet's **selectors** -- `host-tests/site/css_selectors.py`, comments and
+`:not()` contents stripped. Grepping the whole file was answered YES by the
+sentence " * .has-menu is added by assets/topnav.js" in a comment, and a
+reviewer renamed all four real rules with the suite still green and the bar
+broken. What the suite cannot see is behaviour: the wordmark case and the focus
+return were measured in a browser at 390x844.
 
 The breakpoint lives only in `styles.css`. The script closes the panel by
 asking whether the button still has an `offsetParent`, not by comparing a width
 it would have to keep in step.
+
+## One release request per page
+
+The Install button names the version and the report form uses it as the version
+field's placeholder. Both asked GitHub themselves for a day, which put two
+identical requests on every front-page load against an unauthenticated limit of
+60 an hour per IP -- the very limit `assets/install.js`'s own comment gives as
+the reason it asks from the visitor's browser rather than from `/api/firmware`.
+
+`assets/release.js` is the single asker: it publishes `window
+.crossplayLatestRelease()`, memoised, never rejecting. Load it **before** the
+scripts that call it. The suite checks that neither caller has gone back to
+fetching for itself, and that every page carrying one loads the helper first.
 
 ## The study wizard is one step at a time, not one screen
 
@@ -356,13 +389,23 @@ knowing before editing:
 
 - The emulator panel's height is capped by `--preview-chrome`, not by the box
   around it. That cap used to be irrelevant, because the box cropped the panel
-  first; it is now the only thing sizing it, which is why the number moved from
-  12.5rem to the 14rem the chrome actually measures. Too large costs a short
-  page scroll rather than silently trimming the device.
+  first; it is now the only thing sizing it. It is **not** a constant: the
+  foot's one sentence wraps on a narrower window, so the chrome measures 274px
+  where it fits on one line and 285px at 1100x700 where it does not. The token
+  is the worst case (15rem), which is why 12.5rem and then 14rem were both
+  wrong. Re-run the sweep if the foot's wording changes. Below 650px tall the
+  step scrolls whatever this is set to, because the side column's own text is
+  taller than the window -- do not chase those sizes with the token.
+- A step change resets the page scroll, in `study.js`'s `goTo()`. The page is
+  the scroll container now; the step box was, and its own `scrollTop` reset
+  went quietly dead when the box stopped clipping.
 - Reachability is a browser question. The suite checks the mechanism -- that
   the step is in flow and the page may grow -- and cannot see whether a control
-  can be clicked. That is measured with `elementFromPoint` and a real click at
-  the widths in question, the way the bug was found.
+  can be clicked. `host-tests/site/study_layout.py` says so in its own header.
+  It asserts PROPERTIES, not spellings: the first version forbade three exact
+  declarations and a reviewer restored the identical breakage through three
+  others with nothing reported. Reachability itself is measured with
+  `elementFromPoint` and a real click, the way the bug was found.
 
 ## The rules this page follows
 

--- a/site/assets/install.js
+++ b/site/assets/install.js
@@ -29,7 +29,6 @@
 (function () {
   "use strict";
 
-  var REPO = "ma-r-s/crossplay";
 
   // Both boards are ESP32-S3. The check is not X4-Pro-vs-Sticky (nothing on
   // the wire tells those apart); it is "this is not one of the ESP32-C3
@@ -110,12 +109,13 @@
   // Asked from the visitor's browser rather than from /api/firmware, which is
   // the whole reason that endpoint takes a tag instead of looking one up: the
   // GitHub API's unauthenticated rate limit is per IP, and one shared server
-  // address would run out of them long before any one visitor did.
+  // address would run out of them long before any one visitor did. That same
+  // limit is why the request itself lives in assets/release.js: the report form
+  // wants the version too, and one page load must not spend two of the sixty.
   function loadRelease() {
-    return fetch("https://api.github.com/repos/" + REPO + "/releases/latest")
-      .then(function (r) {
-        return r.ok ? r.json() : null;
-      })
+    if (!window.crossplayLatestRelease) return Promise.resolve();
+    return window
+      .crossplayLatestRelease()
       .then(function (data) {
         if (!data || !data.tag_name) return;
         state.tag = data.tag_name;

--- a/site/assets/release.js
+++ b/site/assets/release.js
@@ -1,0 +1,36 @@
+/* The repository's latest release, asked for once per page.
+ *
+ * Two things on the front page want the version: the Install button names it,
+ * and the report form uses it as the version field's placeholder. GitHub's
+ * unauthenticated API allows 60 requests an hour per IP -- which is the whole
+ * reason install.js asks from the visitor's browser rather than from
+ * /api/firmware -- so two identical requests on one load halve how many visits
+ * a person gets before the button can no longer name a version. It was two for
+ * a day: the placeholder was added with a fetch of its own. Both callers share
+ * this promise now, and /report/, which has no installer, is still one request.
+ *
+ * It never rejects. A caller gets null and shows what it can without a version:
+ * the Install button still installs, the report form just has no placeholder.
+ * The repository name lives here rather than in each caller so the two cannot
+ * ask about different repositories.
+ */
+(function () {
+  "use strict";
+
+  var REPO = "ma-r-s/crossplay";
+  var pending = null;
+
+  window.crossplayLatestRelease = function () {
+    if (!pending)
+      pending = fetch(
+        "https://api.github.com/repos/" + REPO + "/releases/latest",
+      )
+        .then(function (r) {
+          return r.ok ? r.json() : null;
+        })
+        .catch(function () {
+          return null;
+        });
+    return pending;
+  };
+})();

--- a/site/assets/report.js
+++ b/site/assets/report.js
@@ -22,6 +22,9 @@
 (function () {
   "use strict";
 
+  // Same repository the Install button reads its release from.
+  var REPO = "ma-r-s/crossplay";
+
   var TEMPLATE = `
 <form class="report-form" id="report-form" novalidate>
   <div class="report-row report-choices">
@@ -50,7 +53,7 @@
   <div class="report-row">
     <div class="report-field">
       <label class="report-label" for="report-version">Firmware version <small>(optional)</small></label>
-      <input type="text" id="report-version" name="version" inputmode="decimal" placeholder="1.12.9" autocomplete="off">
+      <input type="text" id="report-version" name="version" inputmode="decimal" placeholder="" autocomplete="off">
       <p class="report-hint">Settings &gt; About on the device.</p>
     </div>
     <div class="report-field">
@@ -130,6 +133,26 @@
     });
   }
 
+  // The version field's placeholder is the version the site is shipping, asked
+  // for rather than typed here: a number written into this file is right on the
+  // day it is written and wrong at the next release, and this one had drifted
+  // eleven releases behind before anyone noticed. Same source as the Install
+  // button, so the two can never disagree. A failed fetch leaves the field
+  // blank -- the hint under it already says where to find the number -- because
+  // an empty placeholder is better than a confidently wrong one.
+  function fillVersionPlaceholder(version) {
+    if (version.value) return; // ?v= already said which
+    fetch("https://api.github.com/repos/" + REPO + "/releases/latest")
+      .then(function (r) {
+        return r.ok ? r.json() : null;
+      })
+      .then(function (data) {
+        if (!data || !data.tag_name || version.value) return;
+        version.placeholder = String(data.tag_name).replace(/^v/, "");
+      })
+      .catch(function () {});
+  }
+
   // Draws the form into `root` and wires it. Returns the handful of things a
   // host page needs: where to put focus, whether a report has been sent, and
   // how to start over.
@@ -179,6 +202,7 @@
     if (q.get("kind") === "idea")
       form.querySelector('input[name="kind"][value="idea"]').checked = true;
     if (q.get("app")) app.value = q.get("app");
+    fillVersionPlaceholder(version);
 
     photo.addEventListener("change", function () {
       var f = photo.files && photo.files[0];

--- a/site/assets/report.js
+++ b/site/assets/report.js
@@ -22,9 +22,6 @@
 (function () {
   "use strict";
 
-  // Same repository the Install button reads its release from.
-  var REPO = "ma-r-s/crossplay";
-
   var TEMPLATE = `
 <form class="report-form" id="report-form" novalidate>
   <div class="report-row report-choices">
@@ -142,15 +139,11 @@
   // an empty placeholder is better than a confidently wrong one.
   function fillVersionPlaceholder(version) {
     if (version.value) return; // ?v= already said which
-    fetch("https://api.github.com/repos/" + REPO + "/releases/latest")
-      .then(function (r) {
-        return r.ok ? r.json() : null;
-      })
-      .then(function (data) {
-        if (!data || !data.tag_name || version.value) return;
-        version.placeholder = String(data.tag_name).replace(/^v/, "");
-      })
-      .catch(function () {});
+    if (!window.crossplayLatestRelease) return;
+    window.crossplayLatestRelease().then(function (data) {
+      if (!data || !data.tag_name || version.value) return;
+      version.placeholder = String(data.tag_name).replace(/^v/, "");
+    });
   }
 
   // Draws the form into `root` and wires it. Returns the handful of things a

--- a/site/assets/topnav.js
+++ b/site/assets/topnav.js
@@ -22,27 +22,41 @@
 
   bar.classList.add("has-menu");
 
-  function set(open) {
+  function isOpen() {
+    return btn.getAttribute("aria-expanded") === "true";
+  }
+
+  // returnFocus matters only when the panel is being closed from the keyboard.
+  // display:none on the nav destroys whatever focus was inside it, dropping the
+  // caret on BODY so the next Tab restarts at the top of the document -- so
+  // Escape hands focus back to the button it came from. A close caused by a
+  // click or a jump must NOT do that: the person is already somewhere else, and
+  // pulling focus back to the bar would undo the move they just made.
+  function set(open, returnFocus) {
+    var was = isOpen();
     btn.setAttribute("aria-expanded", open ? "true" : "false");
     nav.classList.toggle("is-open", open);
+    if (!open && was && returnFocus) btn.focus();
   }
 
   btn.addEventListener("click", function () {
-    set(btn.getAttribute("aria-expanded") !== "true");
+    set(!isOpen());
   });
 
-  // A jump inside the page would otherwise leave the panel covering the very
-  // heading it jumped to.
-  nav.addEventListener("click", function (ev) {
-    if (ev.target.closest("a")) set(false);
+  // Any link in the BAR, not just in the panel: the wordmark is an anchor to
+  // the top of the page and it sits outside .topnav, so a listener on the panel
+  // alone let it jump the page and leave the panel covering the heading it had
+  // jumped to. The toggle is a <button>, so it never matches this.
+  bar.addEventListener("click", function (ev) {
+    if (ev.target.closest && ev.target.closest("a")) set(false);
   });
 
   document.addEventListener("keydown", function (ev) {
-    if (ev.key === "Escape") set(false);
+    if (ev.key === "Escape") set(false, true);
   });
 
   document.addEventListener("click", function (ev) {
-    if (!ev.target.closest(".topbar")) set(false);
+    if (!ev.target.closest || !ev.target.closest(".topbar")) set(false);
   });
 
   // Asked of the button rather than of a width: the breakpoint is the

--- a/site/assets/topnav.js
+++ b/site/assets/topnav.js
@@ -1,0 +1,55 @@
+/* The top bar's narrow-screen menu.
+ *
+ * The bar holds the name and up to five links. At 320px those labels do not
+ * share a line: the stylesheet used to hide THE SHELF and PLAY NEARBY below
+ * 720px -- the two that lead to what the site is for -- and the one it kept,
+ * ANKI DECKS, still wrapped to two 49px lines inside a 50px bar at 320, 390 and
+ * 414. /study/ did the same with INSTALL THE FIRMWARE. So on a narrow bar the
+ * links move into a panel and this button opens it.
+ *
+ * The class comes from here rather than living in the markup so that a page
+ * whose scripts failed keeps the plain inline bar instead of a button that
+ * opens nothing. Both pages that have a .topbar load this file; a page without
+ * one is left alone.
+ */
+(function () {
+  "use strict";
+
+  var bar = document.querySelector(".topbar");
+  var nav = bar && bar.querySelector(".topnav");
+  var btn = bar && bar.querySelector(".topnav-toggle");
+  if (!bar || !nav || !btn) return;
+
+  bar.classList.add("has-menu");
+
+  function set(open) {
+    btn.setAttribute("aria-expanded", open ? "true" : "false");
+    nav.classList.toggle("is-open", open);
+  }
+
+  btn.addEventListener("click", function () {
+    set(btn.getAttribute("aria-expanded") !== "true");
+  });
+
+  // A jump inside the page would otherwise leave the panel covering the very
+  // heading it jumped to.
+  nav.addEventListener("click", function (ev) {
+    if (ev.target.closest("a")) set(false);
+  });
+
+  document.addEventListener("keydown", function (ev) {
+    if (ev.key === "Escape") set(false);
+  });
+
+  document.addEventListener("click", function (ev) {
+    if (!ev.target.closest(".topbar")) set(false);
+  });
+
+  // Asked of the button rather than of a width: the breakpoint is the
+  // stylesheet's to choose, and a copy of the number here is a copy that goes
+  // stale on its own. A hidden button has no offsetParent, and that is exactly
+  // the state in which the panel must not be left open.
+  window.addEventListener("resize", function () {
+    if (btn.offsetParent === null) set(false);
+  });
+})();

--- a/site/index.html
+++ b/site/index.html
@@ -66,7 +66,9 @@
     </svg>
     <span>CrossPlay</span>
   </a>
-  <nav class="topnav" aria-label="Sections">
+  <button class="topnav-toggle" type="button"
+          aria-expanded="false" aria-controls="topnav">Menu</button>
+  <nav class="topnav" id="topnav" aria-label="Sections">
     <a href="#shelf">The shelf</a>
     <a href="#nearby">Play nearby</a>
     <a href="/study/">Anki decks</a>
@@ -614,6 +616,7 @@
 <!-- The Install button, and the release stamp it also fills in. It pulls
      assets/esptool.bundle.js in only when someone presses Install, so the
      175KB library costs the people just reading the page nothing. -->
+<script src="assets/topnav.js"></script>
 <script src="assets/install.js"></script>
 <script src="assets/report.js"></script>
 <script src="assets/avatar-data.js"></script>

--- a/site/index.html
+++ b/site/index.html
@@ -617,6 +617,7 @@
      assets/esptool.bundle.js in only when someone presses Install, so the
      175KB library costs the people just reading the page nothing. -->
 <script src="assets/topnav.js"></script>
+<script src="assets/release.js"></script>
 <script src="assets/install.js"></script>
 <script src="assets/report.js"></script>
 <script src="assets/avatar-data.js"></script>

--- a/site/report/index.html
+++ b/site/report/index.html
@@ -25,6 +25,7 @@
   <a class="report-back" href="/">Back to CrossPlay</a>
 </main>
 
+<script src="/assets/release.js"></script>
 <script src="/assets/report.js"></script>
 </body>
 </html>

--- a/site/study/index.html
+++ b/site/study/index.html
@@ -36,7 +36,9 @@
     </svg>
     <span>CrossPlay</span>
   </a>
-  <nav class="topnav" aria-label="Sections">
+  <button class="topnav-toggle" type="button"
+          aria-expanded="false" aria-controls="topnav">Menu</button>
+  <nav class="topnav" id="topnav" aria-label="Sections">
     <a href="/#get">Install the firmware</a>
     <a class="topnav-out" href="https://github.com/ma-r-s/crossplay">
       <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false" width="15" height="15">
@@ -220,7 +222,7 @@
   <div class="wiz-foot">
     <p class="wiz-fine">
       Runs the repository's own tools via <a href="https://pyodide.org">Pyodide</a>,
-      served from this site &middot; also available as a
+      from jsDelivr with a copy here as fallback &middot; also available as a
       <a href="https://github.com/ma-r-s/crossplay/blob/xteink/docs/apps/study.md">command-line tool</a>
       &middot; Anki is a trademark of Ankitects; no affiliation
     </p>
@@ -254,6 +256,7 @@
   });
 })();
 </script>
+<script src="/assets/topnav.js"></script>
 <script src="/study/study.js"></script>
 </body>
 </html>

--- a/site/study/study.css
+++ b/site/study/study.css
@@ -1,15 +1,23 @@
-/* The Study installer, as a wizard: one viewport, no page scroll, one step
-   at a time. Shared tokens come from /styles.css; everything here is layout
-   and the handful of components the installer owns. Logs scroll inside
-   their own panes; the page itself never does. */
+/* The Study installer, as a wizard: one step at a time, sized to the viewport
+   when it fits and scrolling the page when it does not. Shared tokens come
+   from /styles.css; everything here is layout and the handful of components
+   the installer owns. Logs scroll inside their own panes.
+
+   It used to clamp the page to 100vh and clip: the step was position:absolute
+   inside a min-height:0 row, so on a 900px-tall window the step-2 "Next" button
+   hung 29 of its 45 pixels below the clip and elementFromPoint at its own
+   centre returned the footer. At 720px tall none of it was on screen and the
+   document reported no scrollable height at all, so the page looked finished.
+   Everything in a step is in normal flow now, and the page scrolls when the
+   step is taller than the window. */
 
 .study-body {
-  height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
+  --preview-chrome: 14rem;
 }
 
 .wizard {
-  height: calc(100vh - var(--bar));
+  min-height: calc(100vh - var(--bar));
   max-width: var(--wrap);
   margin-inline: auto;
   padding: 0 var(--gutter);
@@ -86,16 +94,20 @@
 
 /* --- the step area -------------------------------------------------------- */
 
+/* One cell, every step stacked in it. Only .is-current is displayed, so they
+   never collide; stacking them in a grid cell rather than with position:
+   absolute keeps the visible one in flow, which is what lets a tall step push
+   the page taller instead of being clipped by it. The 1fr row still fills the
+   window when the step is short, so a short step looks exactly as it did. */
 .wiz-body {
-  position: relative;
-  min-height: 0;
+  display: grid;
+  grid-template-rows: 1fr;
 }
 
 .wiz-step {
-  position: absolute;
-  inset: 0;
+  grid-area: 1 / 1;
+  min-width: 0;
   display: none;
-  overflow: auto; /* safety net on short screens; panes scroll first */
   padding: 0.9rem 0.1rem;
 }
 
@@ -351,9 +363,16 @@
   overflow: hidden;
 }
 
+/* --preview-chrome is everything the wizard puts above and below the panel:
+   the top bar, the title block, the stepper, the step's own padding and the
+   foot. 12.5rem was 1.5rem short of the truth (274px of chrome at 1440x900)
+   and nobody could tell, because the step box was position:absolute and
+   cropped the panel before its own cap ever applied. In flow the cap is what
+   decides, so it has to be the real number: too large now costs a short page
+   scroll instead of silently trimming the device. */
 .study-preview-frame {
   height: 100%;
-  max-height: calc(100vh - var(--bar) - 12.5rem);
+  max-height: calc(100vh - var(--bar) - var(--preview-chrome));
   aspect-ratio: 3 / 5;
   max-width: 100%;
   border: 1px solid var(--edge);
@@ -571,17 +590,7 @@
 /* --- small screens ---------------------------------------------------------- */
 
 @media (max-width: 720px) {
-  .study-body {
-    height: auto;
-    overflow: auto;
-  }
-
-  .wizard {
-    height: auto;
-  }
-
   .wiz-step {
-    position: static;
     padding: 0.7rem 0;
   }
 

--- a/site/study/study.css
+++ b/site/study/study.css
@@ -13,7 +13,31 @@
 
 .study-body {
   min-height: 100vh;
-  --preview-chrome: 14rem;
+  /* Everything the wizard puts above and below the emulator: the top bar, the
+     title block, the stepper, the step's own padding and the foot. It is NOT a
+     constant -- the foot's one sentence wraps to two lines on a narrower
+     window -- so this is the worst case, not the typical one.
+
+     Measured at step 3 across 721x600 .. 1920x1080: the chrome is 274px where
+     the foot fits on one line and 285px at 1100x700 where it does not, which
+     needs 14.71rem. 12.5rem was the number before, and it was wrong at every
+     one of those sizes; nobody could tell, because the step box was
+     position:absolute and cropped the panel before the cap ever applied. 14rem
+     was the wide-window truth only, and left step 3 overflowing by 4 to 11px
+     between 721 and 1100. 15rem takes step 3's overflow to zero from 900x650
+     up, and costs the panel 16px of height at 1440x900.
+
+     BELOW 650px TALL IT STILL SCROLLS, AND NO VALUE HERE CAN STOP IT: at
+     721x600 the side column's own paragraph, buttons and status line come to
+     330px against a 310px panel, so the text is what exceeds the window. That
+     is the page doing exactly what this file was changed to let it do. Do not
+     shrink this token chasing those three sizes -- it will not move them, and
+     it will shrink the panel on every screen that was already fine.
+
+     If the foot's wording changes, re-run the sweep. Too large costs a
+     slightly smaller panel; too small puts a scrollbar on a step that did not
+     need one. Neither crops anything any more. */
+  --preview-chrome: 15rem;
 }
 
 .wizard {

--- a/site/study/study.js
+++ b/site/study/study.js
@@ -369,7 +369,6 @@ worker.onmessage = function (event) {
     $("reportPlaceholder").hidden = true;
     $("reportBody").hidden = false;
     reachedStep = Math.max(reachedStep, 4);
-    $("stepCheck").scrollTop = 0;
     if (currentStep < 2) goTo(2);
     else goTo(currentStep);
 
@@ -1213,6 +1212,7 @@ worker.onmessage = function (event) {
   var stepButtons = document.querySelectorAll("#stepper button");
 
   function goTo(step) {
+    var changed = step !== currentStep;
     currentStep = step;
     if (step > reachedStep) reachedStep = step;
     Object.keys(stepSections).forEach(function (key) {
@@ -1226,6 +1226,17 @@ worker.onmessage = function (event) {
       if (mine === step) button.setAttribute("aria-current", "step");
       else button.removeAttribute("aria-current");
     });
+    // A step change is a new screen, and it has to arrive at the top of itself.
+    // The PAGE is the scroll container now; it used to be the step box, which
+    // had its own overflow and its own scrollTop reset in the converter. When
+    // the box stopped clipping, that reset went quietly dead and nothing took
+    // its place: reading step 2 to the bottom and pressing Next put step 3 on
+    // screen at scrollY 380, with the stepper and the title above the fold.
+    //
+    // Only on a real change. The converter calls goTo(currentStep) to redraw
+    // the step somebody is already reading, and yanking the page to the top
+    // under them mid-sentence is its own bug.
+    if (changed) window.scrollTo(0, 0);
   }
 
   stepButtons.forEach(function (button) {

--- a/site/styles.css
+++ b/site/styles.css
@@ -294,9 +294,19 @@ section.tight {
   text-decoration: none;
   padding-block: 0.4rem;
   border-bottom: 1px solid transparent;
-  /* A bar is one line high. A label that wraps inside it is 49px of text in a
-     50px box, which is what ANKI DECKS did at 320, 390 and 414, and INSTALL THE
-     FIRMWARE did on /study/ at the same widths. */
+}
+/* A bar is one line high. A label that wraps inside it is 49px of text in a
+ * 50px box, which is what ANKI DECKS did at 320, 390 and 414, and INSTALL THE
+ * FIRMWARE did on /study/ at the same widths.
+ *
+ * Scoped to .has-menu, and that scope is the point. Unscoped, this rule made
+ * the no-script bar WORSE rather than leaving it alone: with the links still
+ * inline and no longer allowed to wrap, at 320px the last one ran to x=339 past
+ * a 320px viewport, and .topbar is position:fixed, so there is no scrollbar to
+ * reach it with -- the GitHub link simply could not be got at. Wrapping is ugly
+ * and reachable; overflowing a fixed bar is neither. Where the panel exists,
+ * nothing needs to wrap. */
+.topbar.has-menu .topnav a {
   white-space: nowrap;
 }
 .topnav a:hover,

--- a/site/styles.css
+++ b/site/styles.css
@@ -294,6 +294,10 @@ section.tight {
   text-decoration: none;
   padding-block: 0.4rem;
   border-bottom: 1px solid transparent;
+  /* A bar is one line high. A label that wraps inside it is 49px of text in a
+     50px box, which is what ANKI DECKS did at 320, 390 and 414, and INSTALL THE
+     FIRMWARE did on /study/ at the same widths. */
+  white-space: nowrap;
 }
 .topnav a:hover,
 .topnav a:focus-visible {
@@ -309,16 +313,68 @@ section.tight {
 .topnav-out svg {
   display: block;
 }
-/* The section jumps go first on a narrow bar; the source link and the action
- * are the two that survive. */
+/* --- the narrow bar ------------------------------------------------------
+ * Five labels of this length cannot share one line at 320px, and the bar used
+ * to answer that by dropping THE SHELF and PLAY NEARBY -- the two that lead to
+ * what the site is for -- and keeping ANKI DECKS, which then wrapped to two
+ * lines anyway. So below 720px the bar carries the name and one control, and
+ * every link moves into a panel under it where each has a line of its own.
+ *
+ * .has-menu is added by assets/topnav.js. Without it the bar keeps the old
+ * inline row, so a page whose scripts did not run is no worse off than it was
+ * rather than left with an inert button and no links at all.
+ */
+.topnav-toggle {
+  font: inherit;
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink);
+  background: none;
+  border: 1px solid var(--edge);
+  padding: 0.35rem 0.7rem;
+  cursor: pointer;
+  white-space: nowrap;
+  display: none;
+}
+.topnav-toggle[aria-expanded="true"] {
+  border-color: var(--ink);
+}
+
 @media (max-width: 720px) {
-  .topnav a[href="#shelf"],
-  .topnav a[href="#nearby"] {
+  .topbar.has-menu .topnav-toggle {
+    display: block;
+  }
+  .topbar.has-menu .topnav {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding: 0.2rem var(--gutter) 0.6rem;
+    background: var(--paper);
+    border-bottom: 1px solid var(--edge);
+    font-size: 0.75rem;
+  }
+  .topbar.has-menu .topnav.is-open {
+    display: flex;
+  }
+  .topbar.has-menu .topnav a {
+    padding-block: 0.75rem;
+  }
+  /* Without the script the old bar is what is left, and the section jumps are
+   * the two it can afford to drop. */
+  .topbar:not(.has-menu) .topnav a[href="#shelf"],
+  .topbar:not(.has-menu) .topnav a[href="#nearby"] {
     display: none;
   }
 }
 @media (max-width: 380px) {
-  .topnav-out span {
+  .topbar:not(.has-menu) .topnav-out span {
     display: none;
   }
 }


### PR DESCRIPTION
Two live breakages on https://crossplay.ma-r-s.com/, plus two claims that had
drifted from the code — and then nine findings from a cold review of the first
commit, three of which were in the tests it added.

## What was broken on the live site

**1. `/study/` step 2 dead-ended on its own primary button.** `.wiz-step` was
`position: absolute` inside a `min-height: 0` row, so a step taller than the
window was cropped by the row instead of growing the page.

| | before (live) | after |
|---|---|---|
| 1440x900, `elementFromPoint` at button centre (313, 853) | `DIV.wiz-foot` | `BUTTON.btn primary` |
| 1440x900, click at that centre | stayed on step 2 | → step 3 |
| 1280x720 | `hitCenter: null`, 0px visible, `scrollHeight == innerHeight == 720`, no scrollbar | reachable, `scrollHeight 943` vs 720 |
| `.wiz-step` position | `absolute` | `static` |

Confirmed in two independent browsers (playwright and the Browser pane).

**2. The mobile bar hid the product.** `ANKI DECKS` measured **49px in the 50px
bar** at 320, 390 and 414 (`INSTALL THE FIRMWARE` on `/study/` at 320, 360, 390,
414), while `THE SHELF` and `PLAY NEARBY` were hidden outright. Below 720px the
bar now carries the wordmark and a `Menu` button and every link moves into a
panel with a line each. Measured at 320/360/390/414/430/600/719/720: button
inside the bar, all links present, nothing wraps. At 721–1000: inline row, five
items at 31px, no horizontal overflow, no dead zone at the breakpoint.

**3.** `/report/`'s firmware placeholder said `1.12.9` while the site shipped
1.12.23. Derived now — it reads **1.12.24** today.

**4.** `/study/`'s footer said Pyodide was "served from this site" while
`worker.js` has asked jsDelivr first since 2026-08-25. **The claim was changed,
not the code**: the CDN is first because Vercel's own attack mitigation stranded
two real installs.

## The review findings, all nine closed

Three were tests that could not fail. That is the worse half of the diff, and it
is the half that decides whether the fix survives someone else's cleanup.

**1. The class contract was satisfied by a COMMENT.** The grep searched the
whole stylesheet, and `styles.css` says " * .has-menu is added by
assets/topnav.js" in prose. The reviewer renamed `.has-menu` in all four real
rules, left the comment and the `:not(.has-menu)` fallback, and got 0 failures
with the bug fully restored. `host-tests/site/css_selectors.py` now yields
selectors only, comments stripped — and `:not()` contents stripped with them,
because a class named only inside `:not()` is being excluded, not styled, which
is exactly what the mutation left behind.

**2. The three wizard-flow checks forbade three exact declarations.** The
reviewer reintroduced the identical breakage through three they did not name
(`overflow: clip`, `height: calc(...)`, `overflow: hidden`) and measured
`scrollHeight == innerHeight == 720` in Chrome with nothing reported — the exact
sentence the check's own comment claimed to prevent. Renaming `.wiz-step`
emptied the awk range and passed all three at once.
`host-tests/site/study_layout.py` replaces them: it refuses the **property**,
not a spelling of it (any `overflow*` on the body, container or step; any
`height` on the body or wizard; `minmax(0` on the container's row), it reads the
four class names **out of the markup**, and a missing rule block is a failure
rather than an empty range that passes.

**3. The placeholder check depended on attribute order.** Moving `placeholder`
in front of `id` restored `1.12.9` with 0 failures; renaming the id emptied the
capture just as quietly. Every placeholder in the file is scanned now.

**4. `white-space: nowrap` was global, making the no-script bar WORSE** — and
the previous commit message claimed the opposite. Links inline and unable to
wrap ran to x=339 past a 320px viewport with `.topbar` fixed, so the GitHub link
could not be reached at all. Scoped to `.topbar.has-menu`. Measured with JS
disabled: rightmost edge **300 at 320px, 370 at 390px**, no overflow, links
wrap as they used to.

**5. Clicking the wordmark left the panel open** — it is an anchor in the bar
but outside the panel. The close listener is on the bar now. Measured at
390x844: `aria-expanded` false after the click, and `elementFromPoint(195,150)`
returns the `H1`, not a panel link.

**6. Escape dropped focus to BODY.** It hands focus back to the toggle now.
Measured: Tab into the panel (focus on `THE SHELF`), Escape, `activeElement` is
the toggle button.

**7. The homepage made two identical GitHub API calls per load**, against the
60/hour per-IP limit `install.js`'s own comment cites as the reason it asks from
the visitor's browser. `assets/release.js` is the single asker. Measured with a
fresh context per load: home **1**, /report/ **1**, /study/ **0** — and the
Install button still reads "Install v1.12.24 on Xteink X4 Pro".

**8. `study.js`'s `scrollTop = 0` went dead** when the step box stopped being the
scroll container, so a step change carried the previous step's scroll. `goTo()`
resets the page scroll, and only on a real change. Measured at 1440x900,
1280x720 and 390x844: step 2 scrolled to the bottom (scrollY 43 / 223 / 891),
Next, step 3 at **scrollY 0** with stepper and title visible. And the redraw
guard: on step 2 at scrollY 150, clicking step 2's own tab leaves it at **150**;
clicking step 3's tab takes it to **0**.

**9. `--preview-chrome: 14rem` was the wide-window truth only.** Swept at step 3
from 721x600 to 1920x1080: the chrome is 274px where the foot's sentence fits on
one line and 285px at 1100x700 where it wraps, so step 3 overflowed by 4–11px
between 721 and 1100. **15rem** takes that to zero from 900x650 up, at a cost of
16px of panel height at 1440x900. Below 650px tall it still scrolls and no value
can stop it — the side column's own text is 330px against a 310px panel — so the
comment says that outright, to stop anyone re-tuning the token chasing three
sizes it cannot move.

## Tests

199 checks. **Twenty mutations were run against the new ones, the reviewer's six
among them, and every one went red** — with each mutation confirmed to have
actually applied first, because a mutation that silently fails to apply reads
exactly like a check that works.

What the suite still cannot see, said plainly in its own header: whether a
control is reachable, whether the wordmark closes the panel, whether Escape
lands focus on the button. Those are browser questions, they were answered in
browsers, and a static assertion pretending otherwise would be a fourth check
that cannot fail.

## Notes

- One probe of mine was wrong before it was right: the first version of the
  step-change test used `locator.click()`, which scrolls the target into view,
  so it measured the harness scrolling to 0 and blamed the page. Redone with a
  dispatched click.
- A rendered screenshot I opened showed the light theme as dark. Three
  instruments — `getComputedStyle`, `matchMedia` and the PNG's own pixels —
  agree it is light (background (245,242,234), 0.0 dark-ish fraction). The
  visual read was stale; there is no theme bug.

## Not verified

- No hardware; nothing here reaches a device image.
- Chrome only. The menu uses no engine-specific technique, but WebKit and
  Firefox are not installed here.
- The Vercel preview is behind the account's SSO wall, so this was verified
  against `site/serve.py` with the same COOP/COEP headers. There is no build
  step between those files and production.

## Out of scope on purpose

The homepage structure, the shelf section, the copy, the visual design and
`site/vercel.json` are untouched. `site/emulator/` and the emulator workflow are
another worker's; `origin/xteink` was **merged**, not rebased, and its
emulator-fetch checks in `run.sh` were kept alongside mine.

Card #239.
