### PR TITLE
docs(read-bridge): the Instapaper review landed, so say so in both places

### DIFF
--- a/server/read-bridge/README.md
+++ b/server/read-bridge/README.md
@@ -36,13 +36,23 @@ exist. A newly registered application is in **owner only** mode -- the keys
 work immediately for the account that registered them, and for nobody else
 until a separate "Submit for review" is approved.
 
-That distinction decides the deployment order, so it is worth stating as a
-rule rather than a fact: **`READ_ALLOWLIST` must stay the owner's address
-until the review is approved.** Opening it to `*` beforehand lets strangers
-reach the sign-in endpoint with credentials that CANNOT succeed -- Instapaper
-will refuse every one of them -- so it buys nothing and exposes the one
-endpoint that is a credential-stuffing oracle by construction. All risk, no
-capability. Open it when the review lands, and not before.
+**The review was approved (Mario, reported 2026-09-05).** So the rule this
+section used to carry -- keep `READ_ALLOWLIST` at the owner's address until it
+lands -- has been met and is now history rather than instruction. It is left
+here because the reasoning still explains the shape: before approval, opening
+to `*` let strangers reach the sign-in endpoint with credentials Instapaper
+would refuse anyway, which was all risk and no capability.
+
+What has NOT been met is the other precondition, and it is the one that
+matters now. Rate limiting still lives in `bridge/ratelimit.py`, in-process,
+and its own docstring says a distributed attacker defeats it. Behind an
+allowlist that hardly mattered; open to the world it is the whole exposure,
+because sign-in is a credential-stuffing oracle by construction. **Edge rate
+limiting is the gate on opening it now, not the review.**
+
+One thing to do rather than assume when it opens: watch a NON-OWNER sign-in
+actually succeed. That is the only evidence the approval is live, and it costs
+one attempt.
 
 ## Suites
 

--- a/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
+++ b/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
@@ -11,16 +11,20 @@ approved. The consumer key works immediately for the account that registered
 it and for nobody else. So the first deployment proves the whole path on one
 real account, and the service stays closed while it does.
 
-**Do not set `READ_ALLOWLIST=*` yet.** Until the review lands, an open
-allowlist lets strangers reach the sign-in endpoint with credentials Instapaper
-will refuse anyway: it adds no capability and exposes the one endpoint that is
-a credential-stuffing oracle by construction. Worse, the only real defence
-against distributed stuffing is Cloudflare-side rate limiting, which is still
-an open item -- the in-process limiters in `bridge/ratelimit.py` are defeated
-by an attacker with many addresses, by construction and by their own docstring.
+**Do not set `READ_ALLOWLIST=*` yet -- but the reason has changed.** Two
+conditions gated it. The review is one of them and it is DONE: Mario reports
+it was approved, recorded 2026-09-05 on board card #252. Non-owner sign-ins
+can now succeed, so an open allowlist would finally buy capability rather than
+only risk.
 
-Open it when BOTH are true: the review is approved, and the Cloudflare rules
-exist.
+The other condition still stands and is now the whole of it: the only real
+defence against distributed stuffing is Cloudflare-side rate limiting, and it
+does not exist. The in-process limiters in `bridge/ratelimit.py` are defeated
+by an attacker with many addresses, by construction and by their own
+docstring. Behind an allowlist that barely mattered; open to the world it is
+the entire exposure.
+
+Open it when the Cloudflare rules exist -- and in the same change, not after.
 
 ## Status: published 2026-09-03 at https://read.ma-r-s.com, allowlist still CLOSED
 
@@ -40,7 +44,8 @@ code and a pollToken, `GET /api/pair/poll` answers `{"pending":true}`, and
 What remains is step 5 (nobody has signed in and paired a real reader) and
 step 6 (opening the allowlist). **`READ_ALLOWLIST` is untouched and still the
 owner's address only.** Publishing the hostname does not change who may sign
-in, and it must not: see step 6.
+in, and it must not: see step 6 -- whose remaining blocker is the Cloudflare
+rate limiting, no longer the Instapaper review.
 
 The kill switch is one command, and it leaves everything else on the box
 alone:
@@ -155,10 +160,16 @@ problem and was a missing hash. Expect to spend time here rather than none.
 
 ## 6. Later: open it
 
-The app is **submitted for review** (pressed 2026-08-31). When approval lands,
-set `READ_ALLOWLIST=*` and add the Cloudflare rate-limiting rules IN THE SAME
-SITTING. Not before, and not one without the other -- an open allowlist without
-those rules is the credential-stuffing oracle this ordering exists to avoid.
+The app was submitted 2026-08-31 and **approval has landed** (Mario, recorded
+2026-09-05 on board card #252). So the half of this step that was waiting on
+somebody else is done, and what is left is ours: set `READ_ALLOWLIST=*` and add
+the Cloudflare rate-limiting rules IN THE SAME SITTING. Not one without the
+other -- an open allowlist without those rules is the credential-stuffing
+oracle this ordering exists to avoid.
+
+Verify the approval rather than trust this line: watch a NON-OWNER sign-in
+succeed. It costs one attempt and it is the only evidence that the keys now
+work for anyone but the registering account.
 
 ## Before any of it: can this machine even reach the pi?
 


### PR DESCRIPTION
Doc-only. `READ_ALLOWLIST` is untouched and no behaviour changes.

## The problem

Both `server/read-bridge/README.md` and `scripts/DEPLOY-RUNBOOK.md` still
forbade opening `READ_ALLOWLIST` until Instapaper's application review was
approved. **It was approved days ago** — Mario, 2026-09-05, now recorded on
board card #252.

The fact had never left a session transcript, so every document in the repo
still described the world before it.

That is worse than a merely stale doc. The README states it as a **rule**,
firmly and with its reasoning, and the runbook repeats it in three more places
— including step 6, the one someone actually follows during a deploy. A careful
person reading either would **refuse to open the allowlist**, correctly, on the
strength of a document that is out of date.

## What changed

Both now record the approval as done, and keep the reasoning as history rather
than deleting it — it still explains the shape. Before approval, opening to `*`
let strangers reach a sign-in endpoint whose every attempt Instapaper would
refuse: all risk, no capability.

The condition that has **not** been met is now stated more plainly, because it
is the whole gate: rate limiting lives in `bridge/ratelimit.py`, in-process,
and its own docstring says a distributed attacker defeats it. Behind an
allowlist that hardly mattered; open to the world it is the entire exposure.
Both documents now say **edge rate limiting is the blocker, not the review**,
and the runbook keeps its rule that the two land in the same sitting.

## And a verification step, in both

Watch a **non-owner sign-in succeed**. That is one attempt and it is the only
evidence the keys work for anyone but the registering account. This PR records
Mario's report, which nobody here can check against Instapaper — so the
documents say to confirm it rather than trust them.

## Verified

`./scripts_local/check.sh --tests`: all green, no skips.

Board card #269, child of #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)