### PR TITLE
fix: one type ladder, and every real title measured against the cut that draws it

### DIFF
--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -376,11 +376,20 @@ the 64px cut in BODY and `cardFaces()` puts 64 in TITLE and 44 in SMALL, so on
 those screens a hand-rolled "step down" steps up. `fittedTitle` orders its rungs
 by what `lineHeight()` answers, so it cannot.
 
-`host-tests/fittedtitle/` walks every real string the fork can put in a title
-through the real builders, with a target that measures in the real cuts, and
-fails on any string cut short while a cut that screen bound would have shown it
-whole. It also prints what no cut can save, per screen, so that number is
-visible rather than folded into a pass.
+`host-tests/fittedtitle/` walks the real strings of EIGHT screens -- the
+dungeon's guide and its 65 names, Forehead's categories, the linkplay games, Toy
+Battle's maps and how-to, every date the Connections header can format, the
+Hacker News reader's headlines and every comic title in the pack -- through the
+real builders, with a target that measures in the real cuts. It fails on any
+string cut short while a cut that screen bound would have shown it whole.
+
+Eight screens, not all of them: about twenty files call `headerBand` and this
+compiles seven of them. Adding yours is a line in its `run.sh` and a loop.
+
+It also prints, per screen, what no bound cut could have saved, and pins the one
+band that keeps a known exception. Those numbers are output rather than
+assertions on purpose: a gap published as a count is a gap somebody can act on,
+and a gap folded into a pass is one nobody sees.
 
 **A glyph the font does not have draws as nothing.** No box, no fallback.
 `EpdFont::getGlyph` answers nullptr and the pen does not advance, so the

--- a/docs/building-apps.md
+++ b/docs/building-apps.md
@@ -360,6 +360,28 @@ straight through the subtitle underneath it. The component supports a wrapping
 label _or_ a subtitle, never both; put the secondary value in the `value` slot
 instead, which sits in the band beside the label.
 
+**A title too wide for its box gets a smaller cut, not an ellipsis.** The rule
+is `ToyboxFonts.h`'s: pick the largest cut it fits in, walk the available cuts
+down, and only break a word when the smallest still overflows. Call
+`toybox::fittedTitle(target, text, width, style)` (`ui/ToyboxText.h`) -- it
+rewrites `style.font` to the cut it chose and hands back the string to draw,
+which is your string whenever a cut fitted.
+
+Header bands need no call at all: `toybox::headerBand()` fits the title for
+every one of them, against the width the header component really gives it
+rather than the page margins. What you must not do is write your own ladder.
+Six apps did, and all six walked the cuts by slot NAME -- TITLE, BODY, SMALL --
+which only descends while an app binds descending cuts. `bigNumberFaces()` puts
+the 64px cut in BODY and `cardFaces()` puts 64 in TITLE and 44 in SMALL, so on
+those screens a hand-rolled "step down" steps up. `fittedTitle` orders its rungs
+by what `lineHeight()` answers, so it cannot.
+
+`host-tests/fittedtitle/` walks every real string the fork can put in a title
+through the real builders, with a target that measures in the real cuts, and
+fails on any string cut short while a cut that screen bound would have shown it
+whole. It also prints what no cut can save, per screen, so that number is
+visible rather than folded into a pass.
+
 **A glyph the font does not have draws as nothing.** No box, no fallback.
 `EpdFont::getGlyph` answers nullptr and the pen does not advance, so the
 character is not merely wrong, it is absent. A real Hacker News comment

--- a/host-tests/fittedtitle/corpus.py
+++ b/host-tests/fittedtitle/corpus.py
@@ -29,16 +29,24 @@ REPO = HERE.parents[1]
 
 
 def c_string(s):
+    """A C string literal of the UTF-8 BYTES, escaped in three-digit octal.
+
+    Bytes, because a title is handed to the app as UTF-8 and the fold that
+    cleans it up runs on bytes. Octal, because \\x eats every hex digit that
+    follows it: "GPT\\u20115.6" came out as \\x20115 -- one escape, out of
+    range, and the build stopped. \\ooo stops after three digits and cannot.
+    """
     out = []
-    for ch in s:
+    for byte in s.encode("utf-8"):
+        ch = chr(byte)
         if ch == '"':
             out.append('\\"')
         elif ch == "\\":
             out.append("\\\\")
-        elif 0x20 <= ord(ch) < 0x7F:
+        elif 0x20 <= byte < 0x7F:
             out.append(ch)
         else:
-            out.append("\\x%02x" % ord(ch))
+            out.append("\\%03o" % byte)
     return '"%s"' % "".join(out)
 
 
@@ -52,6 +60,24 @@ def link_titles():
     return sorted(set(found))
 
 
+def hn_headlines():
+    """Real Hacker News headlines, from the front page the emulator ships.
+
+    Thirty of them, captured from the live API, and the only corpus here that is
+    somebody else's prose rather than the fork's own strings -- which is exactly
+    what the reader's band carries. They are stored RAW; the test folds them
+    with utf8FoldTypography the way HackerNewsActivity does on the way in, so
+    the curly quotes and the dash family are handled by the real function.
+    """
+    import json
+
+    path = REPO / "tools_local/wasm/sdcard/canned/hn-front.json"
+    if not path.is_file():
+        return []
+    hits = json.loads(path.read_text(encoding="utf-8")).get("hits", [])
+    return [h["title"] for h in hits if h.get("title")]
+
+
 def pack_format_version():
     """The layout XkcdCore.h reads, so this parser and the device agree."""
     src = (REPO / "src/apps_local/xkcd/XkcdCore.h").read_text()
@@ -59,6 +85,21 @@ def pack_format_version():
     if not m:
         sys.exit("cannot find kFormatVersion in XkcdCore.h")
     return int(m.group(1))
+
+
+def table_titles(path, opener, pattern):
+    """Titles out of a constexpr table, so a test need not read them off the panel.
+
+    Two corpora used to take their expected string from the run the header had
+    just drawn -- which is the fitted string, so `drawn == expected` held no
+    matter how badly the title had been cut. A cold review proved it by
+    truncating every title to five characters and watching both stay green.
+    Read from the table, they cannot be circular.
+    """
+    src = (REPO / path).read_text(encoding="utf-8", errors="replace")
+    block = src[src.index(opener):]
+    block = block[: block.index("\n};")]
+    return re.findall(pattern, block)
 
 
 def xkcd_pack():
@@ -161,6 +202,17 @@ def bindings():
 def main():
     out = pathlib.Path(sys.argv[1])
     link = link_titles()
+    headlines = hn_headlines()
+    guide = table_titles(
+        "src/apps_local/dungeon/DungeonScreens.cpp",
+        "constexpr GuidePage kGuide[] = {",
+        r'\{\s*"([^"]+)",\s*\n?\s*"',
+    )[::2]
+    walk = table_titles(
+        "src/apps_local/toybattle/ToyBattleHowTo.cpp",
+        "kWalkPages[] = {",
+        r'\{"([^"]+)",\s*(?:true|false),',
+    )
     label, xkcd = xkcd_pack()
     ids, faces, values = bindings()
 
@@ -186,6 +238,28 @@ def main():
     lines += [
         "};",
         "inline constexpr int kLinkGameTitleCount = %d;" % len(link),
+        "",
+        "inline constexpr const char* kHnHeadlines[] = {",
+    ]
+    lines += ["    %s," % c_string(t) for t in headlines]
+    lines += [
+        '    "",  // never empty, so the array is well formed with no capture',
+        "};",
+        "inline constexpr int kHnHeadlineCount = %d;" % len(headlines),
+        "",
+        "inline constexpr const char* kDungeonGuideTitles[] = {",
+    ]
+    lines += ["    %s," % c_string(t) for t in guide]
+    lines += [
+        "};",
+        "inline constexpr int kDungeonGuideTitleCount = %d;" % len(guide),
+        "",
+        "inline constexpr const char* kToyBattleHowToTitles[] = {",
+    ]
+    lines += ["    %s," % c_string(t) for t in walk]
+    lines += [
+        "};",
+        "inline constexpr int kToyBattleHowToTitleCount = %d;" % len(walk),
         "",
         "inline constexpr const char* kXkcdPackLabel = %s;" % c_string(label),
         "inline constexpr const char* kXkcdTitles[] = {",
@@ -234,8 +308,9 @@ def main():
     ]
     out.write_text("\n".join(lines), encoding="utf-8")
     print(
-        "corpus: %d link game titles, %d xkcd titles from %s; %d font ids, %d face sets"
-        % (len(link), len(xkcd), label, len(ids), len(faces)),
+        "corpus: %d link game titles, %d HN headlines, %d dungeon guide pages, %d how-to pages, %d xkcd titles from %s;"
+        " %d font ids, %d face sets"
+        % (len(link), len(headlines), len(guide), len(walk), len(xkcd), label, len(ids), len(faces)),
         file=sys.stderr,
     )
 

--- a/host-tests/fittedtitle/corpus.py
+++ b/host-tests/fittedtitle/corpus.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Emit the corpora this suite walks, DERIVED from where they really live.
+
+Two of the five corpora cannot be reached from the test's own C++: the link
+game titles are one string per game Activity header, and the xkcd titles are in
+a pack on the card rather than in the repository. Everything else the test
+calls directly (forehead::kCategories, toybattle::terrainAt, the dungeon guide
+and Connections' own formatDate), because a corpus copied into a test is a
+corpus that stops matching the app the day somebody adds a game.
+
+    host-tests/fittedtitle/corpus.py <out.h>
+
+The xkcd pack is looked for in $XKCD_PACK, then the workspace card, then the
+emulator's small canned pack. WHICH ONE WAS USED IS COMPILED IN and printed by
+the suite: a run over 32 comics and a run over 3279 are not the same evidence,
+and a suite that did not say which it had would let the small one pass for the
+big one.
+"""
+
+import os
+import pathlib
+import re
+import struct
+import subprocess
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO = HERE.parents[1]
+
+
+def c_string(s):
+    out = []
+    for ch in s:
+        if ch == '"':
+            out.append('\\"')
+        elif ch == "\\":
+            out.append("\\\\")
+        elif 0x20 <= ord(ch) < 0x7F:
+            out.append(ch)
+        else:
+            out.append("\\x%02x" % ord(ch))
+    return '"%s"' % "".join(out)
+
+
+def link_titles():
+    """Every game that can show the link screen, from its own Activity header."""
+    found = []
+    pattern = re.compile(r'linkGameTitle\(\)\s*const\s*override\s*\{\s*return\s*"([^"]*)"')
+    for path in sorted((REPO / "src" / "apps_local").rglob("*.h")):
+        for m in pattern.finditer(path.read_text(encoding="utf-8", errors="replace")):
+            found.append(m.group(1))
+    return sorted(set(found))
+
+
+def pack_format_version():
+    """The layout XkcdCore.h reads, so this parser and the device agree."""
+    src = (REPO / "src/apps_local/xkcd/XkcdCore.h").read_text()
+    m = re.search(r"kFormatVersion\s*=\s*(\d+)", src)
+    if not m:
+        sys.exit("cannot find kFormatVersion in XkcdCore.h")
+    return int(m.group(1))
+
+
+def xkcd_pack():
+    """-> (label, [titles]). Empty list when no pack is reachable."""
+    candidates = []
+    if os.environ.get("XKCD_PACK"):
+        candidates.append(pathlib.Path(os.environ["XKCD_PACK"]))
+    # The workspace card. Walking up from this checkout finds it from a normal
+    # worktree and NOT from the throwaway one check.sh --committed builds in,
+    # which lives under TMPDIR -- so the gate would silently fall through to the
+    # 32-comic canned pack while a developer's run walked 3279. Asking git for
+    # the common directory finds the real repository from either, and its
+    # parents are where the card sits.
+    roots = [REPO]
+    try:
+        common = subprocess.run(
+            ["git", "-C", str(REPO), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        if common:
+            roots.append(pathlib.Path(common))
+    except Exception:  # no git, no repo, no matter: the in-repo pack still answers
+        pass
+    for root in roots:
+        for up in list(root.parents)[:4]:
+            candidates.append(up / "fs_mario" / "xkcd")
+            candidates.append(up / "fs_agent" / "xkcd")
+    candidates.append(REPO / "tools_local" / "wasm" / "sdcard" / "xkcd")
+
+    for pack in candidates:
+        index = pack / "index.dat"
+        text = pack / "text.dat"
+        if not index.is_file() or not text.is_file():
+            continue
+        idx = index.read_bytes()
+        txt = text.read_bytes()
+        if len(idx) < 16:
+            continue
+        magic, version, _reserved, count, _max = struct.unpack_from("<IHHII", idx, 0)
+        # The version is CHECKED, not read for the label. This parser knows one
+        # record layout, and a pack of another version is not a smaller corpus,
+        # it is garbage that looks like one: the canned v2 pack in the repo has
+        # 32 records and this walked it into 2 "titles" and reported them as a
+        # corpus. The device rejects a stale pack whole (XkcdCore.h,
+        # kFormatVersion) and so does this, and the number it rejects on is read
+        # from that header rather than typed here.
+        if magic != 0x44434B58 or version != pack_format_version():
+            continue
+        titles = []
+        for i in range(count):
+            at = 16 + i * 40
+            if at + 40 > len(idx):
+                break
+            (text_offset,) = struct.unpack_from("<I", idx, at + 16)
+            end = txt.find(b"\0", text_offset)
+            if end < 0:
+                break
+            titles.append(txt[text_offset:end].decode("ascii", "replace"))
+        if titles:
+            return ("%s (format v%d)" % (pack, version), titles)
+    return ("NO PACK FOUND (none reachable at format v%d)" % pack_format_version(), [])
+
+
+def bindings():
+    """Which cut each font id really is, and which three each Faces set binds.
+
+    BOTH ARE DERIVED, and that is not fussiness. A test that wrote down
+    "kDisplayFontId is toybox_30" would keep passing after somebody rebound it,
+    measuring one face while the app drew another -- and the whole value of
+    this suite is that it measures the real cut. ToyboxFonts.cpp's
+    insertFont() calls and ToyboxTheme.h's Faces functions are the two places
+    those facts exist, so they are the two places these are read from.
+    """
+    fonts_h = (REPO / "src/apps_local/ui/ToyboxFonts.h").read_text()
+    fonts_src = (REPO / "src/apps_local/ui/ToyboxFonts.cpp").read_text()
+    theme_src = (REPO / "src/apps_local/ui/ToyboxTheme.h").read_text()
+
+    data_of = dict(re.findall(r"^EpdFont\s+(\w+)\(&(\w+)\);", fonts_src, re.M))
+    font_of = dict(re.findall(r"^EpdFontFamily\s+(\w+)\(&(\w+)\);", fonts_src, re.M))
+    ids = []
+    for font_id, family in re.findall(r"insertFont\((k\w+),\s*(\w+)\)", fonts_src):
+        ids.append((font_id, data_of[font_of[family]]))
+
+    struct = re.search(r"struct Faces \{([^}]*)\}", theme_src).group(1)
+    default = re.findall(r"(\w+)\s*=\s*(k\w+);", struct)
+    default = [v for _, v in default]
+    faces = []
+    for name, args in re.findall(r"inline Faces (\w+)\(\)\s*\{\s*return Faces\{([^}]*)\};", theme_src):
+        slots = [a.strip() for a in args.split(",") if a.strip()] or default
+        if len(slots) != 3:
+            sys.exit("Faces %s does not name three slots: %r" % (name, args))
+        faces.append((name, slots))
+    # The id VALUES too: ToyboxFonts.h declares them beside a GfxRenderer
+    # include, so a freestanding suite cannot include it to learn them.
+    values = re.findall(r"constexpr int (k\w+FontId) = (0x[0-9A-Fa-f']+);", fonts_h)
+    values = [(name, value.replace("'", "")) for name, value in values]
+    return ids, faces, values
+
+
+def main():
+    out = pathlib.Path(sys.argv[1])
+    link = link_titles()
+    label, xkcd = xkcd_pack()
+    ids, faces, values = bindings()
+
+    lines = [
+        "// Generated by host-tests/fittedtitle/corpus.py. Do not edit; do not commit.",
+        "#pragma once",
+        "",
+        "// Its own font includes, because it cannot rely on being included after",
+        "// them: clang-format sorts an include block alphabetically, so a source",
+        "// file's comment promising an order is a comment the formatter deletes the",
+        "// meaning of. (It did, and the build said 'undeclared identifier",
+        "// instrument_24' with nothing pointing at the formatter.)",
+    ]
+    for face in sorted({data for _id, data in ids}):
+        lines.append('#include "fonts/%s.h"' % face)
+    lines += [
+        "",
+        "namespace fitted {",
+        "",
+        "inline constexpr const char* kLinkGameTitles[] = {",
+    ]
+    lines += ["    %s," % c_string(t) for t in link]
+    lines += [
+        "};",
+        "inline constexpr int kLinkGameTitleCount = %d;" % len(link),
+        "",
+        "inline constexpr const char* kXkcdPackLabel = %s;" % c_string(label),
+        "inline constexpr const char* kXkcdTitles[] = {",
+    ]
+    lines += ["    %s," % c_string(t) for t in xkcd]
+    lines += [
+        '    "",  // never empty, so the array is well formed with no pack',
+        "};",
+        "inline constexpr int kXkcdTitleCount = %d;" % len(xkcd),
+        "",
+        "// The font ids themselves. ToyboxFonts.h declares them next to a",
+        "// GfxRenderer include, so a freestanding suite reads them from here.",
+    ]
+    for name, value in values:
+        lines.append("inline constexpr int %s = %s;" % (name, value))
+    lines += [
+        "",
+        "// The cut behind each font id, from ToyboxFonts.cpp's insertFont calls.",
+        "inline const EpdFontData* dataForId(const int id) {",
+    ]
+    for font_id, data in ids:
+        lines.append("  if (id == %s) return &%s;" % (font_id, data))
+    lines += [
+        "  return nullptr;",
+        "}",
+        "",
+        "// The three slots each Faces set binds, from ToyboxTheme.h.",
+        "struct FaceSet {",
+        "  const char* name;",
+        "  int small;",
+        "  int body;",
+        "  int title;",
+        "};",
+        "inline constexpr FaceSet kFaceSets[] = {",
+    ]
+    for name, slots in faces:
+        lines.append(
+            '    {"%s", %s, %s, %s},' % (name, slots[0], slots[1], slots[2])
+        )
+    lines += [
+        "};",
+        "inline constexpr int kFaceSetCount = %d;" % len(faces),
+        "",
+        "}  // namespace fitted",
+        "",
+    ]
+    out.write_text("\n".join(lines), encoding="utf-8")
+    print(
+        "corpus: %d link game titles, %d xkcd titles from %s; %d font ids, %d face sets"
+        % (len(link), len(xkcd), label, len(ids), len(faces)),
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/host-tests/fittedtitle/real_target.h
+++ b/host-tests/fittedtitle/real_target.h
@@ -1,0 +1,162 @@
+#pragma once
+
+// A DrawTarget that answers with the REAL font, and truncates the way the
+// device really truncates.
+//
+// host-tests/ui's FakeTarget answers a flat ten pixels a character and records
+// whatever string it is handed. Both are deliberate there and both are fatal
+// here: a flat cell cannot tell one cut from another, so a font ladder measured
+// against it always picks the first rung; and a target that records the string
+// it was given can never see a title being cut, because the cutting happens
+// inside the renderer, after the builder has handed the string over.
+//
+// So this one:
+//
+//   * measures with EpdFont, over the generated cuts in src/apps_local/ui/fonts,
+//     which is the same code and the same data drawText uses on the panel;
+//   * reproduces GfxRendererTarget::text()'s single-line path, INCLUDING
+//     GfxRenderer::truncatedText -- ellipsis chosen by asking the resolved face
+//     whether it carries U+2026 and falling back to "..." when it does not;
+//   * records what it would actually have DRAWN, not what it was asked to draw.
+//
+// The difference between those last two is the whole instrument: `drawn ==
+// asked` is the property "the panel shows the whole string", and nothing that
+// measures in fake pixels can express it.
+
+#include <EpdFont.h>
+#include <FreeInkUI.h>
+#include <Utf8.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace fui = freeink::ui;
+
+namespace fitted {
+
+// The three slots a GfxRendererTarget binds (ToyboxTheme.h). A screen's Faces
+// set is exactly this triple, so a test binds one the same way the app does.
+struct Faces {
+  const EpdFontData* small;
+  const EpdFontData* body;
+  const EpdFontData* title;
+};
+
+struct TextRun {
+  fui::Rect rect;
+  std::string asked;  // what the builder handed over
+  std::string drawn;  // what the panel would show
+  fui::FontId font;
+  fui::Color color;
+  bool cut() const { return asked != drawn; }
+};
+
+class RealTarget : public fui::DrawTarget {
+ public:
+  explicit RealTarget(const Faces& faces) : faces_(faces) {}
+
+  std::vector<TextRun> texts;
+
+  const EpdFontData* face(const fui::FontId slot) const {
+    switch (slot) {
+      case fui::FONT_SLOT_TITLE:
+        return faces_.title;
+      case fui::FONT_SLOT_BODY:
+        return faces_.body;
+      default:
+        // fui components resolve only the three slots and fall back to BODY,
+        // which is the rule in the fui-font-slot-fallback memory. A test that
+        // answered some fourth id would be measuring a face no component can
+        // ever ask for.
+        return slot == fui::FONT_SLOT_SMALL ? faces_.small : faces_.body;
+    }
+  }
+
+  fui::Size measureText(const fui::FontId font, const char* text, const fui::TextStyle) const override {
+    if (text == nullptr || *text == '\0') return fui::Size{0, lineHeight(font)};
+    int w = 0, h = 0;
+    EpdFont(face(font)).getTextDimensions(text, &w, &h);
+    return fui::Size{static_cast<int16_t>(w), lineHeight(font)};
+  }
+
+  int16_t lineHeight(const fui::FontId font) const override { return static_cast<int16_t>(face(font)->advanceY); }
+
+  // GfxRenderer::truncatedText, reproduced. The ellipsis is chosen by asking
+  // the face -- of the six Toybox cuts only toybox_10 carries U+2026 -- because
+  // the marker's width feeds the fitting loop, so a marker picked at draw time
+  // would overflow the box the truncation exists to respect.
+  std::string truncated(const fui::FontId font, const char* text, const int16_t maxWidth) const {
+    std::string item(text == nullptr ? "" : text);
+    const EpdFont f(face(font));
+    const char* ellipsis = f.hasCodepoint(0x2026) ? "\xe2\x80\xa6" : "...";
+    if (measureText(font, item.c_str(), fui::TextStyle{}).width <= maxWidth) return item;
+    while (!item.empty() && measureText(font, (item + ellipsis).c_str(), fui::TextStyle{}).width >= maxWidth) {
+      utf8RemoveLastChar(item);
+    }
+    return item.empty() ? std::string(ellipsis) : item + ellipsis;
+  }
+
+  void text(const fui::Rect rect, const char* text, const fui::TextStyle style) override {
+    if (text == nullptr) return;
+    const uint8_t maxLines = style.maxLines > 0 ? style.maxLines : 1;
+    std::string drawn(text);
+    if (measureText(style.font, text, style).width > rect.width) {
+      if (maxLines == 1) {
+        drawn = truncated(style.font, text, rect.width);
+      } else {
+        // The wrapped path joins its lines back with a space, so a wrapped run
+        // that lost nothing compares equal to what it was asked to draw and one
+        // that was cut does not. Only the last line can carry the marker.
+        drawn = wrapped(style.font, text, rect.width, maxLines);
+      }
+    }
+    texts.push_back(TextRun{rect, std::string(text), drawn, style.font, style.color});
+  }
+
+  void fill(fui::Rect, fui::Paint, uint8_t = 0, uint8_t = 0xFF) override {}
+  void stroke(fui::Rect, fui::Paint, uint8_t, uint8_t = 0, uint8_t = 0xFF) override {}
+  void line(fui::Point, fui::Point, uint8_t, fui::Paint) override {}
+  void triangle(fui::Point, fui::Point, fui::Point, fui::Paint) override {}
+  void bitmap(fui::Rect, fui::BitmapRef, fui::BitmapMode, fui::Paint = {},
+              fui::Rotation = fui::Rotation::None) override {}
+
+ private:
+  // GfxRenderer::wrappedText, reduced to what this suite asks of it: greedy
+  // break on spaces, hard cut of a word wider than the line, ellipsis on the
+  // last line when anything is left over.
+  std::string wrapped(const fui::FontId font, const char* text, const int16_t maxWidth, const int maxLines) const {
+    const EpdFont f(face(font));
+    const std::string marker = f.hasCodepoint(0x2026) ? "\xe2\x80\xa6" : "...";
+    std::string remaining(text);
+    std::string out;
+    int lines = 0;
+    while (!remaining.empty() && lines < maxLines) {
+      if (measureText(font, remaining.c_str(), fui::TextStyle{}).width <= maxWidth) {
+        out += (out.empty() ? "" : " ") + remaining;
+        return out;
+      }
+      if (lines + 1 == maxLines) {
+        out += (out.empty() ? "" : " ") + truncated(font, remaining.c_str(), maxWidth);
+        return out;
+      }
+      size_t split = std::string::npos;
+      for (size_t at = remaining.find(' '); at != std::string::npos; at = remaining.find(' ', at + 1)) {
+        if (measureText(font, remaining.substr(0, at).c_str(), fui::TextStyle{}).width > maxWidth) break;
+        split = at;
+      }
+      if (split == std::string::npos) {
+        out += (out.empty() ? "" : " ") + truncated(font, remaining.c_str(), maxWidth);
+        return out;
+      }
+      out += (out.empty() ? "" : " ") + remaining.substr(0, split);
+      remaining = remaining.substr(split + 1);
+      ++lines;
+    }
+    return out;
+  }
+
+  Faces faces_;
+};
+
+}  // namespace fitted

--- a/host-tests/fittedtitle/run.sh
+++ b/host-tests/fittedtitle/run.sh
@@ -48,6 +48,7 @@ python3 ./corpus.py "$BUILD_DIR/corpus.generated.h"
   -I../../lib/Utf8 -I../../lib/EpdFont \
   -I"$APPS/ui" -I"$APPS/connections" -I"$APPS/dungeon" -I"$APPS/forehead" \
   -I"$APPS/link" -I"$APPS/toybattle" -I"$APPS/xkcd" -I"$APPS/player" \
+  -I"$APPS/hackernews" \
   "$SDK/src/FreeInkUI.cpp" \
   ../../lib/Utf8/Utf8.cpp \
   ../../lib/EpdFont/EpdFont.cpp \
@@ -56,6 +57,7 @@ python3 ./corpus.py "$BUILD_DIR/corpus.generated.h"
   "$APPS/dungeon/DungeonCore.cpp" \
   "$APPS/dungeon/DungeonScreens.cpp" \
   "$APPS/forehead/ForeheadCore.cpp" \
+  "$APPS/hackernews/HackerNewsScreens.cpp" \
   "$APPS/forehead/ForeheadScreens.cpp" \
   "$APPS/link/LinkScreens.cpp" \
   "$APPS/player/PlayerAvatar.cpp" \

--- a/host-tests/fittedtitle/run.sh
+++ b/host-tests/fittedtitle/run.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Every title in the fork, measured in the cut that will really draw it.
+#
+#   host-tests/fittedtitle/run.sh
+#
+# Two things make this different from host-tests/ui, which already builds these
+# same screen files:
+#
+#   * the DrawTarget measures with the REAL cuts (EpdFont over
+#     src/apps_local/ui/fonts) and reproduces GfxRenderer's truncation, so it
+#     can see a title being cut. host-tests/ui's target answers a flat ten
+#     pixels a character and records whatever string it is handed, which is
+#     right for layout tests and blind to this entirely.
+#
+#   * the corpora are COMPLETE and DERIVED, never sampled and never copied:
+#     corpus.py reads the linkplay titles out of the game Activities and the
+#     comic titles out of the pack on the card, and the test walks Forehead's,
+#     Toy Battle's and the dungeon's own tables and every date Connections can
+#     format. A corpus written into a test is a corpus that stops matching the
+#     app the day somebody adds a game.
+#
+# No PlatformIO and no device: the screen builders are freestanding C++17 and
+# EpdFont/Utf8 are too. If a builder ever reaches for GfxRenderer or the card,
+# this build fails loudly rather than the check quietly becoming device-only.
+set -e
+cd "$(dirname "$0")"
+# Keyed to this checkout, not just the suite name: two worktrees sharing one
+# build dir means one tree can run -- and pass -- a binary the other built.
+BUILD_DIR="${TMPDIR:-/tmp}/$(basename "${CXX:-c++}")-fittedtitle-tests-$(cd ../.. && pwd | cksum | cut -d" " -f1)"
+mkdir -p "$BUILD_DIR"
+SDK=../../freeink-sdk/libs/ui/FreeInkUI
+ICONS=../../freeink-sdk/libs/assets/Icons
+APPS=../../src/apps_local
+
+python3 ./corpus.py "$BUILD_DIR/corpus.generated.h"
+
+# Three warnings silenced, all of them GCC-only noise on code this suite only
+# compiles in order to drive it. -Wno-missing-field-initializers: the font
+# headers are GENERATED aggregates that stop at the last field fontconvert.py
+# has a value for, exactly as host-tests/typefold explains. -Wno-comment and
+# -Wno-format-truncation: the same two host-tests/ui silences, for the same
+# screen files -- without them GCC fails this build on a snprintf in
+# ConnectionsScreens.cpp that has nothing to do with fitting a title.
+"${CXX:-c++}" -std=c++17 -O2 -Wall -Wextra -Werror -Wno-comment -Wno-format-truncation \
+  -Wno-missing-field-initializers \
+  -I"$BUILD_DIR" -I. \
+  -I"$SDK/include" -I"$ICONS/include" \
+  -I../../lib/Utf8 -I../../lib/EpdFont \
+  -I"$APPS/ui" -I"$APPS/connections" -I"$APPS/dungeon" -I"$APPS/forehead" \
+  -I"$APPS/link" -I"$APPS/toybattle" -I"$APPS/xkcd" -I"$APPS/player" \
+  "$SDK/src/FreeInkUI.cpp" \
+  ../../lib/Utf8/Utf8.cpp \
+  ../../lib/EpdFont/EpdFont.cpp \
+  "$APPS/connections/ConnectionsCore.cpp" \
+  "$APPS/connections/ConnectionsScreens.cpp" \
+  "$APPS/dungeon/DungeonCore.cpp" \
+  "$APPS/dungeon/DungeonScreens.cpp" \
+  "$APPS/forehead/ForeheadCore.cpp" \
+  "$APPS/forehead/ForeheadScreens.cpp" \
+  "$APPS/link/LinkScreens.cpp" \
+  "$APPS/player/PlayerAvatar.cpp" \
+  "$APPS/player/PlayerName.cpp" \
+  "$APPS/toybattle/ToyBattleCore.cpp" \
+  "$APPS/toybattle/ToyBattleFlow.cpp" \
+  "$APPS/toybattle/ToyBattleHowTo.cpp" \
+  "$APPS/toybattle/ToyBattleMenus.cpp" \
+  "$APPS/toybattle/ToyBattleScreens.cpp" \
+  "$APPS/xkcd/XkcdScreens.cpp" \
+  test_fittedtitle.cpp -o "$BUILD_DIR/test_fittedtitle"
+"$BUILD_DIR/test_fittedtitle"

--- a/host-tests/fittedtitle/test_fittedtitle.cpp
+++ b/host-tests/fittedtitle/test_fittedtitle.cpp
@@ -1,0 +1,433 @@
+// A title must show its whole string. Asked of every real string there is.
+//
+// Mario's rule, given on 2026-09-05 about Connections tiles: "a tile needs to
+// show the whole text, no exceptions." ToyboxFonts.h has stated the mechanism
+// for it since the reading cuts were added -- "pick the largest cut it fits in,
+// walking the available cuts down, and only break a word when the smallest
+// still overflows" -- and until this suite there was no toybox:: function that
+// did it. Six apps had written their own ladder and the rest of the fork had
+// none, so a title handed to a header band was cut by the renderer instead.
+//
+// WHAT THIS SUITE IS FOR, and why it is not a list of examples: every corpus
+// below is COMPLETE. Every dungeon guide page, every Forehead category, every
+// linkplay game, every Toy Battle map, every date the Connections header can
+// format, and every comic title in the pack on the card. A sampled suite would
+// pass on the day somebody adds the one long name -- which is precisely how
+// "CURSED CEMETERY" reached a panel as "CURSED CEMETER".
+//
+// The instrument is real_target.h: real cuts, real EpdFont measurement, and the
+// renderer's own truncation reproduced, so the question it answers is "what
+// would the panel show", not "what did the builder pass".
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "ConnectionsScreens.h"
+#include "DungeonPuzzles.h"
+#include "DungeonScreens.h"
+#include "ForeheadScreens.h"
+#include "ForeheadWords.h"
+#include "LinkScreens.h"
+#include "ToyBattleCore.h"
+#include "ToyBattleMenus.h"
+#include "ToyBattleScreens.h"
+#include "ToyboxScreen.h"
+#include "ToyboxText.h"
+#include "XkcdScreens.h"
+#include "corpus.generated.h"
+#include "fonts/instrument_10.h"
+#include "fonts/instrument_13.h"
+#include "fonts/instrument_24.h"
+#include "fonts/reading_serif_11.h"
+#include "fonts/reading_serif_14.h"
+#include "fonts/reading_serif_bold_12.h"
+#include "fonts/reading_serif_bold_16.h"
+#include "fonts/toybox_10.h"
+#include "fonts/toybox_14.h"
+#include "fonts/toybox_20.h"
+#include "fonts/toybox_30.h"
+#include "fonts/toybox_44.h"
+#include "fonts/toybox_64.h"
+#include "real_target.h"
+
+namespace {
+
+int checks = 0;
+int failed = 0;
+
+// What the suite actually walked, counted rather than described. A total
+// written into a commit message is a total that was right once.
+int walked = 0;
+int residual = 0;
+
+void ok(const bool condition, const std::string& what) {
+  ++checks;
+  if (!condition) {
+    ++failed;
+    std::printf("FAIL fittedtitle  %s\n", what.c_str());
+  }
+}
+
+// The panel, and the bezel the X4 Pro's glass really hides (docs/bezel-insets).
+// Not an empty safe area: an empty one is what lets a doubled margin pass
+// unnoticed, and the header band's ink top is derived from it.
+fui::DeviceContext panel() {
+  fui::DeviceContext device;
+  device.width = 480;
+  device.height = 800;
+  device.hasTouch = true;
+  device.safeArea = fui::Insets{10, 1, 0, 1};
+  return device;
+}
+
+fitted::Faces facesNamed(const char* name) {
+  for (int i = 0; i < fitted::kFaceSetCount; ++i) {
+    const fitted::FaceSet& set = fitted::kFaceSets[i];
+    if (std::strcmp(set.name, name) != 0) continue;
+    return fitted::Faces{fitted::dataForId(set.small), fitted::dataForId(set.body), fitted::dataForId(set.title)};
+  }
+  std::printf("FAIL fittedtitle  no Faces set named %s in ToyboxTheme.h\n", name);
+  ++failed;
+  return fitted::Faces{&toybox_10, &toybox_20, &toybox_30};
+}
+
+// One screen, drawn for real.
+struct Paint {
+  explicit Paint(const char* faces) : target(facesNamed(faces)) {}
+  fitted::RealTarget target;
+  toybox::Interactions interactions;
+};
+
+// The run that carries `source`, wherever on the screen it ended up.
+//
+// A title can lose its tail two ways and they look identical on the panel: the
+// app shortens it before handing it over (Hacker News and the xkcd bar both
+// do), or the renderer truncates what it was handed. Matching on "the drawn
+// text is a prefix of the source, ignoring any ellipsis" catches both with one
+// rule, which is the point -- from a reader's side they are one defect.
+const fitted::TextRun* carrier(const std::vector<fitted::TextRun>& runs, const std::string& source) {
+  const fitted::TextRun* best = nullptr;
+  size_t bestLength = 0;
+  for (const fitted::TextRun& run : runs) {
+    std::string body = run.drawn;
+    for (const char* mark : {"\xe2\x80\xa6", "..."}) {
+      const size_t len = std::strlen(mark);
+      if (body.size() >= len && body.compare(body.size() - len, len, mark) == 0) {
+        body.resize(body.size() - len);
+        break;
+      }
+    }
+    while (!body.empty() && body.back() == ' ') body.pop_back();
+    if (body.empty() || source.compare(0, body.size(), body) != 0) continue;
+    if (best == nullptr || body.size() > bestLength) {
+      best = &run;
+      bestLength = body.size();
+    }
+  }
+  return best;
+}
+
+// The assertion, for one string on one screen.
+//
+// TWO NUMBERS, and only one of them is gated, because only one of them is a
+// property this change can construct.
+//
+//   avoidable  a string reached the panel short WHILE ONE OF THE CUTS THIS
+//              SCREEN BOUND WOULD HAVE SHOWN IT WHOLE. That is the rule
+//              ToyboxFonts.h states and toybox::fittedTitle now keeps, and it
+//              is what fails the suite. Zero, everywhere, no exceptions.
+//
+//   residual   a string that no bound cut can show whole on one line. The bar
+//              at the foot of the xkcd reader is 336px and some comic titles
+//              are two hundred pixels of type past that at the smallest face
+//              the reader binds. A ladder cannot fix those; a second line or a
+//              smaller cut in the app's Faces set could. REPORTED, not gated,
+//              and reported with a count so it cannot quietly grow -- the same
+//              shape host-tests/i18nwidth's all-language survey uses, and for
+//              the same reason: a gap published as a number is a gap somebody
+//              can act on, and a gap folded into a pass is one nobody sees.
+struct Tally {
+  const char* what;
+  int walked = 0;
+  int missing = 0;    // never reached the panel at all
+  int avoidable = 0;  // cut, and a bound cut would have shown it whole
+  int residual = 0;   // cut, and no bound cut could have shown it
+  std::string worst;
+  std::string worstDrawn;
+};
+
+// Would ANY of the three cuts this screen bound have taken the whole string in
+// the width it was drawn into? Asked of the target, so it is the real face.
+bool aCutWouldHaveFitted(const fitted::RealTarget& target, const fitted::TextRun& run, const std::string& source) {
+  const fui::FontId slots[3] = {fui::FONT_SLOT_SMALL, fui::FONT_SLOT_BODY, fui::FONT_SLOT_TITLE};
+  for (const fui::FontId slot : slots) {
+    if (target.measureText(slot, source.c_str(), fui::TextStyle{}).width <= run.rect.width) return true;
+  }
+  return false;
+}
+
+void expectWhole(Tally& tally, const fitted::RealTarget& target, const std::string& source) {
+  ++tally.walked;
+  const fitted::TextRun* run = carrier(target.texts, source);
+  if (run == nullptr) {
+    ++tally.missing;
+    if (tally.worst.empty()) {
+      tally.worst = source;
+      tally.worstDrawn = "(never drawn)";
+    }
+    return;
+  }
+  if (run->drawn == source) return;
+  const bool avoidable = aCutWouldHaveFitted(target, *run, source);
+  if (avoidable) {
+    ++tally.avoidable;
+  } else {
+    ++tally.residual;
+  }
+  if (tally.worstDrawn.empty() || source.size() > tally.worst.size()) {
+    tally.worst = source;
+    tally.worstDrawn = run->drawn;
+  }
+}
+
+void report(const Tally& tally) {
+  walked += tally.walked;
+  residual += tally.residual;
+  const int bad = tally.missing + tally.avoidable;
+  std::printf("%-34s %5d walked  %4d avoidable  %4d residual  %3d never drawn\n", tally.what, tally.walked,
+              tally.avoidable, tally.residual, tally.missing);
+  if (tally.avoidable != 0 || tally.residual != 0 || tally.missing != 0) {
+    std::printf("      longest short of it: %s\n                      -> %s\n", tally.worst.c_str(),
+                tally.worstDrawn.c_str());
+  }
+  ok(bad == 0, std::string(tally.what) + ": " + std::to_string(bad) + " of " + std::to_string(tally.walked) +
+                   " strings were cut while a bound cut would have shown them whole");
+}
+
+// --- The corpora ---------------------------------------------------------
+
+// The fitted style has to SURVIVE Screen::header().
+//
+// headerBand() rewrites the title's font and hands the props on; Screen::header
+// then replaces any title style that is "entirely default-constructed" with the
+// theme's own. FONT_SLOT_SMALL is 0, so a title fitted all the way down to the
+// small slot, with every other field left alone, is one field away from reading
+// as a style nobody set -- and the substitution would put the display cut back
+// and undo the fitting, silently, on exactly the longest strings.
+//
+// What stands between those two today is one token: Toybox's titleText is
+// White, because the band is solid black. That is a real guarantee and an
+// invisible one, so it is asserted here rather than trusted.
+void themeKeepsTheFittedCut() {
+  fui::TextStyle title = toybox::themeTokens().titleText;
+  title.align = toybox::themeTokens().headerTitleAlign;
+  title.font = fui::FONT_SLOT_SMALL;
+  ok(!fui::textStyleUnset(title),
+     "a title fitted down to the small slot reads as unset, so Screen::header would put the display cut back");
+}
+
+void dungeonGuide() {
+  Tally tally{"dungeon: guide page titles"};
+  for (int page = 0; page < dungeonui::guidePageCount(); ++page) {
+    Paint paint("toyboxFaces");
+    toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+    toybox::Screen screen(frame);
+    dungeonui::GuideModel model;
+    model.page = page;
+    model.pageCount = dungeonui::guidePageCount();
+    dungeonui::buildGuide(screen, model);
+    // The title is data the screen owns, so it is read back off the panel
+    // rather than named here: whatever the header drew IS the corpus entry.
+    const std::vector<fitted::TextRun>& runs = paint.target.texts;
+    ok(!runs.empty(), "dungeon guide drew nothing");
+    if (runs.empty()) continue;
+    // The band's title is the first white run in the header band.
+    for (const fitted::TextRun& run : runs) {
+      if (run.color != fui::Color::White || run.rect.y >= toybox::kHeaderHeight) continue;
+      expectWhole(tally, paint.target, run.asked);
+      break;
+    }
+  }
+  report(tally);
+}
+
+// Every dungeon's name, on both screens that show it. The names are the app's
+// longest data -- thirty-three characters at the top -- and the two screens
+// treat them differently on purpose: the menu's foot is one line beside an icon
+// and a TUTORIAL button, and the cleared screen is two centred lines with the
+// map underneath.
+void dungeonNames() {
+  Tally menu{"dungeon: next-dungeon name"};
+  Tally win{"dungeon: cleared-dungeon name"};
+  for (int i = 0; i < dungeon::kPuzzleCount; ++i) {
+    const char* name = dungeon::kPuzzles[i].name;
+    {
+      Paint paint("toyboxFaces");
+      toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+      toybox::Screen screen(frame);
+      dungeonui::MenuModel model;
+      model.dungeonName = name;
+      model.selectedIndex = i;
+      model.total = dungeon::kPuzzleCount;
+      dungeonui::PickerLayout layout;
+      dungeonui::buildMenu(screen, model, layout);
+      expectWhole(menu, paint.target, name);
+    }
+    {
+      Paint paint("toyboxFaces");
+      toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+      toybox::Screen screen(frame);
+      dungeonui::WinModel model;
+      model.dungeonName = name;
+      model.cleared = &dungeon::kPuzzles[i];
+      model.solvedCount = i + 1;
+      model.total = dungeon::kPuzzleCount;
+      dungeonui::buildWin(screen, model);
+      expectWhole(win, paint.target, name);
+    }
+  }
+  report(menu);
+  report(win);
+}
+
+void foreheadCategories() {
+  Tally tally{"forehead: category titles"};
+  for (int i = 0; i < forehead::kCategoryCount; ++i) {
+    Paint paint("bigNumberFaces");
+    toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+    toybox::Screen screen(frame);
+    foreheadui::ResultModel model;
+    model.category = i;
+    model.score = 7;
+    foreheadui::buildResult(screen, model);
+    expectWhole(tally, paint.target, forehead::kCategories[i].title);
+  }
+  report(tally);
+}
+
+void linkGames() {
+  Tally tally{"link: game titles"};
+  for (int i = 0; i < fitted::kLinkGameTitleCount; ++i) {
+    Paint paint("toyboxFaces");
+    toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+    toybox::Screen screen(frame);
+    linkui::LinkModel model;
+    model.gameTitle = fitted::kLinkGameTitles[i];
+    model.headline = "LOOKING FOR A PLAYER";
+    model.yourName = "YOU";
+    model.yourFaceName = "BRAVE SILVER FOX";
+    linkui::buildLink(screen, model);
+    expectWhole(tally, paint.target, fitted::kLinkGameTitles[i]);
+  }
+  report(tally);
+}
+
+void connectionsDates() {
+  Tally tally{"connections: header dates"};
+  // Every date the header can format, not the dates one pack happens to hold.
+  // The archive grows by one a day, so a suite pinned to today's newest is a
+  // suite that stops covering the format the moment somebody imports more.
+  for (int year = 2015; year <= 2035; ++year) {
+    for (int month = 1; month <= 12; ++month) {
+      static const int days[12] = {31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+      for (int day = 1; day <= days[month - 1]; ++day) {
+        const uint32_t date = static_cast<uint32_t>(year * 10000 + month * 100 + day);
+        char text[16];
+        connectionsui::formatDate(date, text, sizeof(text));
+        Paint paint("serifBoardFaces");
+        toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+        toybox::Screen screen(frame);
+        connectionsui::BoardModel model;
+        model.date = date;
+        connectionsui::buildBoardChrome(screen, model);
+        expectWhole(tally, paint.target, text);
+      }
+    }
+  }
+  report(tally);
+}
+
+void toyBattleMaps() {
+  Tally tally{"toy battle: map names"};
+  for (int i = 0; i < toybattle::kTerrainCount; ++i) {
+    Paint paint("toyboxFaces");
+    toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+    toybox::Screen screen(frame);
+    tbui::BriefModel model;
+    model.board = &toybattle::terrainAt(i);
+    model.specialBases = true;
+    tbui::buildBrief(screen, model);
+    expectWhole(tally, paint.target, toybattle::terrainAt(i).name);
+  }
+  report(tally);
+}
+
+void toyBattleHowTo() {
+  Tally tally{"toy battle: how-to page titles"};
+  for (int page = 0; page < tbui::howToPages(); ++page) {
+    Paint paint("toyboxFaces");
+    toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+    toybox::Screen screen(frame);
+    tbui::HowToModel model;
+    model.page = page;
+    tbui::buildHowTo(screen, model);
+    for (const fitted::TextRun& run : paint.target.texts) {
+      if (run.color != fui::Color::White || run.rect.y >= toybox::kHeaderHeight) continue;
+      expectWhole(tally, paint.target, run.asked);
+      break;
+    }
+  }
+  report(tally);
+}
+
+void xkcdReaderBar() {
+  Tally tally{"xkcd: comic titles in the bar"};
+  std::printf("xkcd pack: %s\n", fitted::kXkcdPackLabel);
+  for (int i = 0; i < fitted::kXkcdTitleCount; ++i) {
+    Paint paint("readingChromeFaces");
+    // The panel NEVER rotates for this reader: a wide comic is stored already
+    // turned on its side and the player turns the device, so the bar keeps the
+    // 480px width every other screen has (XkcdActivity::onEnter). Handing this
+    // an 800px landscape context -- the obvious guess -- makes the bar 320px
+    // wider than it is and hides all but eight of the titles it cuts.
+    toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+    fui::ThemeTokens tokens = toybox::themeTokens();
+    tokens.headerHeight = xkcdui::kHeaderBand;
+    toybox::Screen screen(frame, tokens);
+    xkcdui::ReaderModel model;
+    model.num = static_cast<uint32_t>(i + 1);
+    model.title = fitted::kXkcdTitles[i];
+    model.imageW = 600;
+    model.imageH = 900;
+    model.viewW = 600;
+    model.viewH = 480;
+    model.hasOverview = true;
+    model.hasAlt = true;
+    xkcdui::buildReaderBar(screen, model);
+    char line[128];
+    std::snprintf(line, sizeof(line), "#%u  %s", static_cast<unsigned>(model.num), fitted::kXkcdTitles[i]);
+    expectWhole(tally, paint.target, line);
+  }
+  report(tally);
+}
+
+}  // namespace
+
+int main() {
+  std::printf("--- every title, every real string ---\n");
+  themeKeepsTheFittedCut();
+  dungeonGuide();
+  dungeonNames();
+  foreheadCategories();
+  linkGames();
+  connectionsDates();
+  toyBattleMaps();
+  toyBattleHowTo();
+  xkcdReaderBar();
+  std::printf("\n%d real strings walked, %d of them shown short because no bound cut could take them\n", walked,
+              residual);
+  std::printf("%d checks, %d failed\n", checks, failed);
+  return failed == 0 ? 0 : 1;
+}

--- a/host-tests/fittedtitle/test_fittedtitle.cpp
+++ b/host-tests/fittedtitle/test_fittedtitle.cpp
@@ -29,12 +29,14 @@
 #include "DungeonScreens.h"
 #include "ForeheadScreens.h"
 #include "ForeheadWords.h"
+#include "HackerNewsScreens.h"
 #include "LinkScreens.h"
 #include "ToyBattleCore.h"
 #include "ToyBattleMenus.h"
 #include "ToyBattleScreens.h"
 #include "ToyboxScreen.h"
 #include "ToyboxText.h"
+#include "Utf8.h"
 #include "XkcdScreens.h"
 #include "corpus.generated.h"
 #include "fonts/instrument_10.h"
@@ -192,9 +194,18 @@ void expectWhole(Tally& tally, const fitted::RealTarget& target, const std::stri
   }
 }
 
-void report(const Tally& tally) {
+// `allowed` is the number of avoidable cuts this corpus is KNOWN to have and a
+// person has decided to keep. It is a pin, not an excuse: the check is
+// equality, so the count failing UPWARD and failing DOWNWARD both go red, and
+// the reason has to be written at the call site. Every corpus but one passes 0.
+void report(const Tally& tally, const int allowed = 0, const char* why = nullptr) {
   walked += tally.walked;
   residual += tally.residual;
+  // A corpus that walked NOTHING is not a corpus that passed. Every one below
+  // is either a table in this repository or a range this suite generates, so an
+  // empty one means the generator stopped matching, not that the app lost its
+  // screens -- and `0 walked 0 avoidable` reads exactly like a clean run.
+  ok(tally.walked > 0, std::string(tally.what) + ": walked no strings at all");
   const int bad = tally.missing + tally.avoidable;
   std::printf("%-34s %5d walked  %4d avoidable  %4d residual  %3d never drawn\n", tally.what, tally.walked,
               tally.avoidable, tally.residual, tally.missing);
@@ -202,8 +213,12 @@ void report(const Tally& tally) {
     std::printf("      longest short of it: %s\n                      -> %s\n", tally.worst.c_str(),
                 tally.worstDrawn.c_str());
   }
-  ok(bad == 0, std::string(tally.what) + ": " + std::to_string(bad) + " of " + std::to_string(tally.walked) +
-                   " strings were cut while a bound cut would have shown them whole");
+  if (allowed != 0) {
+    std::printf("      %d of those are a KEPT exception: %s\n", allowed, why == nullptr ? "(no reason given)" : why);
+  }
+  ok(bad == allowed, std::string(tally.what) + ": " + std::to_string(bad) + " of " + std::to_string(tally.walked) +
+                         " strings were cut while a bound cut would have shown them whole, and " +
+                         std::to_string(allowed) + " is the number this corpus is pinned at");
 }
 
 // --- The corpora ---------------------------------------------------------
@@ -220,6 +235,100 @@ void report(const Tally& tally) {
 // What stands between those two today is one token: Toybox's titleText is
 // White, because the band is solid black. That is a real guarantee and an
 // invisible one, so it is asserted here rather than trusted.
+// THE LADDER ITSELF, which every corpus below is blind to.
+//
+// A cold review reintroduced the exact bug the shared function exists to fix --
+// walking the cuts by slot NAME instead of by measured size, and dropping the
+// "never above the cut the caller asked for" guard -- and every corpus below
+// printed byte-identical output. They can only see a string arriving SHORT, and
+// a ladder that steps the wrong way makes strings arrive BIG. So the two
+// properties that only this code can break are asserted directly, against a
+// target whose slots are deliberately out of name order.
+//
+// bigNumberFaces() and cardFaces() are not hypothetical shapes: they are two of
+// the nine sets in ToyboxTheme.h, they put a 64px cut in a slot named BODY and
+// a 44px one in a slot named SMALL, and Forehead binds both. Eleven of its
+// seventeen category titles fit at the 64px cut, so without the ceiling eleven
+// result screens would set their title at a 133px line height inside a 76px
+// band -- and no corpus here would have said a word.
+void theLadderItself() {
+  const fitted::Faces bigNumber = facesNamed("bigNumberFaces");  // SMALL 29, BODY 133, TITLE 63
+  fitted::RealTarget target(bigNumber);
+
+  const int16_t small = target.lineHeight(fui::FONT_SLOT_SMALL);
+  const int16_t body = target.lineHeight(fui::FONT_SLOT_BODY);
+  const int16_t titleSlot = target.lineHeight(fui::FONT_SLOT_TITLE);
+  ok(body > titleSlot && titleSlot > small,
+     "bigNumberFaces no longer binds a BODY cut taller than its TITLE cut, so this test proves nothing");
+
+  // Asked for the TITLE cut with room to spare: it must come back unchanged,
+  // and must NOT be promoted to the taller cut sitting in BODY.
+  {
+    fui::TextStyle style;
+    style.font = fui::FONT_SLOT_TITLE;
+    style.color = fui::Color::White;
+    const std::string out = toybox::fittedTitle(target, "MUSIC", 448, style);
+    ok(out == "MUSIC", "a title that fits was altered");
+    ok(style.font == fui::FONT_SLOT_TITLE, "fitting stepped UP into the taller cut bound to the BODY slot");
+  }
+
+  // Asked for the TITLE cut with too little room: it must step DOWN to the
+  // small slot, never up, and never sideways into BODY.
+  {
+    fui::TextStyle style;
+    style.font = fui::FONT_SLOT_TITLE;
+    style.color = fui::Color::White;
+    const std::string out = toybox::fittedTitle(target, "FAMOUS PEOPLE", 200, style);
+    ok(out == "FAMOUS PEOPLE", "a title that fits a smaller cut was elided instead of shrunk");
+    ok(style.font == fui::FONT_SLOT_SMALL, "fitting did not walk down to the smallest cut this screen bound");
+  }
+
+  // The LARGEST that fits, not merely one that fits. A ladder that jumped
+  // straight to the smallest would pass every "was it cut" check in this file.
+  {
+    fui::TextStyle style;
+    style.font = fui::FONT_SLOT_TITLE;
+    style.color = fui::Color::White;
+    const fui::Size atTitle = target.measureText(fui::FONT_SLOT_TITLE, "SCIENCE", style);
+    const std::string out = toybox::fittedTitle(target, "SCIENCE", atTitle.width, style);
+    ok(out == "SCIENCE", "a title measured to fit exactly was still shortened");
+    ok(style.font == fui::FONT_SLOT_TITLE, "fitting stepped down from a cut the string fitted in exactly");
+  }
+
+  // cardFaces puts the 44px cut in SMALL and the 30px one in BODY, so "walk
+  // TITLE, BODY, SMALL" would end on the LARGER of the two. Asked at BODY, the
+  // only legal step is to stay or to shrink -- and SMALL is bigger here, so the
+  // only legal answer is BODY itself.
+  {
+    const fitted::Faces card = facesNamed("cardFaces");  // SMALL 92, BODY 63, TITLE 133
+    fitted::RealTarget cardTarget(card);
+    ok(cardTarget.lineHeight(fui::FONT_SLOT_SMALL) > cardTarget.lineHeight(fui::FONT_SLOT_BODY),
+       "cardFaces no longer binds a SMALL cut taller than its BODY cut, so this test proves nothing");
+    fui::TextStyle style;
+    style.font = fui::FONT_SLOT_BODY;
+    style.color = fui::Color::White;
+    toybox::fittedTitle(cardTarget, "LITTLE RED RIDING HOOD", 60, style);
+    ok(style.font == fui::FONT_SLOT_BODY,
+       "with nothing smaller bound, fitting moved to a LARGER cut rather than staying and marking");
+
+    // And the case that separates MEASURED order from NAME order outright.
+    // Under cardFaces the two smaller cuts are SMALL (92) and BODY (63), in
+    // that order by size and the other way round by name. Given a width both
+    // fit in, "largest that fits" is SMALL; a walk by name reaches BODY first
+    // and stops, one rung smaller than it had to be. Nothing arrives cut either
+    // way, which is why every corpus in this file is blind to it.
+    fui::TextStyle wide;
+    wide.font = fui::FONT_SLOT_TITLE;
+    wide.color = fui::Color::White;
+    const int16_t atSmall = cardTarget.measureText(fui::FONT_SLOT_SMALL, "FOX", wide).width;
+    const int16_t atTitleCut = cardTarget.measureText(fui::FONT_SLOT_TITLE, "FOX", wide).width;
+    ok(atTitleCut > atSmall, "cardFaces' TITLE cut is no longer wider than its SMALL cut");
+    toybox::fittedTitle(cardTarget, "FOX", atSmall, wide);
+    ok(wide.font == fui::FONT_SLOT_SMALL,
+       "fitting took a SMALLER cut than it had to: the rungs were walked by slot name, not by measured size");
+  }
+}
+
 void themeKeepsTheFittedCut() {
   fui::TextStyle title = toybox::themeTokens().titleText;
   title.align = toybox::themeTokens().headerTitleAlign;
@@ -230,6 +339,16 @@ void themeKeepsTheFittedCut() {
 
 void dungeonGuide() {
   Tally tally{"dungeon: guide page titles"};
+  // The corpus comes from the TABLE, never from the panel. Read off the panel
+  // it was circular: headerBand rewrites props.title to the fitted string
+  // before the component draws it, so "what was drawn" and "what was expected"
+  // were the same object and the check could not fail. A cold review proved it
+  // by truncating every title to five characters and watching this stay green.
+  //
+  // Which makes the count load-bearing: a table row the generator's pattern
+  // misses is a page that silently stops being walked.
+  ok(fitted::kDungeonGuideTitleCount == dungeonui::guidePageCount(),
+     "corpus.py found a different number of dungeon guide pages than the app has");
   for (int page = 0; page < dungeonui::guidePageCount(); ++page) {
     Paint paint("toyboxFaces");
     toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
@@ -238,17 +357,7 @@ void dungeonGuide() {
     model.page = page;
     model.pageCount = dungeonui::guidePageCount();
     dungeonui::buildGuide(screen, model);
-    // The title is data the screen owns, so it is read back off the panel
-    // rather than named here: whatever the header drew IS the corpus entry.
-    const std::vector<fitted::TextRun>& runs = paint.target.texts;
-    ok(!runs.empty(), "dungeon guide drew nothing");
-    if (runs.empty()) continue;
-    // The band's title is the first white run in the header band.
-    for (const fitted::TextRun& run : runs) {
-      if (run.color != fui::Color::White || run.rect.y >= toybox::kHeaderHeight) continue;
-      expectWhole(tally, paint.target, run.asked);
-      break;
-    }
+    expectWhole(tally, paint.target, fitted::kDungeonGuideTitles[page]);
   }
   report(tally);
 }
@@ -366,6 +475,8 @@ void toyBattleMaps() {
 
 void toyBattleHowTo() {
   Tally tally{"toy battle: how-to page titles"};
+  ok(fitted::kToyBattleHowToTitleCount == tbui::howToPages(),
+     "corpus.py found a different number of how-to pages than the app has");
   for (int page = 0; page < tbui::howToPages(); ++page) {
     Paint paint("toyboxFaces");
     toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
@@ -373,18 +484,80 @@ void toyBattleHowTo() {
     tbui::HowToModel model;
     model.page = page;
     tbui::buildHowTo(screen, model);
-    for (const fitted::TextRun& run : paint.target.texts) {
-      if (run.color != fui::Color::White || run.rect.y >= toybox::kHeaderHeight) continue;
-      expectWhole(tally, paint.target, run.asked);
-      break;
-    }
+    expectWhole(tally, paint.target, fitted::kToyBattleHowToTitles[page]);
   }
   report(tally);
+}
+
+// The Hacker News reader's band, which is the one title in this fork that is
+// always somebody else's sentence.
+//
+// It is here because this change touched it: the band carries a SAVE control
+// whose width was in neither term of the room the headline was fitted to, so a
+// long headline was shortened by the app to a room about ninety pixels too
+// wide and then shortened AGAIN by the component. Two ellipses, one headline.
+// Walking it with the control both present and absent is what holds that shut.
+//
+// The headlines are folded with utf8FoldTypography first, exactly as
+// HackerNewsActivity does on the way in -- unfolded, a curly quote would draw
+// as a hole and this suite would be measuring a different defect.
+void hackerNewsReader() {
+  Tally tally{"hacker news: story headlines"};
+  ok(fitted::kHnHeadlineCount > 0, "no captured Hacker News front page to walk");
+  for (int i = 0; i < fitted::kHnHeadlineCount; ++i) {
+    const std::string headline = utf8FoldTypography(fitted::kHnHeadlines[i]);
+    for (int variant = 0; variant < 3; ++variant) {
+      Paint paint("readingFaces");
+      toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
+      toybox::Screen screen(frame);
+      toybox::WrappedText wrap;
+      hnui::ReaderBody body;
+      body.text = "One line of article, which this screen is not measuring.";
+      body.style = screen.theme().bodyText;
+      body.wrap = &wrap;
+      hnui::ReaderModel model;
+      model.title = headline.c_str();
+      model.pageLabel = "3 / 12";
+      // No control, the outlined SAVE, and the filled SAVED: three different
+      // widths taken out of the same band, and the widest is the one the old
+      // arithmetic left out entirely.
+      model.canSave = variant > 0;
+      model.saved = variant == 2;
+      hnui::buildReader(screen, model, body);
+      expectWhole(tally, paint.target, headline);
+    }
+  }
+  // TEN, and they are a decision rather than a bug. The only cut smaller than
+  // this band's reading face is the SMALL slot, which readingFaces binds to
+  // toybox_10 -- a 21px Jersey line box in a 76px band. Stepping down would
+  // rescue these ten and leave the other seventy-eight elided anyway, so the
+  // band would set some headlines in a display cut a third the height of the
+  // rest for no gain a reader could name. The fork's rule says step down; this
+  // band has nothing worth stepping down TO, which is a face-binding question
+  // (readerFaces, or reading_serif_11 in a slot) and not this function's.
+  // Card #268. Pinned so the number cannot drift in either direction unnoticed.
+  report(tally, 10, "no cut between reading_serif_14 and toybox_10 is bound on this band -- card #268");
 }
 
 void xkcdReaderBar() {
   Tally tally{"xkcd: comic titles in the bar"};
   std::printf("xkcd pack: %s\n", fitted::kXkcdPackLabel);
+  // The ONE corpus that is not in this repository: the comics live in a pack on
+  // the card. With no pack this walked zero titles and reported `0 walked 0
+  // avoidable`, which is indistinguishable from a clean run -- and it is the
+  // corpus that catches 588 avoidable cuts, on the runner nobody can skip.
+  //
+  // So it says SKIP, on its own line, at the start of the line, because that is
+  // what scripts_local/check.sh greps for and prints beside an otherwise-green
+  // suite. A check that did not run must not scroll past looking like one that
+  // passed.
+  if (fitted::kXkcdTitleCount == 0) {
+    std::printf(
+        "SKIP fittedtitle: no xkcd pack reachable, so NOT ONE comic title was walked.\n"
+        "     That is the corpus that found 588 avoidable cuts; everything else here still ran.\n"
+        "     Put a pack on the card or point XKCD_PACK at one.\n");
+    return;
+  }
   for (int i = 0; i < fitted::kXkcdTitleCount; ++i) {
     Paint paint("readingChromeFaces");
     // The panel NEVER rotates for this reader: a wide comic is stored already
@@ -417,6 +590,7 @@ void xkcdReaderBar() {
 
 int main() {
   std::printf("--- every title, every real string ---\n");
+  theLadderItself();
   themeKeepsTheFittedCut();
   dungeonGuide();
   dungeonNames();
@@ -425,6 +599,7 @@ int main() {
   connectionsDates();
   toyBattleMaps();
   toyBattleHowTo();
+  hackerNewsReader();
   xkcdReaderBar();
   std::printf("\n%d real strings walked, %d of them shown short because no bound cut could take them\n", walked,
               residual);

--- a/src/apps_local/dungeon/DungeonScreens.cpp
+++ b/src/apps_local/dungeon/DungeonScreens.cpp
@@ -1,7 +1,9 @@
 #include "DungeonScreens.h"
 
 #include <cstdio>
+#include <string>
 
+#include "../ui/ToyboxText.h"
 #include "DungeonArt.h"
 
 namespace dungeonui {
@@ -178,13 +180,12 @@ void drawArt(toybox::Screen& screen, const fui::Rect& cell, const freeink::Icon&
 // "THE GRAVEYARD OF THE VE" with no mark at all to say it had been cut, and the
 // only sign anything was wrong was `No glyph for codepoint 8230` in the log.
 // Setting the name smaller is not a lie about it; truncating silently is.
+// The ladder is toybox::fittedTitle's; the caller says where it starts, which
+// is the UI cut, and fitting only ever goes down from there.
 fui::FontId fitLabel(toybox::Screen& screen, const char* text, const int width, fui::TextStyle& style) {
-  const fui::FontId cuts[2] = {toybox::kUiFont, toybox::kSmallFont};
-  for (const fui::FontId cut : cuts) {
-    style.font = cut;
-    if (screen.target().measureText(cut, text, style).width <= width) return cut;
-  }
-  return cuts[1];
+  style.font = toybox::kUiFont;
+  toybox::fittedTitle(screen.target(), text, static_cast<int16_t>(width), style);
+  return style.font;
 }
 
 void drawClue(toybox::Screen& screen, const fui::Rect& box, const fui::Rect& chip, const int value, const int placed) {
@@ -782,12 +783,19 @@ void buildWin(toybox::Screen& screen, const WinModel& model) {
   const fui::Rect actions = screen.takeBottom(toybox::kPillHeight, toybox::kGutter);
   const fui::Rect body = screen.body();
 
+  // Two centred lines, in the largest cut the whole name lays out in. Seven of
+  // the sixty-five names are longer than two lines of the display cut, and
+  // without the ladder each of those reached this screen with its tail replaced
+  // by an ellipsis -- on the screen whose entire job is to name what you just
+  // finished. Stepping down also buys the height back: two display lines are
+  // 126px in a 90px box and two UI lines are 84.
   fui::TextStyle name;
   name.font = toybox::kDisplayFont;
   name.align = fui::TextAlign::Center;
   name.maxLines = 2;
-  screen.target().text(fui::makeRect(body.x, static_cast<int16_t>(body.y + 40), body.width, 90), model.dungeonName,
-                       name);
+  const fui::Rect nameBox = fui::makeRect(body.x, static_cast<int16_t>(body.y + 40), body.width, 90);
+  const std::string fittedName = toybox::fittedTitle(screen.target(), model.dungeonName, nameBox.width, name);
+  screen.target().text(nameBox, fittedName.c_str(), name);
 
   // The map they have just finished. Nothing else on this screen is worth
   // looking at, and this is the one thing on it they made.

--- a/src/apps_local/hackernews/HackerNewsScreens.cpp
+++ b/src/apps_local/hackernews/HackerNewsScreens.cpp
@@ -311,7 +311,21 @@ uint32_t buildReader(toybox::Screen& screen, const ReaderModel& model, ReaderBod
           ? static_cast<int16_t>(screen.target().measureText(labelStyle.font, model.pageLabel, labelStyle).width +
                                  toybox::kGutter)
           : 0;
-  const int16_t room = static_cast<int16_t>(screen.device().width - 2 * toybox::kMargin - labelWidth);
+  // The SAVE control is in the band too, and it was in NEITHER term of this
+  // sum. The component reserves `label + 20 + icon + 4`, then another 8 of
+  // gutter (components/controls/header.h), so a headline was fitted to a room
+  // about ninety pixels wider than the one it is drawn into -- and then cut a
+  // second time by the component, with a second ellipsis, on the one screen in
+  // this fork whose title is always somebody else's sentence. Instapaper's twin
+  // has no trailing control and so had no second term to forget.
+  int16_t saveWidth = 0;
+  if (model.canSave) {
+    const fui::TextStyle& trailing = screen.theme().bodyText;
+    const char* label = model.saved ? "SAVED" : "SAVE";
+    saveWidth = static_cast<int16_t>(screen.target().measureText(trailing.font, label, trailing).width + 20 +
+                                     icon_saved_32.w + 4 + 8);
+  }
+  const int16_t room = static_cast<int16_t>(screen.device().width - 2 * toybox::kMargin - labelWidth - saveWidth);
   const std::string headline = fitLines(screen.target(), model.title, room, 1, bandTitle);
   chrome(screen, headline.c_str(), model.pageLabel, &bandTitle, model.canSave, model.saved);
 

--- a/src/apps_local/hackernews/HackerNewsScreens.cpp
+++ b/src/apps_local/hackernews/HackerNewsScreens.cpp
@@ -68,6 +68,11 @@ fui::StyleSet bandOutlineStyles() {
 // label stayed invisible through two renders and the suite carried a failing
 // pin (paperOnTheBand) against exactly this until the fix landed. The games'
 // toyboxChrome copies had the right slot all along; jaipur paid for it first.
+// What the band's save chip says, in ONE place. The reader has to know it too,
+// because the chip's width comes out of the room its headline is fitted to, and
+// a second copy of "SAVED" is a second copy that can be edited alone.
+const char* saveChipLabel(const bool saved) { return saved ? "SAVED" : "SAVE"; }
+
 void chrome(toybox::Screen& screen, const char* title, const char* rightLabel,
             const fui::TextStyle* titleText = nullptr, const bool showSave = false, const bool saved = false) {
   fui::HeaderProps header;
@@ -79,7 +84,7 @@ void chrome(toybox::Screen& screen, const char* title, const char* rightLabel,
     // A verb for what a tap will do, a past tense for what it did -- which is
     // also the confirmation the screen owed anyone who just tapped it.
     header.trailingIcon = fui::bitmapFromIcon(icon_saved_32);
-    header.trailingLabel = saved ? "SAVED" : "SAVE";
+    header.trailingLabel = saveChipLabel(saved);
     header.trailingAction = saved ? ActionUnsave : ActionSave;
     header.trailingStyles = saved ? bandFilledStyles() : bandOutlineStyles();
     header.trailingRadius = toybox::kPillRadius / 2;
@@ -320,10 +325,13 @@ uint32_t buildReader(toybox::Screen& screen, const ReaderModel& model, ReaderBod
   // has no trailing control and so had no second term to forget.
   int16_t saveWidth = 0;
   if (model.canSave) {
+    // Every term the component charges for a trailing button, in its order:
+    // the label at the style Screen::header substitutes (bodyText), its 20px of
+    // padding, the icon and its 4, and the 8 of gutter beside the button.
     const fui::TextStyle& trailing = screen.theme().bodyText;
-    const char* label = model.saved ? "SAVED" : "SAVE";
-    saveWidth = static_cast<int16_t>(screen.target().measureText(trailing.font, label, trailing).width + 20 +
-                                     icon_saved_32.w + 4 + 8);
+    saveWidth =
+        static_cast<int16_t>(screen.target().measureText(trailing.font, saveChipLabel(model.saved), trailing).width +
+                             20 + icon_saved_32.w + 4 + 8);
   }
   const int16_t room = static_cast<int16_t>(screen.device().width - 2 * toybox::kMargin - labelWidth - saveWidth);
   const std::string headline = fitLines(screen.target(), model.title, room, 1, bandTitle);

--- a/src/apps_local/insider/InsiderScreens.cpp
+++ b/src/apps_local/insider/InsiderScreens.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdio>
 
+#include "../ui/ToyboxText.h"
 #include "InsiderArt.h"
 
 namespace insiderui {
@@ -42,15 +43,16 @@ void chrome(toybox::Screen& screen, const char* title, const char* rightLabel) {
 // loses its tail to a glyph that draws as *nothing*: "WE SAID THE WORD" became
 // "WE SAID THE WOR" with an [ERR] line nobody was reading. Every label built
 // from a value goes through here.
+//
+// The ladder itself is toybox::fittedTitle's now. This kept its own for a
+// while and its own had the bug every hand-rolled copy has: the cuts were
+// walked by slot NAME, which only descends while an app binds descending cuts.
+// Only the string is dropped here -- these two labels are a player count and a
+// word from a list, and neither has ever needed the ellipsis half.
 fui::FontId fitted(toybox::Screen& screen, const char* text, const int16_t width, const fui::TextStyle& probe) {
-  const fui::FontId cuts[3] = {toybox::kDisplayFont, toybox::kUiFont, toybox::kTileFont};
-  fui::TextStyle measure = probe;
-  for (const fui::FontId cut : cuts) {
-    if (cut == toybox::kDisplayFont && probe.font != toybox::kDisplayFont) continue;
-    measure.font = cut;
-    if (screen.target().measureText(cut, text, measure).width <= width) return cut;
-  }
-  return toybox::kTileFont;
+  fui::TextStyle style = probe;
+  toybox::fittedTitle(screen.target(), text, width, style);
+  return style.font;
 }
 
 // Lays `text` out at `width` by greedy break-at-spaces, and draws each line as

--- a/src/apps_local/toybattle/ToyBattleHowTo.cpp
+++ b/src/apps_local/toybattle/ToyBattleHowTo.cpp
@@ -40,11 +40,11 @@ void chrome(toybox::Screen& screen, const char* title, const char* rightLabel = 
   header.subtitleText.font = toybox::kUiFont;
   header.subtitleText.color = fui::Color::White;
   header.subtitleText.align = fui::TextAlign::Right;
-  // The counter is in the band too, so the title's room is what is left of it.
-  header.titleText = fittedHeaderTitle(
-      screen, title,
-      static_cast<int16_t>(screen.target().measureText(toybox::kUiFont, rightLabel, header.subtitleText).width +
-                           toybox::kGutter));
+  // The counter is in the band too, and the title's room is what is left of
+  // it -- which headerBand now works out from the component's own arithmetic
+  // rather than from this sum. The sum was wrong in a way nothing showed: the
+  // component ALREADY subtracts the right label's width, so reserving it here
+  // as well charged the title for the counter twice.
   header.borderEdges = fui::EdgesNone;
   toybox::absoluteChrome(screen);
   toybox::headerBand(screen, header);

--- a/src/apps_local/toybattle/ToyBattleScreens.cpp
+++ b/src/apps_local/toybattle/ToyBattleScreens.cpp
@@ -568,24 +568,6 @@ const char* refusalBlurb(const tb::Refusal why) {
   return "";
 }
 
-// The largest cut a header title fits in, walking down rather than truncating.
-// "CURSED CEMETERY" came out of the display cut as "CURSED CEMETER" -- not a
-// wrapped line and not an ellipsis, just a name with its last letter gone, which
-// reads as a misspelling rather than as an overflow. The map names are data and
-// the longest one is fifteen characters today; shrinking is the fix that cannot
-// regress the next time somebody traces a board with a long name.
-fui::TextStyle fittedHeaderTitle(toybox::Screen& screen, const char* title, const int16_t reserved) {
-  fui::TextStyle style;
-  style.color = fui::Color::White;
-  const int16_t room = static_cast<int16_t>(screen.device().width - toybox::kMargin * 2 - reserved);
-  const fui::FontId cuts[] = {toybox::kDisplayFont, toybox::kUiFont, toybox::kSmallFont};
-  for (const fui::FontId cut : cuts) {
-    style.font = cut;
-    if (screen.target().measureText(cut, title, style).width <= room) return style;
-  }
-  return style;
-}
-
 // THE TROOP REFERENCE. Every card, its real face, and what it does.
 //
 // One page rather than a footer under the map's special bases: crammed under
@@ -637,9 +619,14 @@ void troopReference(toybox::Screen& screen, const fui::Rect& box, const int colu
 // what doubled.
 void buildBrief(toybox::Screen& screen, const BriefModel& model) {
   const char* title = model.board ? model.board->name : "TERRAIN";
+  // "CURSED CEMETERY" came out of the display cut as "CURSED CEMETER" -- not a
+  // wrapped line and not an ellipsis, just a name with its last letter gone,
+  // which reads as a misspelling rather than as an overflow. The map names are
+  // data and the longest is fifteen characters today. The ladder that fixes it
+  // is toybox::headerBand's now, so every band in the fork has it and this
+  // screen carries no copy: host-tests/fittedtitle walks all ten maps.
   fui::HeaderProps header;
   header.title = title;
-  header.titleText = fittedHeaderTitle(screen, title);
   header.borderEdges = fui::EdgesNone;
   toybox::absoluteChrome(screen);
   toybox::headerBand(screen, header);

--- a/src/apps_local/toybattle/ToyBattleScreens.h
+++ b/src/apps_local/toybattle/ToyBattleScreens.h
@@ -99,14 +99,6 @@ struct ResultModel {
 };
 void buildResult(toybox::Screen& screen, const ResultModel& model);
 
-// The largest cut a header title fits in, walking the cuts down rather than
-// letting the component truncate. Map names are data and the deck's page titles
-// are prose; both have already overrun the display cut once.
-// `reserved` is whatever else shares the band -- a page counter, a medal
-// tally. Measuring against the full width is how TWO WAYS TO WIN came out
-// as TWO WAYS TO W beside its own 1/6.
-fui::TextStyle fittedHeaderTitle(toybox::Screen& screen, const char* title, int16_t reserved = 0);
-
 // The marks, for anything outside this file that has to draw them. The rules
 // screens teach the same symbols the board uses, which is the whole point of
 // having a design language rather than a set of pictures.

--- a/src/apps_local/ui/ToyboxScreen.h
+++ b/src/apps_local/ui/ToyboxScreen.h
@@ -257,9 +257,31 @@ inline void headerBand(Screen& screen, const freeink::ui::HeaderProps& props) {
     fitted.titleText.align = screen.theme().headerTitleAlign;
   }
   if (fui::textStyleUnset(fitted.subtitleText)) fitted.subtitleText = screen.theme().smallText;
+  // trailingText too, and it is not a tidy-up: headerTitleWidth measures the
+  // trailing button's LABEL to know how much of the band it takes, and an
+  // unset style measures it at font 0 -- the SMALL slot -- while the component
+  // draws it at BODY. On the Hacker News band those are toybox_10 and
+  // reading_serif_14, so "SAVED" measured 51px against the 91px it really
+  // occupies and the fit believed it had 40px it did not have. The error
+  // points the wrong way: the ladder declines to step down and the renderer
+  // cuts instead.
+  if (fui::textStyleUnset(fitted.trailingText)) fitted.trailingText = screen.theme().bodyText;
   if (fitted.sidePadding < 0) fitted.sidePadding = screen.theme().headerSidePadding;
-  const std::string title =
+  const fui::TextStyle asked = fitted.titleText;
+  std::string title =
       fittedTitle(screen.target(), fitted.title, headerTitleWidth(screen, ink, fitted), fitted.titleText);
+  // A fitted style that reads as DEFAULT would be replaced by the theme's own
+  // inside Screen::header(), putting the cut we just chose back to the display
+  // one -- silently, and only on the longest strings. FONT_SLOT_SMALL is 0, so
+  // a title stepped all the way down with every other field left alone is one
+  // field away from that. Toybox's own titleText is White and cannot reach it;
+  // a caller supplying a black, left-aligned title style could. Rather than
+  // emit a style that will be undone, keep the cut that caller asked for and
+  // let fitLines mark the overflow instead.
+  if (fui::textStyleUnset(fitted.titleText) && !fui::textStyleUnset(asked)) {
+    fitted.titleText = asked;
+    title = fitLines(screen.target(), props.title, headerTitleWidth(screen, ink, fitted), 1, fitted.titleText);
+  }
   if (fitted.title != nullptr) fitted.title = title.c_str();
 
   screen.header(fitted, ink);

--- a/src/apps_local/ui/ToyboxScreen.h
+++ b/src/apps_local/ui/ToyboxScreen.h
@@ -31,6 +31,7 @@
 #include <Icon.h>
 
 #include "../../../lib/GfxRenderer/RevealedInteractions.h"
+#include "ToyboxText.h"
 #include "ToyboxTokens.h"
 
 namespace toybox {
@@ -147,6 +148,55 @@ class Screen : public freeink::ui::Screen<kMaxInteractions> {
 // safe rect through its own path and does not use this.
 inline void absoluteChrome(Screen& screen) { screen.setContentMarginAbsolute(freeink::ui::Insets{}); }
 
+// The width the header component will really give the title, computed with the
+// component's own arithmetic (components/controls/header.h) rather than from
+// the page margins.
+//
+// Guessing it is not a smaller version of this; it is a different number. The
+// two readers fit their headline to `width - 2 * kMargin - pageLabel`, and the
+// band also carries a SAVE button whose width is in neither term -- so a
+// headline is trimmed to a room it does not get and then trimmed AGAIN by the
+// component, twice-elided, on the one screen in this fork whose title is always
+// somebody else's sentence. Every term the component subtracts is subtracted
+// here, in the same order, so the fit and the draw cannot drift.
+//
+// `props` must already carry the theme substitutions Screen::header() makes,
+// because the padding and the right label's style are two of the terms.
+inline int16_t headerTitleWidth(Screen& screen, const freeink::ui::Rect& band, const freeink::ui::HeaderProps& props) {
+  namespace fui = freeink::ui;
+  const int16_t sidePad = props.sidePadding < 0 ? 6 : props.sidePadding;
+  int16_t width = static_cast<int16_t>(band.width - sidePad * 2);
+  if (props.leftReserve > 0) width = static_cast<int16_t>(width - props.leftReserve);
+  if (props.rightReserve > 0) width = static_cast<int16_t>(width - props.rightReserve);
+
+  const fui::BitmapRef leading =
+      props.leadingIcon ? props.leadingIcon : fui::resolveBitmap(screen.frame().assets(), props.leadingIconAsset);
+  if (leading && props.leadingAction != fui::NO_ACTION && !props.centered) {
+    width = static_cast<int16_t>(width - (band.height - 8) - 8);
+  }
+
+  const fui::BitmapRef trailing =
+      props.trailingIcon ? props.trailingIcon : fui::resolveBitmap(screen.frame().assets(), props.trailingIconAsset);
+  if ((props.trailingLabel != nullptr || trailing) && props.trailingAction != fui::NO_ACTION) {
+    int16_t buttonW = static_cast<int16_t>(band.height - 8);
+    if (props.trailingLabel != nullptr) {
+      const fui::Size label =
+          screen.target().measureText(props.trailingText.font, props.trailingLabel, props.trailingText);
+      buttonW = static_cast<int16_t>(label.width + 20 + (trailing ? trailing.width + 4 : 0));
+    }
+    if (!props.centered) width = static_cast<int16_t>(width - buttonW - 8);
+  }
+
+  if (props.rightLabel != nullptr) {
+    const fui::Size label = screen.target().measureText(props.subtitleText.font, props.rightLabel, props.subtitleText);
+    const int16_t used = static_cast<int16_t>(label.width + 6);
+    // A centred title gives up the same width on BOTH sides so it stays centred
+    // on the band, which is the component's rule and not a doubling by mistake.
+    width = static_cast<int16_t>(width - (props.centered ? used * 2 : used));
+  }
+  return width > 0 ? width : 0;
+}
+
 // The header band. Paint and ink are placed by different rules, and the split
 // is the whole point.
 //
@@ -166,6 +216,14 @@ inline void absoluteChrome(Screen& screen) { screen.setContentMarginAbsolute(fre
 // rect exactly as screen.header(props) would take it, so nothing below moves --
 // under absolute chrome (bottom at the tuned kHeaderHeight) or under the safe
 // area alike. Call in place of screen.header(props).
+//
+// The TITLE is fitted before it is drawn, which is the one thing this wrapper
+// adds beyond placement. See headerTitleWidth() below for why the width is
+// computed rather than guessed, and ToyboxText.h's fittedTitle() for the rule.
+// Doing it here rather than at the call sites is deliberate: there are
+// twenty-four copies of this chrome across the apps, every one of them ends in
+// this function, and a rule added to one copy at a time is a rule the
+// twenty-fifth copy will not have.
 inline void headerBand(Screen& screen, const freeink::ui::HeaderProps& props) {
   namespace fui = freeink::ui;
   const fui::Rect band = screen.takeTop(screen.theme().headerHeight);
@@ -178,7 +236,33 @@ inline void headerBand(Screen& screen, const freeink::ui::HeaderProps& props) {
   // top-bordered band would need its corners and its rule carried up here too.
   screen.target().fill(fui::makeRect(0, 0, screen.device().screen().width, band.bottom()),
                        styles.resolve(fui::StateNormal).background);
-  screen.header(props, fui::makeRect(band.x, inkTop, band.width, static_cast<int16_t>(band.bottom() - inkTop)));
+
+  // The rect the component is really handed, which is the band CLIPPED to the
+  // visible rows: the bezel hides the top ten, and the ink stays below them.
+  // The fitting is done against this one and not against the band, because the
+  // component sizes its leading and trailing buttons from `rect.height - 8` --
+  // measuring those against the taller band reserved ten pixels the title was
+  // then never given back.
+  const fui::Rect ink = fui::makeRect(band.x, inkTop, band.width, static_cast<int16_t>(band.bottom() - inkTop));
+
+  fui::HeaderProps fitted = props;
+  // The theme substitutions Screen::header() is about to make, made here first
+  // because the fitting needs the real style and the real padding. Taking the
+  // theme's title style whole -- rather than building one -- is what keeps the
+  // band's ink WHITE: titleText.color is White in the tokens precisely because
+  // this band is always solid black, and a style assembled field by field here
+  // would paint every title in the fork black on black.
+  if (fui::textStyleUnset(fitted.titleText)) {
+    fitted.titleText = screen.theme().titleText;
+    fitted.titleText.align = screen.theme().headerTitleAlign;
+  }
+  if (fui::textStyleUnset(fitted.subtitleText)) fitted.subtitleText = screen.theme().smallText;
+  if (fitted.sidePadding < 0) fitted.sidePadding = screen.theme().headerSidePadding;
+  const std::string title =
+      fittedTitle(screen.target(), fitted.title, headerTitleWidth(screen, ink, fitted), fitted.titleText);
+  if (fitted.title != nullptr) fitted.title = title.c_str();
+
+  screen.header(fitted, ink);
 }
 
 // Vertical top for an element of height h centred in the VISIBLE part of the

--- a/src/apps_local/ui/ToyboxText.h
+++ b/src/apps_local/ui/ToyboxText.h
@@ -122,4 +122,96 @@ inline std::string fitLines(const freeink::ui::DrawTarget& target, const char* t
   return kept + kEllipsis;
 }
 
+// The fork's own type ladder, in one place at last.
+//
+// ToyboxFonts.h has stated the rule in prose since the reading cuts were added:
+// "pick the largest cut it fits in, walking the available cuts down, and only
+// break a word when the smallest still overflows." There was no function that
+// did it. SIX apps wrote their own -- toybattle's fittedHeaderTitle, insider's
+// fitted, the dungeon's fitLabel, connections' chooseTileCut, forehead's
+// layOutCard and the xkcd bar's fitLabel -- and every screen that wrote none
+// handed its title straight to a component that cuts rather than shrinks. That
+// is how "CURSED CEMETERY" reached a panel as "CURSED CEMETER": not a wrapped
+// line and not an ellipsis, a name with its last letter gone.
+//
+// THE RUNGS ARE ORDERED BY WHAT THE FACE MEASURES, never by what the slot is
+// called, and that is the bug all six hand-rolled ladders share. Each of them
+// walks TITLE, then BODY, then SMALL, which is only descending while an app
+// binds descending cuts. bigNumberFaces() puts the 64px cut in BODY and the
+// 30px one in TITLE; cardFaces() puts 44 in SMALL, 30 in BODY and 64 in TITLE.
+// Walked by name on either of those, the "step down" steps UP into a face twice
+// the size of the one it was asked to shrink. Asked of lineHeight() it cannot:
+// the ladder is whatever this screen really bound, sorted.
+//
+// Never above the cut the caller already chose, either. A title asked for at
+// the UI cut must not come back at the display cut because the display cut
+// happens to fit too -- fitting is a licence to get SMALLER and nothing else.
+//
+// Rewrites `style.font` to the chosen cut and returns the string to draw, which
+// is `text` itself whenever a rung fitted. Only when the smallest still
+// overflows does it fall through to fitLines() above: a word boundary and an
+// ellipsis the cut can really draw, never a silent cut mid-word.
+inline std::string fittedTitle(const freeink::ui::DrawTarget& target, const char* text, const int16_t width,
+                               freeink::ui::TextStyle& style) {
+  namespace fui = freeink::ui;
+  if (text == nullptr || *text == '\0' || width <= 0) return std::string(text == nullptr ? "" : text);
+
+  // The three slots a GfxRendererTarget binds, plus whatever the caller asked
+  // for. Three because three is all there are: the fui components resolve only
+  // these and fall back to BODY for anything else, so a fourth id would name a
+  // face no component could ever draw in.
+  const fui::FontId slots[4] = {style.font, fui::FONT_SLOT_TITLE, fui::FONT_SLOT_BODY, fui::FONT_SLOT_SMALL};
+  fui::FontId rungs[4] = {};
+  int16_t heights[4] = {};
+  int count = 0;
+  const int16_t ceiling = target.lineHeight(style.font);
+  for (const fui::FontId slot : slots) {
+    const int16_t height = target.lineHeight(slot);
+    if (height > ceiling) continue;  // fitting only ever goes down
+    bool seen = false;
+    for (int i = 0; i < count; ++i) seen = seen || rungs[i] == slot;
+    if (seen) continue;
+    rungs[count] = slot;
+    heights[count] = height;
+    ++count;
+  }
+  // Largest first. An insertion sort over at most four rungs, so the order is
+  // the measurement rather than an assumption about the slots.
+  for (int i = 1; i < count; ++i) {
+    for (int j = i; j > 0 && heights[j] > heights[j - 1]; --j) {
+      const fui::FontId font = rungs[j];
+      const int16_t height = heights[j];
+      rungs[j] = rungs[j - 1];
+      heights[j] = heights[j - 1];
+      rungs[j - 1] = font;
+      heights[j - 1] = height;
+    }
+  }
+
+  // A rung fits when the WHOLE string lays out in it, which for a style that
+  // may wrap is not the same question as "is it narrower than the box". The
+  // measured width answers the one-line case directly and cheaply; anything
+  // wider is put through the same wrap that will draw it, and fits only if the
+  // wrap gave everything back. The fit test IS the layout, which is the rule
+  // the Connections tiles arrived at independently.
+  const int lines = style.maxLines > 0 ? style.maxLines : 1;
+  fui::TextStyle probe = style;
+  for (int i = 0; i < count; ++i) {
+    probe.font = rungs[i];
+    if (target.measureText(rungs[i], text, probe).width <= width) {
+      style.font = rungs[i];
+      return std::string(text);
+    }
+    if (lines > 1 && fitLines(target, text, width, lines, probe) == text) {
+      style.font = rungs[i];
+      return std::string(text);
+    }
+  }
+
+  // Even the smallest cut this screen bound will not take it. Wrap and mark,
+  // which is the rule's own last clause and what fitLines has always done.
+  if (count > 0) style.font = rungs[count - 1];
+  return fitLines(target, text, width, lines, style);
+}
+
 }  // namespace toybox

--- a/src/apps_local/xkcd/XkcdScreens.cpp
+++ b/src/apps_local/xkcd/XkcdScreens.cpp
@@ -1,6 +1,9 @@
 #include "XkcdScreens.h"
 
 #include <cstdio>
+#include <string>
+
+#include "../ui/ToyboxText.h"
 
 namespace xkcdui {
 namespace {
@@ -128,33 +131,6 @@ void addButton(toybox::Screen& screen, fui::ButtonProps props, const fui::Rect& 
 // this defect, because the ellipsis is not in the font. Adding U+2026 to
 // tools_local/toybox/gen_toybox_fonts.sh would fix the class, at the cost of
 // regenerating shared font headers.
-void fitLabel(const fui::DrawTarget& target, const char* text, int16_t width, const fui::TextStyle& style, char* out,
-              int cap) {
-  if (out == nullptr || cap <= 0) return;
-  out[0] = '\0';
-  if (text == nullptr) return;
-
-  int n = 0;
-  while (text[n] != '\0' && n < cap - 1) out[n] = text[n], ++n;
-  out[n] = '\0';
-  if (target.measureText(style.font, out, style).width <= width) return;
-
-  // Give back a character at a time until the text plus its ellipsis fits.
-  // Measured rather than counted: the face is proportional, so a character
-  // budget over-trims a narrow title and under-trims a wide one.
-  while (n > 0) {
-    --n;
-    out[n] = '\0';
-    if (n + 3 < cap) {
-      out[n] = '.';
-      out[n + 1] = '.';
-      out[n + 2] = '.';
-      out[n + 3] = '\0';
-    }
-    if (target.measureText(style.font, out, style).width <= width) return;
-    out[n] = '\0';
-  }
-}
 
 // The theme's title style is built for the header band, which is solid black,
 // so its colour is White. Drawn on paper it is white on white: invisible, and
@@ -501,9 +477,16 @@ void buildReaderBar(toybox::Screen& screen, const ReaderModel& model) {
   // text on the font's *line box*, which is taller than the ink, so a short
   // rect pushes the baseline past the bottom of the panel. That drew the title
   // half off the screen and filled the log with out-of-range pixel writes.
-  char fitted[80];
-  fitLabel(screen.target(), left, labelWidth, label, fitted, sizeof(fitted));
-  screen.target().text(fui::makeRect(toybox::kGutter, bar.y, labelWidth, kBarHeight), fitted, label);
+  //
+  // Fitted by the ladder rather than by an ellipsis. This used to give back one
+  // character at a time until the title plus "..." fitted, at the one cut it was
+  // handed -- so 936 of the 3279 titles on a full pack reached the bar short,
+  // measured, and none of them had been offered a smaller cut first. The bar
+  // binds a second one it can step down to; both line boxes clear its 44px, so
+  // stepping down costs the bar no height. host-tests/fittedtitle walks every
+  // title in the pack and publishes what is left.
+  const std::string fitted = toybox::fittedTitle(screen.target(), left, labelWidth, label);
+  screen.target().text(fui::makeRect(toybox::kGutter, bar.y, labelWidth, kBarHeight), fitted.c_str(), label);
 
   if (showMap) drawMap(screen, map, model);
 


### PR DESCRIPTION
> **Panel check owed, not blocking.** This merges on host evidence; the
> photographs happen in the morning and any finding becomes a follow-up card
> (card #237, `desk`).
>
> The device could not be reached tonight: X4 Pro `b8:1f:3f:d4:82:60`
> enumerates, but that is the ESP32-S3's built-in USB-Serial-JTAG peripheral,
> which appears whenever the chip has power and says nothing about the app. Its
> dev bridge does not answer, the port emits zero bytes across a reset, esptool
> cannot enter download mode in any `--before` mode, and it is not on the
> network. It needs a button pressed on the device.
>
> **What a reviewer should look at, and why it is narrow.** `headerBand()` now
> fits every band in the fork, so the change is fork-wide — but it can only ever
> make a cut SMALLER, never larger, and only for a title that does not fit. When
> a title fits, `fittedTitle` returns the string and the font untouched and the
> draw is byte-identical: same rect, same theme substitutions. On today's data
> all five reported header sites already fit, so nothing on them moves.
>
> **Exactly one header in the fork changes today, and I measured which.**
> `fittedTitle` only alters a title that does not fit, so I measured every
> header corpus against the width its band really gives it:
>
> | screen | right label | room | steps down? |
> | --- | --- | --- | --- |
> | Toy Battle brief (map names) | none | 448px | **yes** — `CURSED CEMETERY` is 460px, drops to the UI cut |
> | dungeon guide | `1/8` | 393px | no |
> | Toy Battle how-to | `8/8` | 386px | no |
> | Connections date, Forehead category, linkplay title | none | 448px | no |
>
> That matters because of a second-order effect worth knowing about:
> `components/controls/header.h` bottom-aligns `rightLabel` to the *title's* line
> box, so a title that shrinks drags its right label down with it. **No screen
> that carries a right label steps down today**, so that interaction is real in
> the code and unexercised by current data — nobody needs to go hunting it.
>
> So the render to look at is Toy Battle's brief on the Cursed Cemetery map,
> plus the dungeon CLEARED screen (not a header — its two-line name now steps to
> the UI cut, which also buys back the height: two display lines are 126px in a
> 90px box, two UI lines are 84).

Mario, about Connections tiles: **"a tile needs to show the whole text, no exceptions."**

`ToyboxFonts.h:52-57` has stated the mechanism for that in prose since the
reading cuts landed — *"pick the largest cut it fits in, walking the available
cuts down, and only break a word when the smallest still overflows"* — and
there was no `toybox::` function that did it. Six apps had written their own
ladder. Every screen that had not handed its title to a component that cuts
rather than shrinks.

## The shared function

`toybox::fittedTitle(target, text, width, style&)` — the largest cut this
screen bound in which the whole string lays out, walking down, never above the
cut the caller chose; and only when the smallest still overflows, `fitLines`'s
word-boundary ellipsis rather than a silent cut.

It differs from all six copies in the thing all six got wrong: **the rungs are
ordered by what the face measures, not by slot name.** Every copy walks TITLE,
BODY, SMALL, which only descends while an app binds descending cuts.
`bigNumberFaces()` puts the 64px cut in BODY and the 30px one in TITLE;
`cardFaces()` puts 44 in SMALL and 64 in TITLE. On either of those a "step
down" steps *up*. It also tests a wrapping style by running the wrap that will
draw it, rather than by comparing one line's width.

`toybox::headerBand()` applies it to every band in the fork. That is where the
five reported data-title sites are fixed — connections `:215`, forehead `:619`,
link `:85`, dungeon `:714`, xkcd `:331`/`:580` — without editing one of the
twenty-four chrome copies. `headerTitleWidth()` works the room out with the
header component's own arithmetic instead of guessing from the page margins,
and against the band **clipped to the visible rows**: the component sizes its
leading and trailing buttons from that rect's height, so measuring them against
the taller full band reserved ten pixels the title never got back.

## The six ladders

**Folded in** (behaviour preserved, verified by measuring every `Faces` set's
real `advanceY`): toybattle's `fittedHeaderTitle` (deleted; it also reserved the
right label's width the component already subtracts, charging the title for the
counter twice), insider's `fitted()`, the dungeon's `fitLabel()`. Plus a seventh
the report did not list: the xkcd bar's own `fitLabel()`, which was not a ladder
at all, only the ellipsis half.

**Kept, and why:**

- `connections`' `chooseTileCut` sizes ONE cut for sixteen strings at once.
  Different rule, and another session owns that file right now —
  `ConnectionsScreens.cpp` is untouched by this PR.
- `forehead`'s `layOutCard` emits its own per-line rects for a three-line card.
- `ToyboxText`'s `fitLines` is the fallback half, now called *by* `fittedTitle`
  rather than instead of it.

## Three defects the suite found that the report did not have

- The dungeon's **CLEARED** screen elided 7 of its 65 dungeon names — on the
  screen whose only job is to name what you just finished.
- The **Hacker News reader** fitted its headline to a room ~90px wider than the
  one it gets: the SAVE control is in the band and in neither term of the sum,
  so a long headline was elided by the app and then elided again by the
  component.
- `headerTitleWidth` measured that same SAVE label at font 0 (SMALL) while the
  component draws it at `bodyText` — 51px measured against the 91px it occupies,
  with the error pointing the wrong way.

## And one the report has backwards

On today's data all five reported header sites **already fit** at the display
cut. The exposure was real (no fitting existed on that path) but nothing was
being cut there. The suite prints the numbers.

## The suite

`host-tests/fittedtitle/` walks **11,237 real strings** — a number it prints
rather than one typed here — through the real builders: every dungeon guide
page, every dungeon name on both screens that show one, every Forehead category,
every linkplay game, every Toy Battle map and how-to page, every date the
Connections header can format, the Hacker News reader's captured headlines, and
every comic title in the pack.

Its DrawTarget measures with the **real cuts** (`EpdFont` over
`src/apps_local/ui/fonts`) and reproduces `GfxRenderer`'s own truncation, so it
can see a title being cut at all. `host-tests/ui` cannot: its target answers ten
pixels a character and records whatever string it was handed.

The corpora are derived, never copied: `corpus.py` reads the linkplay titles out
of the game Activities, the guide and how-to titles out of their tables, the
comic titles out of the pack, the font ids out of `ToyboxFonts.cpp`'s
`insertFont` calls and the Faces triples out of `ToyboxTheme.h`.

It **gates** on the constructible property — *no string is cut while a cut this
screen bound would have shown it whole* — and **publishes** the residual.

Verbatim, on the code before this change:

```
xkcd: comic titles in the bar       3279 walked   588 avoidable   348 residual    0 never drawn
      longest short of it: #7  Girl sleeping (Sketch -- 11th grade Spanish class)
                      -> #7  Girl sleeping (Sketc...
FAIL fittedtitle  xkcd: comic titles in the bar: 588 of 3279 strings were cut while a bound cut would have shown them whole
```

With the ladder removed again from `headerBand` it prints
`CURSED CEMETERY -> CURSED CEMETE...`, which is the symptom ToyBattle's own
comment recorded.

## A cold review found the tests could not fail

A reviewer was given the spec and the diff and told to falsify seven claims. It
falsified three, and the two that mattered said this suite could not fail on the
thing the change is about. All are closed in the second commit:

- **Blind to its own headline claim.** Reintroducing the exact bug the ladder
  exists to fix — cuts walked by slot *name*, ceiling dropped — produced
  byte-identical output. The corpora only see a string arriving *short*; a
  ladder stepping the wrong way makes strings arrive *big*. `theLadderItself()`
  asserts both properties directly, and two of its checks were watched going red
  with the sort and the ceiling removed.
- **Two corpora were circular.** `dungeonGuide` and `toyBattleHowTo` read the
  expected string off the panel *after* the fit, and `headerBand` rewrites
  `props.title` before drawing — so `drawn == expected` always. Proved by
  truncating every title to five characters and watching both stay green. Both
  now come from the tables and assert their count against the app's own page
  count; under the same experiment they report 8 of 8.
- **With no card, the largest corpus walked zero and passed green.** Every
  corpus now fails if it walked nothing; the one that can legitimately be absent
  prints `SKIP` at line start, which `check.sh` surfaces.
- **The HN fix was guarded by nothing** — the suite did not compile that app. It
  does now, and reverting the fix moves the count.

## What is left, published rather than hidden

450 strings — 348 comic titles, 78 Hacker News headlines, 24 dungeon names —
that no bound cut can show whole on one line. Card #254.

And one **kept exception**, pinned rather than fixed: 10 of 90 Hacker News
headline cases are cut where the small slot *would* have shown them whole. That
slot binds `toybox_10`, so obeying the ladder would set ten headlines in a 21px
Jersey line box inside a 76px band while the other 78 stay elided at
`reading_serif_14` anyway. That is a face-binding decision (`readerFaces`, or
`reading_serif_11` in a reachable slot) — **card #268**. Pinned at exactly 10
with the reason at the call site: reverting the `saveWidth` fix moves it *down*
to 6, which a `<=` check would have passed.

## NOT VERIFIED

No device and no simulator shot. Every measurement here is the host suite's,
over the real font data. Green under Apple clang and `g++-16` (nothing in CI or
`check.sh` compiles this suite with GCC, so that was run by hand).

The suite walks eight screens; about twenty files call `headerBand`. Adding one
is a line in its `run.sh` and a loop.

One observation not acted on: the CLEARED screen reserves 90px for a name block
that is two display lines (126px) for most of the 65 names. Nothing else is
drawn in the overrun, so it is an under-sized rect rather than a collision, and
the ladder now steps the longest names down to the UI cut where two lines are 84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
