### PR TITLE
Harden the two public bridges: close the gitignore hole, fix a cross-user traversal, and attack them as a deploy gate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,8 @@ failure rather than something the next reader has to notice.
 project is (`identity.md`), the shelf contract (`shelf.md`), the two real
 buttons (`buttons.md`), what scale does to games (`games-at-scale.md`), how to
 reflash and inspect a device over Wi-Fi with no cable
-(`developer-mode.md`), and what is knowingly unfinished (`open-items.md`).
+(`developer-mode.md`), how the two open bridges are attacked and defended
+(`bridge-security.md`), and what is knowingly unfinished (`open-items.md`).
 
 Four more are narrower but no less load-bearing, and this paragraph did not
 name any of them until the suite started asking: what the glass hides

--- a/docs/bridge-security.md
+++ b/docs/bridge-security.md
@@ -1,0 +1,214 @@
+# Hardening the two bridges
+
+`server/read-bridge` (Instapaper, **read.ma-r-s.com**) and `server/study-bridge`
+(AnkiWeb, **sync.ma-r-s.com**) are open to anyone on the internet and their
+source is public. Every number below -- the rate limits, the code alphabet, the
+lockout windows, the token lifetimes -- is readable by whoever is attacking
+them. That is how every real service works, and it means **nothing here may
+depend on any of it being unknown.**
+
+This is the whole picture in one place: what the threat model is, what each
+layer refuses, what Mario has to click in Cloudflare, and what is still not
+covered. `server/read-bridge/README.md` and `server/study-bridge/README.md`
+describe the services; this file is only about attacking them.
+
+## The threat model, which is narrower than it looks
+
+Both services do the same three things, and there is nothing else on their
+surface:
+
+1. take a password once, exchange it upstream for a token, **never store the
+   password** (`bridge/accounts.py` in both),
+2. pair a device: the reader shows an 8-character code, a signed-in human
+   claims it in a browser, the reader asks for a button press before it stores
+   anything (`bridge/pairing.py`, byte-identical twins),
+3. sync, and serve files, to a device holding a bearer token.
+
+So the things worth attacking are: the **sign-in** endpoint, which is a
+credential-stuffing oracle by construction; the **pairing** flow; the **device
+token** path; and whatever the **session cookie** authorises. What is NOT in
+the model: the box itself (see each service's `scripts/firewall.sh` and
+`isolation_test.sh`, and the `a-green-deploy-is-not-an-isolated-one` memory),
+and the upstream accounts themselves.
+
+## Three layers, and each one does a different job
+
+Confusing them is how a limit ends up in the wrong place.
+
+| Layer                          | Answers                                         | Where                 |
+| ------------------------------ | ----------------------------------------------- | --------------------- |
+| Cloudflare rate limiting rules | "should this request reach the pi at all?"      | dashboard, below      |
+| in-process limiters            | "is this account or address being abused?"      | `bridge/app.py`       |
+| the isolation firewall         | "if the container is owned, what can it touch?" | `scripts/firewall.sh` |
+
+The edge layer exists because the origin is a small ARM box running one uvicorn
+worker with `pids_limit` 128 (read) / 256 (study). Volume that the app would
+refuse still costs it a socket, a thread and a scheduling slot; the edge is what
+makes that volume free.
+
+The app layer exists because Cloudflare cannot see accounts. A spray that uses
+each address once is invisible to a per-IP rule and obvious to a per-account
+one, and vice versa. Neither layer replaces the other.
+
+## What the app refuses today
+
+Numbers and their reasons, both services (they are twins, and were made twins
+on 2026-09-05 -- study-bridge had the weaker half of every pair):
+
+| Limiter                       | Setting                                                       | Why that number                                                                                                                                                                                                                                                                                                                                                                                    |
+| ----------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LOGIN_IP`                    | 5 / 5 min / address                                           | A person signs in once. Five covers a mistype and a password-manager retry.                                                                                                                                                                                                                                                                                                                        |
+| `LOGIN_LOCKOUT`               | 2 free failures, then 30s doubling to 1h, forgotten after 24h | Counts **failures**, not attempts, so a person who signs in correctly is never slowed however often they do it, and an attacker is slowed by the thing that identifies them. Checked _before_ the upstream call, so a locked-out username costs Instapaper/AnkiWeb nothing.                                                                                                                        |
+| `GLOBAL_LOGIN`                | 30 / min, service-wide                                        | The ceiling with only **one** of it. Per-IP and per-username counters are both defeated by having many of each, which is exactly what a credential-stuffing run has. Set far above any real rate, so it is a backstop and not a throttle. It does mean a flood can deny sign-in to everyone while it lasts: a bounded oracle that is briefly unavailable beats an unbounded one that is always up. |
+| `CLAIM_IP` / `CLAIM_USER`     | 20 / 5 min each                                               | Guessing a pairing code. 32^8 codes over a five-minute life is not guessable; guessing **for free** was the problem, and until 2026-09-05 the claim endpoint answered unlimited wrong codes to anyone with an account of their own.                                                                                                                                                                |
+| `PAIR_IP`                     | 10 / 5 min                                                    | Starting pairings. A person pairs a reader once.                                                                                                                                                                                                                                                                                                                                                   |
+| `REPORT_IP` / `GLOBAL_REPORT` | 30 / 5 min, 240 / min                                         | Device crash reports ride the `X-CrossPlay-Report` header of any response under 400 -- including `/healthz`, which takes no token. Uncapped, that is a stranger writing rows to the board as fast as they can open sockets, one thread each.                                                                                                                                                       |
+| `SYNC_USER` / `GLOBAL_SYNC`   | 6 / 5 min, 60 / min                                           | A sync is expensive; a reader syncs on a schedule.                                                                                                                                                                                                                                                                                                                                                 |
+
+There is deliberately **no** flat per-username window beside `LOGIN_LOCKOUT`.
+read-bridge had one and it shadowed the lockout completely -- both keyed on the
+username, the flat one fired first, and its cruder message was the only thing a
+locked account ever saw. Two limiters on one key, the weaker winning, is worse
+than either alone.
+
+### The assumption under every per-IP limit
+
+`client_ip()` trusts the `CF-Connecting-IP` header. That is correct **only**
+because cloudflared is the sole route to the origin and Cloudflare overwrites
+that header on the way in. Nothing is published on the host and the compose
+network is not reachable from the LAN, so today the assumption holds.
+
+It is written down here because it is load-bearing and invisible: if the origin
+were ever exposed directly, every per-IP limit becomes worthless in one line of
+curl. `GLOBAL_LOGIN` is what still stands in that case, which is the reason it
+exists rather than being redundant with the per-IP rule.
+`server/attacks.py` spoofs the header on purpose for exactly this reason.
+
+## Cloudflare: what Mario has to click
+
+**Nothing here can be done from this repository.** The tunnel is TOKEN-managed,
+so its routes and the zone's rules live in the dashboard rather than in a file
+on the pi, there is no `cf` CLI in this workspace, and no API token exists for
+one. Every step below is manual, and it is the only part of this card that is.
+
+Go to **dash.cloudflare.com > the `ma-r-s.com` zone > Security > WAF > Rate
+limiting rules**, and add:
+
+### Rule 1 (the one that matters): authentication endpoints
+
+- **Name**: `bridge auth`
+- **If incoming requests match** (use the _Edit expression_ box):
+
+  ```
+  (http.host in {"read.ma-r-s.com" "sync.ma-r-s.com"}
+   and http.request.method eq "POST"
+   and http.request.uri.path in {"/login" "/api/pair/claim" "/api/pair/start"})
+  ```
+
+- **Characteristics**: IP
+- **Rate**: 20 requests per 1 minute
+- **Action**: Block, **Duration** 1 hour
+- **Response**: default (429)
+
+Twenty POSTs to those three paths in one minute is not a person: a real sign-in
+is one request, a real pairing is one claim and one start. It is four times the
+app's own per-IP sign-in allowance, deliberately -- the app should be the thing
+that shapes a legitimate person's experience, and this rule should only ever
+fire on traffic the app was already going to refuse. Its value is that the
+traffic stops at Cloudflare instead of at the pi.
+
+**On the Free plan you get one rate limiting rule per zone.** That is why the
+expression covers three paths and both hostnames at once rather than being
+three tidy rules. If the zone is on Pro or above, split it: `/login` at 20/min,
+`/api/pair/claim` at 30/min, `/api/pair/start` at 30/min, and add rule 2.
+
+### Rule 2 (Pro and above only): the device API
+
+- **Name**: `bridge api volume`
+- **If**: `(http.host in {"read.ma-r-s.com" "sync.ma-r-s.com"} and starts_with(http.request.uri.path, "/api/"))`
+- **Characteristics**: IP
+- **Rate**: 600 requests per 1 minute
+- **Action**: Block, Duration 10 minutes
+
+Sized from what a real sync does, not from a round number: a first Instapaper
+sync downloads one file per article and Mario's own account was 21 of them, so
+a reader can legitimately burst 25-30 requests, and a household with two
+readers on one address can do that several times an hour. 600/min leaves an
+order of magnitude of headroom and still stops a flood dead.
+
+### Two things NOT to turn on
+
+- **Bot Fight Mode** (Security > Bots). It challenges non-browser clients, and
+  the readers _are_ non-browser clients: they speak plain HTTPS from wolfSSL
+  with no JavaScript. Turning it on breaks every sync on every device, and it
+  will look like the bridge is down.
+- **A managed challenge action on any `/api/` rule**, for the same reason. For
+  API paths the action must be **Block**. Challenges are fine on the human
+  pages (`/`, `/pair`, `/devices`) if a rule is ever wanted there.
+
+### After changing anything
+
+Nothing in this repository can read the zone's configuration back, so the only
+verification is behavioural:
+
+```bash
+cd server/read-bridge && .venv/bin/python tests/attack_test.py --base https://read.ma-r-s.com
+cd server/study-bridge && .venv/bin/python tests/attack_test.py --base https://sync.ma-r-s.com
+```
+
+That runs the subset of the attack suite which is safe against a service people
+are using. It does **not** run the floods -- they would spend a shared rate
+limiter and lock real accounts out -- so it cannot confirm the rule fires. To
+confirm that, watch **Security > Events** in the dashboard while making the
+requests, or accept that this one is unverified from here and say so.
+
+## The attack suite
+
+`server/attacks.py` is one checklist run against both services. One file, not
+two, because every security bug found in these bridges so far has been a fix
+that landed on one twin and not the other -- including the cross-user traversal
+that this suite was written to catch.
+
+```bash
+server/read-bridge/.venv/bin/python  server/read-bridge/tests/attack_test.py
+server/study-bridge/.venv/bin/python server/study-bridge/tests/attack_test.py
+server/verify_attacks.sh          # the matrix: watch every check go red
+```
+
+Both deploy scripts run the hermetic form **before** they ship anything, so a
+vulnerable service is never deployed. That follows the precedent set by
+`isolation_test.sh`: a claim about safety that nothing runs is not a claim.
+
+`server/verify_attacks.sh` is the part that makes the suite worth having. For
+each entry in `server/weaken.py` it breaks the service on purpose, runs the
+suite, and asserts that **exactly** the checks that weakening claims went red --
+both directions, because a check that stays green under its own weakening does
+not work, and a check that reddens under a weakening it does not claim means the
+map from "this went red" to "this is broken" is wrong. Run it whenever a check
+is added or changed.
+
+## What is not covered, and should be said out loud
+
+- **The Cloudflare rules are unverified from here.** Nothing in the repository
+  can read the zone back. If Mario does not click them, the app-layer limits
+  are the only ones there are -- which is a real defence, just a more expensive
+  one for the pi.
+- **The live services have not been attacked.** Every result above is against
+  the real ASGI app with a real fake upstream, on a developer machine. The
+  `--base` mode exists for the live run and its safe subset is a subset.
+- **In-memory limiters die with the process.** A deploy or a reboot forgets
+  every counter and every lockout, so a restart loop is a way to reset the
+  backoff. The services are pinned to one worker (the per-user asyncio mutex
+  stops being a mutex above one), so there is no cross-worker gap, but there is
+  a cross-restart one. Fixing it means persisting the lockout, which is a
+  different change and is not made here.
+- **`/api/pair/poll` is deliberately unlimited.** A reader polls it every
+  second or two for up to five minutes while a human types the code, so any
+  rate limit tight enough to matter would break pairing. Its token is 24 random
+  bytes and is not guessable; the exposure is request volume, which is what the
+  edge rule is for.
+- **Fernet-at-rest buys nothing against a live compromised box** -- the key is
+  in the environment next to the data. It exists so that backups and stray
+  copies of a data directory carry no usable credentials. Both `accounts.py`
+  files say so; it is repeated here so nobody reads "encrypted at rest" as more
+  than it is.

--- a/server/attacks.py
+++ b/server/attacks.py
@@ -1,0 +1,730 @@
+"""The attacks an outsider would actually run, as a suite that fails a deploy.
+
+Both bridges are open to the world and their source is public: the rate
+limits, the code alphabet, the lockout windows and the token lifetimes are all
+readable by whoever is attacking them. Security therefore cannot rest on any
+of them being unknown, and this file is how that is checked rather than
+asserted. It is the sibling of scripts/isolation_test.sh -- the precedent that
+a claim about safety which nothing runs is not a claim -- and it is wired into
+both deploy scripts for the same reason.
+
+ONE FILE, TWO SERVICES, deliberately. read-bridge and study-bridge are twins
+and every security bug found in them so far has been a fix that landed on one
+twin and not the other (the fix-the-twin-too memory; the cross-user traversal
+this suite was written to catch was exactly that shape -- read-bridge sanitised
+the filename it took off the wire, study-bridge did not). A shared checklist
+cannot drift. What differs between the services is described by the Service
+profile below and nothing else.
+
+The suite runs against the service's real ASGI app, over its real HTTP surface,
+with a real fake upstream behind it. It does not import the limiters and ask
+them questions; it asks the service.
+
+Two ways to run it, and only the first proves anything about the CODE:
+
+  hermetic (tests/attack_test.py, no arguments) -- a throwaway data directory
+      and a fake upstream. Every check runs, including the floods. This is
+      what gates a deploy.
+  live (tests/attack_test.py --base https://...) -- against a deployed
+      service. Only the checks that are SAFE against production run: nothing
+      that floods a shared rate limiter, locks a real account out, or writes.
+      Which checks those are is a property of the check (safe_live), not a
+      flag at the call site, so the list cannot rot.
+
+Adding a check: write it, then WATCH IT GO RED. weaken.py exists so that the
+checks which pass today can be seen failing against a service broken on
+purpose. A check that has never been red is a check that does not work; this
+repository has already shipped two of those.
+"""
+
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable
+
+# ---------------------------------------------------------------------------
+# What differs between the two services.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Service:
+    """One bridge, described only where it differs from the other."""
+
+    name: str
+    # Session cookie name: read_session / bridge_session.
+    cookie: str
+    # An account the fake upstream will accept, and its password.
+    good_user: str
+    good_password: str
+    # The device endpoint used to prove a token is or is not accepted. Must be
+    # a POST that answers 401 without a valid Bearer token.
+    sync_path: str
+    # A body that endpoint parses. Content, not correctness: these checks never
+    # get far enough for a real sync to matter.
+    sync_body: bytes
+    # The file-download endpoint, as a template taking one path segment string.
+    # The traversal probe fills it with dot segments; see traversal_reach().
+    download_template: str
+    # Where the victim's secret sits, relative to the data root, and a string
+    # that must never appear in a response.
+    victim_relative: str
+    sentinel: str
+    # Clears the service's rate-limit state. Called before EVERY check, never
+    # inside one: each check is its own scenario and must not fail because the
+    # check before it spent the global ceiling. Within a check the limiters are
+    # untouched, which is where they are actually under test.
+    reset: object = None
+    # Filled in by the harness before run().
+    client: object = None
+    victim_uid: str = ""
+    attacker_uid: str = ""
+    attacker_token: str = ""
+    # Endpoints that must refuse an unauthenticated caller outright, as
+    # (method, path, takes_a_body).
+    device_paths: list = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Bookkeeping. One line per check, and the failures say what was expected.
+# ---------------------------------------------------------------------------
+
+
+class Report:
+    def __init__(self, live: bool = False):
+        self.checks = 0
+        self.failures = 0
+        self.skipped = 0
+        self.live = live
+        # Which named checks went red. verify_attacks.sh reads these off
+        # stdout to assert that a given weakening reddens exactly the checks
+        # that claim to cover it.
+        self.red: list = []
+        self.current = ""
+
+    def ok(self, condition, what, detail=""):
+        self.checks += 1
+        if condition:
+            print(f"  ok    {what}")
+        else:
+            self.failures += 1
+            if self.current and self.current not in self.red:
+                self.red.append(self.current)
+            print(f"  FAIL  {what}")
+            if detail:
+                for line in str(detail).splitlines()[:6]:
+                    print(f"        {line}")
+
+    def skip(self, what, why):
+        self.skipped += 1
+        print(f"  skip  {what} -- {why}")
+
+
+CHECKS: list = []
+
+
+def check(name, *, safe_live=False):
+    """Register one attack. safe_live=True means it may be run against a
+    deployed service without harming it or anyone using it."""
+
+    def wrap(fn):
+        fn.check_name = name
+        fn.safe_live = safe_live
+        CHECKS.append(fn)
+        return fn
+
+    return wrap
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def sign_in(svc, username, password, ip=None):
+    headers = {}
+    if ip:
+        headers["CF-Connecting-IP"] = ip
+    return await svc.client.post(
+        "/login", data={"username": username, "password": password}, headers=headers
+    )
+
+
+def refused(response):
+    """Did the service turn this sign-in away for RATE, rather than for the
+    password? Both answer 200 with a page, because the page is for a person;
+    the status cannot tell them apart and the body can."""
+    return "Slow down" in response.text or response.status_code == 429
+
+
+def signed_in(response, svc):
+    return response.status_code == 303 and bool(response.cookies.get(svc.cookie))
+
+
+def traversal_reach(svc, up: int, tail: str) -> str:
+    """A download URL whose leading path segments climb `up` directories.
+
+    Percent-encoded, because an HTTP client normalises ".." out of a path
+    before it is sent and the server would never see it. The server decodes
+    before routing, so this is what a hostile client actually gets to say.
+    """
+    segments = ["%2E%2E"] * up
+    return svc.download_template.format(segments="/".join(segments), tail=tail)
+
+
+# ---------------------------------------------------------------------------
+# Sign-in
+# ---------------------------------------------------------------------------
+
+
+@check("credential stuffing: many passwords, one account, one address")
+async def stuffing_one_account(svc, r):
+    tries = 25
+    accepted = 0
+    for i in range(tries):
+        resp = await sign_in(svc, svc.good_user, f"guess-{i}", ip="203.0.113.10")
+        if refused(resp):
+            break
+        accepted += 1
+    r.ok(
+        accepted < tries,
+        f"guessing one account's password is cut off (got {accepted} of {tries} through)",
+        "Nothing stopped 25 consecutive wrong passwords for one account.",
+    )
+
+
+@check("credential stuffing: many accounts, one address")
+async def stuffing_one_ip(svc, r):
+    tries = 25
+    accepted = 0
+    for i in range(tries):
+        resp = await sign_in(
+            svc, f"victim-{i}@example.com", "hunter2", ip="203.0.113.20"
+        )
+        if refused(resp):
+            break
+        accepted += 1
+    r.ok(
+        accepted < tries,
+        f"spraying many accounts from one address is cut off (got {accepted} of {tries} through)",
+        "One address tried 25 different accounts and was never slowed.",
+    )
+
+
+@check("credential stuffing: a fresh address AND a fresh account every time")
+async def stuffing_distributed(svc, r):
+    """The attack that per-IP and per-username limits are both blind to.
+
+    A botnet has many addresses and a leaked password list has many accounts,
+    so the attacker never repeats either key. Only a ceiling with ONE of it --
+    a global counter -- can see this, which is why both services must have one.
+
+    CF-Connecting-IP is what the service believes: it sits behind cloudflared,
+    which overwrites that header, so in production it cannot be spoofed. This
+    check spoofs it anyway, because that is exactly the assumption that must
+    not be load-bearing -- if the origin is ever reachable off the tunnel, the
+    per-IP limit is worth nothing and the global ceiling is all that is left.
+    """
+    tries = 80
+    accepted = 0
+    for i in range(tries):
+        resp = await sign_in(
+            svc, f"spray-{i}@example.com", "hunter2", ip=f"198.51.100.{i % 254 + 1}"
+        )
+        if refused(resp):
+            break
+        accepted += 1
+    r.ok(
+        accepted < tries,
+        f"a distributed spray still hits a ceiling (got {accepted} of {tries} through)",
+        "Every per-IP and per-username limit was sidestepped by using each key\n"
+        "once, and nothing global stopped the run. This is the shape of a real\n"
+        "credential-stuffing run against a public service.",
+    )
+
+
+@check("a wrong password and an unknown account are refused alike", safe_live=True)
+async def login_is_not_an_account_oracle(svc, r):
+    """Otherwise the sign-in page answers 'does this person have an account
+    here', which is worth stealing on its own."""
+    a = await sign_in(svc, svc.good_user, "definitely-wrong", ip="203.0.113.30")
+    b = await sign_in(
+        svc, "no-such-person@example.com", "definitely-wrong", ip="203.0.113.31"
+    )
+    if refused(a) or refused(b):
+        r.skip(
+            "sign-in refusals do not name which half was wrong",
+            "rate-limited before both landed",
+        )
+        return
+    import re
+
+    def gist(resp):
+        text = re.sub(r"<[^>]+>", " ", resp.text)
+        return " ".join(text.split())
+
+    r.ok(
+        gist(a) == gist(b),
+        "sign-in does not say whether the account exists",
+        f"known account: {gist(a)[:160]}\nunknown account: {gist(b)[:160]}",
+    )
+
+
+@check("the sign-in page does not reflect what was typed into it", safe_live=True)
+async def login_does_not_reflect(svc, r):
+    payload = "</p><script>alert(1)</script>"
+    resp = await sign_in(svc, payload, "x", ip="203.0.113.40")
+    r.ok(
+        "<script>alert(1)</script>" not in resp.text,
+        "a script tag in the username does not come back as markup",
+        resp.text[:400],
+    )
+
+
+@check("the session cookie is HttpOnly, Secure and SameSite")
+async def session_cookie_flags(svc, r):
+    resp = await sign_in(svc, svc.good_user, svc.good_password, ip="203.0.113.50")
+    raw = resp.headers.get("set-cookie", "")
+    import re as _re
+
+    body = " ".join(_re.sub(r"<[^>]+>", " ", resp.text).split())[:240]
+    r.ok(
+        signed_in(resp, svc),
+        "the good password still signs in",
+        f"status {resp.status_code}, set-cookie {raw[:80]!r}\npage said: {body}",
+    )
+    low = raw.lower()
+    r.ok("httponly" in low, "Set-Cookie is HttpOnly", raw[:200] or "no Set-Cookie header")
+    r.ok("secure" in low, "Set-Cookie is Secure", raw[:200] or "no Set-Cookie header")
+    r.ok(
+        "samesite=lax" in low or "samesite=strict" in low,
+        "Set-Cookie is SameSite",
+        raw[:200] or "no Set-Cookie header",
+    )
+
+
+@check("a hand-made session cookie is not a session", safe_live=True)
+async def forged_session(svc, r):
+    import base64
+    import json as _json
+
+    forged = base64.urlsafe_b64encode(
+        _json.dumps({"uid": svc.victim_uid, "username": "victim", "csrf": "x"}).encode()
+    ).decode()
+    for cookie in (forged, "gAAAAA-not-a-real-token", ""):
+        resp = await svc.client.get(
+            "/devices", cookies={svc.cookie: cookie}, follow_redirects=False
+        )
+        r.ok(
+            resp.status_code in (302, 307) or "Sign in" in resp.text,
+            f"a forged session cookie ({cookie[:12] or 'empty'}...) is signed out",
+            f"status {resp.status_code}: {resp.text[:160]}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pairing
+# ---------------------------------------------------------------------------
+
+
+async def fresh_pairing(svc, ip="203.0.113.60"):
+    resp = await svc.client.post("/api/pair/start", headers={"CF-Connecting-IP": ip})
+    return resp.json()
+
+
+async def session_for(svc, username=None, password=None, ip="203.0.113.61"):
+    """A signed-in browser: cookie plus the CSRF token bound to it."""
+    import json as _json
+    import os
+
+    from cryptography.fernet import Fernet
+
+    resp = await sign_in(
+        svc, username or svc.good_user, password or svc.good_password, ip=ip
+    )
+    cookie = resp.cookies.get(svc.cookie)
+    if not cookie:
+        return None, None
+    key = os.environ.get("READ_FERNET_KEY") or os.environ["BRIDGE_FERNET_KEY"]
+    csrf = _json.loads(Fernet(key.encode()).decrypt(cookie.encode()))["csrf"]
+    return cookie, csrf
+
+
+@check("brute forcing a pairing code is cut off")
+async def pairing_brute_force(svc, r):
+    """A pairing code is eight characters from a 32-glyph alphabet and lives
+    five minutes, so guessing it is not the risk; guessing it FOR FREE is. An
+    endpoint that will answer an unlimited number of wrong codes is an
+    unlimited oracle over every code pending for every user at once, and the
+    only account it costs the attacker is one of their own.
+    """
+    cookie, csrf = await session_for(svc, ip="203.0.113.62")
+    if not cookie:
+        r.ok(
+            False, "brute forcing a pairing code is cut off", "could not sign in to try"
+        )
+        return
+    await fresh_pairing(svc)  # something to guess at
+    tries = 60
+    answered = 0
+    for i in range(tries):
+        resp = await svc.client.post(
+            "/api/pair/claim",
+            data={"code": f"{i:08d}".replace("0", "A"), "csrf": csrf},
+            cookies={svc.cookie: cookie},
+            headers={"CF-Connecting-IP": "203.0.113.62"},
+        )
+        if resp.status_code == 429 or "Slow down" in resp.text:
+            break
+        answered += 1
+    r.ok(
+        answered < tries,
+        f"wrong pairing codes stop being answered (got {answered} of {tries} through)",
+        "The claim endpoint answered 60 wrong codes without complaint. It is\n"
+        "the only guess-limiter the pairing code has.",
+    )
+
+
+@check("a pairing code cannot be claimed twice", safe_live=False)
+async def pairing_claim_is_single_use(svc, r):
+    cookie, csrf = await session_for(svc, ip="203.0.113.63")
+    if not cookie:
+        r.ok(
+            False, "a pairing code cannot be claimed twice", "could not sign in to try"
+        )
+        return
+    pair = await fresh_pairing(svc)
+    first = await svc.client.post(
+        "/api/pair/claim",
+        data={"code": pair["code"], "csrf": csrf},
+        cookies={svc.cookie: cookie},
+    )
+    second = await svc.client.post(
+        "/api/pair/claim",
+        data={"code": pair["code"], "csrf": csrf},
+        cookies={svc.cookie: cookie},
+    )
+    r.ok(
+        "confirm on the reader" in first.text,
+        "the first claim is accepted",
+        first.text[:200],
+    )
+    r.ok(
+        "did not work" in second.text,
+        "the same code claimed a second time is refused",
+        "A code claimed twice binds one reader to two accounts, and the second\n"
+        "claimant's reader is handed the first claimant's token.",
+    )
+
+
+@check("a delivered pairing cannot be replayed", safe_live=False)
+async def pairing_poll_is_one_shot(svc, r):
+    cookie, csrf = await session_for(svc, ip="203.0.113.64")
+    if not cookie:
+        r.ok(
+            False, "a delivered pairing cannot be replayed", "could not sign in to try"
+        )
+        return
+    pair = await fresh_pairing(svc)
+    await svc.client.post(
+        "/api/pair/claim",
+        data={"code": pair["code"], "csrf": csrf},
+        cookies={svc.cookie: cookie},
+    )
+    first = await svc.client.get(f"/api/pair/poll?pollToken={pair['pollToken']}")
+    replay = await svc.client.get(f"/api/pair/poll?pollToken={pair['pollToken']}")
+    r.ok(
+        first.status_code == 200 and first.json().get("deviceToken"),
+        "the device collects its token once",
+        first.text[:200],
+    )
+    r.ok(
+        replay.status_code == 410,
+        "replaying the poll token yields nothing",
+        "A pollToken that keeps answering hands a second device the same\n"
+        "account, and the poll token travels in a URL.",
+    )
+
+
+@check("claiming a code needs a session and its CSRF token", safe_live=True)
+async def pairing_claim_needs_csrf(svc, r):
+    pair = await fresh_pairing(svc)
+    no_session = await svc.client.post(
+        "/api/pair/claim", data={"code": pair["code"], "csrf": "x"}
+    )
+    r.ok(
+        no_session.status_code == 401,
+        "claiming without a session is refused",
+        f"status {no_session.status_code}: {no_session.text[:160]}",
+    )
+    cookie, csrf = await session_for(svc, ip="203.0.113.65")
+    if not cookie:
+        r.skip(
+            "claiming with the wrong CSRF token is refused", "could not sign in to try"
+        )
+        return
+    for bad in ("", "not-the-token", csrf[:-1]):
+        resp = await svc.client.post(
+            "/api/pair/claim",
+            data={"code": pair["code"], "csrf": bad},
+            cookies={svc.cookie: cookie},
+        )
+        r.ok(
+            resp.status_code == 401,
+            f"claiming with CSRF {bad[:10]!r} is refused",
+            f"status {resp.status_code}: {resp.text[:160]}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Device authentication
+# ---------------------------------------------------------------------------
+
+
+@check("device endpoints refuse an unauthenticated caller", safe_live=True)
+async def device_needs_auth(svc, r):
+    for method, path, _body in svc.device_paths:
+        resp = await svc.client.request(method, path)
+        r.ok(
+            resp.status_code == 401,
+            f"{method} {path} without a token is refused",
+            f"status {resp.status_code}: {resp.text[:160]}",
+        )
+
+
+@check("a forged bearer token is refused", safe_live=True)
+async def device_forged_token(svc, r):
+    for token in ("nonsense", "", "Bearer", "a" * 64, svc.attacker_token + "x"):
+        resp = await svc.client.post(
+            svc.sync_path,
+            content=svc.sync_body,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        r.ok(
+            resp.status_code == 401,
+            f"a made-up token ({token[:10]!r}) is refused",
+            f"status {resp.status_code}: {resp.text[:160]}",
+        )
+
+
+@check("one account's device cannot read another account's files")
+async def cross_user_files(svc, r):
+    """The check the study bridge failed on 2026-09-05.
+
+    Its deck endpoint built the directory it was going to serve out of FROM
+    THE URL, resolved it, and only then asked whether the target was inside
+    that directory. The comparison was true by construction: dot segments in
+    the leading parameters moved the base as well as the target. Two of them
+    reached <data>/users/, from which every other account's state.json --
+    their encrypted AnkiWeb hostKey and every device token hash paired to
+    them -- was one segment away.
+
+    The twin was safe for a reason worth writing down: read-bridge strips
+    everything but alphanumerics out of the filename it takes off the wire, so
+    the escape cannot be spelled at all. The lesson is not "add a check", it is
+    that a path from the network must be sanitised before it becomes a path.
+
+    This probe climbs every depth from one to six, so it cannot pass merely
+    because the depth it happened to try was wrong.
+    """
+    headers = {"Authorization": f"Bearer {svc.attacker_token}"}
+    leaked = []
+    tried = []
+    # Both spellings at every depth. The right one depends on how many
+    # directories the endpoint's own base sits below <data>/, which differs
+    # between the two services -- and a probe that guesses that wrong reports
+    # a clean run against a service that is wide open.
+    tails = [svc.victim_relative, "users/" + svc.victim_relative]
+    for up in range(1, 7):
+        for tail in tails:
+            url = traversal_reach(svc, up, tail)
+            resp = await svc.client.get(url, headers=headers)
+            tried.append(f"{up}:{resp.status_code}")
+            if resp.status_code == 200 and svc.sentinel in resp.text:
+                leaked.append(f"  {url}\n    -> {resp.text[:100]}")
+    r.ok(
+        not leaked,
+        f"no depth of dot segments reaches another account's files ({', '.join(tried)})",
+        "Another account's file came back over the download endpoint:\n"
+        + "\n".join(leaked),
+    )
+
+
+@check("a device cannot ask about another account's job", safe_live=False)
+async def cross_user_job(svc, r):
+    """Job ids are handed out per account and the status endpoint must bind
+    them to the caller, or a summary of somebody else's sync is one guess of
+    a short id away."""
+    headers = {"Authorization": f"Bearer {svc.attacker_token}"}
+    seen = []
+    for job in ("1", "2", "3", "job-1", "0"):
+        resp = await svc.client.get(f"/api/sync/status?job={job}", headers=headers)
+        body = (
+            resp.json()
+            if resp.headers.get("content-type", "").startswith("application/json")
+            else {}
+        )
+        if body.get("status") in ("done", "running", "queued") or "summary" in body:
+            seen.append(f"job={job} -> {resp.text[:120]}")
+    r.ok(not seen, "guessed job ids belong to nobody", "\n".join(seen) or "")
+
+
+@check("a revoked device token stops working immediately", safe_live=False)
+async def revoked_token_is_dead(svc, r):
+    import importlib
+
+    store = importlib.import_module("bridge.store")
+    pairing = importlib.import_module("bridge.pairing")
+    th = pairing.token_hash(svc.attacker_token)
+    before = await svc.client.post(
+        svc.sync_path,
+        content=svc.sync_body,
+        headers={"Authorization": f"Bearer {svc.attacker_token}"},
+    )
+    r.ok(
+        before.status_code != 401,
+        "the paired token works before revocation",
+        f"status {before.status_code}: {before.text[:160]}",
+    )
+    store.revoke_device(svc.attacker_uid, th)
+    after = await svc.client.post(
+        svc.sync_path,
+        content=svc.sync_body,
+        headers={"Authorization": f"Bearer {svc.attacker_token}"},
+    )
+    r.ok(
+        after.status_code == 401,
+        "and is refused the instant it is revoked",
+        f"status {after.status_code}: {after.text[:160]}",
+    )
+    store.register_device(svc.attacker_uid, th, "X4 Pro")
+
+
+# ---------------------------------------------------------------------------
+# What an unauthenticated stranger can spend
+# ---------------------------------------------------------------------------
+
+
+@check("an unauthenticated stranger cannot post to the board at will")
+async def report_flood(svc, r):
+    """Every response under 400 relays the caller's X-CrossPlay-Report header
+    to the board as a firmware event, on EVERY endpoint including /healthz --
+    which needs no token at all. Each one costs a thread and a row in Mario's
+    Supabase project. Unbounded, that is a stranger writing to the board as
+    fast as they can open sockets, and the container's pids_limit is 128.
+    """
+    import importlib
+
+    events = importlib.import_module("bridge.events")
+    sent = []
+    real_post = events.post
+
+    def counting_post(*a, **k):
+        sent.append(k.get("event"))
+        return None
+
+    events.post = counting_post
+    try:
+        for i in range(120):
+            await svc.client.get(
+                "/healthz",
+                headers={
+                    "CF-Connecting-IP": "203.0.113.90",
+                    "X-CrossPlay-Report": '{"crash":{"message":"flood","backtrace":"x"}}',
+                },
+            )
+    finally:
+        events.post = real_post
+    r.ok(
+        len(sent) < 120,
+        f"device reports from one address are capped ({len(sent)} of 120 relayed)",
+        "An unauthenticated GET /healthz relayed 120 crash reports to the board.\n"
+        "Nothing about the caller was checked, and each one costs a thread.",
+    )
+
+
+@check("the interactive API documentation is not published", safe_live=True)
+async def no_docs(svc, r):
+    for path in ("/docs", "/redoc", "/openapi.json"):
+        resp = await svc.client.get(path)
+        r.ok(
+            resp.status_code == 404,
+            f"{path} is not served",
+            f"status {resp.status_code}",
+        )
+
+
+@check("a malformed body is never a stack trace", safe_live=True)
+async def malformed_bodies(svc, r):
+    headers = {"Authorization": f"Bearer {svc.attacker_token}"}
+    junk = [
+        b"",
+        b"{",
+        b"not json at all",
+        b"\x00\xff\xfe",
+        b"[]",
+        b'{"decks": "not a list"}',
+        b"\xff\xff\xff\xff" + b"x" * 32,
+    ]
+    for method, path, takes_body in svc.device_paths:
+        if not takes_body:
+            continue
+        for body in junk:
+            resp = await svc.client.request(method, path, content=body, headers=headers)
+            r.ok(
+                resp.status_code < 500,
+                f"{method} {path} survives {body[:14]!r}",
+                f"status {resp.status_code}: {resp.text[:200]}",
+            )
+
+
+@check("an oversized body is refused rather than buffered")
+async def oversized_bodies(svc, r):
+    """Every endpoint that takes a body must have a ceiling on it. One that
+    does not is a way to spend the container's 512MB from the outside, and it
+    is reachable by anyone holding any device token -- including one for their
+    own account."""
+    headers = {"Authorization": f"Bearer {svc.attacker_token}"}
+    big = b'{"decks": ["' + b"A" * (12 * 1024 * 1024) + b'"]}'
+    for method, path, takes_body in svc.device_paths:
+        if not takes_body:
+            continue
+        resp = await svc.client.request(method, path, content=big, headers=headers)
+        r.ok(
+            resp.status_code in (400, 413),
+            f"{method} {path} refuses a 12MB body (status {resp.status_code})",
+            f"status {resp.status_code}: {resp.text[:200]}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+async def run(svc: Service, *, live: bool = False) -> Report:
+    r = Report(live=live)
+    print(
+        f"attacking {svc.name}" + (" (live: only the harmless checks)" if live else "")
+    )
+    for fn in CHECKS:
+        if live and not fn.safe_live:
+            r.skip(fn.check_name, "not safe against a service people are using")
+            continue
+        print(f"\n{fn.check_name}")
+        r.current = fn.check_name
+        if svc.reset is not None:
+            svc.reset()
+        try:
+            await fn(svc, r)
+        except Exception as e:  # a check that explodes is a failed check
+            r.failures += 1
+            r.checks += 1
+            if fn.check_name not in r.red:
+                r.red.append(fn.check_name)
+            print(f"  FAIL  {fn.check_name} raised {type(e).__name__}: {e}")
+    for name in r.red:
+        print(f"RED: {name}")
+    print(f"\n{svc.name}: {r.checks} checks, {r.failures} failed, {r.skipped} skipped")
+    return r
+
+
+CallableCheck = Callable[[Service, Report], Awaitable[None]]

--- a/server/board/.gitignore
+++ b/server/board/.gitignore
@@ -1,0 +1,13 @@
+# The board's connection secrets live in <workspace>/.board/supabase.env, which
+# is outside this repository -- but the Supabase CLI, `supabase link` and
+# dotenvx all write into the directory they are run from, and this repository
+# is public. supabase/.gitignore covers .env.local and .env.keys under
+# supabase/ only; it does not cover a plain .env, and it does not cover here.
+.env
+.env.*
+!.env.example
+*.pem
+*.key
+.branches
+.temp
+__pycache__/

--- a/server/read-bridge/.gitignore
+++ b/server/read-bridge/.gitignore
@@ -1,5 +1,31 @@
-.venv/
-data/
+# ma-r-s/crossplay is a PUBLIC repository and this directory is deployed by
+# hand from a developer machine, so the only thing between a maintainer's
+# `git add -A` and their Instapaper credentials on GitHub is this file.
+#
+# Every entry below is something this service, its deploy or its tests
+# actually write. Nothing here is speculative, and nothing that is written is
+# missing -- the two halves an ignore file gets wrong.
+
+# Secrets. .env exists on the pi at mode 600 (READ_FERNET_KEY, the Instapaper
+# consumer key and secret, CLOUDFLARE_TUNNEL_TOKEN, the Supabase anon key) and
+# is what `docker compose` substitutes ${VAR} from, so it appears in this
+# directory the moment anyone runs the stack locally. deploy.sh excludes it
+# from the rsync TO the pi; this excludes it from the trip INTO git.
 .env
+.env.*
+!.env.example
+# cloudflared writes these when a tunnel is run credentials-file style rather
+# than token style. Neither belongs to any tracked file here.
+*.pem
+*.key
+
+# The live credential store: users/<uid>/state.json holds every account's
+# Fernet-encrypted OAuth token and the device tokens paired to it.
+data/
+
+# Local build and tool output.
+.venv/
 __pycache__/
+# The deployed commit, stamped by scripts/deploy.sh and served on /healthz.
+# Derived per deploy; committing it would make every deploy a diff.
 BUILD

--- a/server/read-bridge/bridge/app.py
+++ b/server/read-bridge/bridge/app.py
@@ -62,6 +62,19 @@ GLOBAL_LOGIN = Window(30, 60)
 # for opening registration. Counts failures, not attempts.
 LOGIN_LOCKOUT = Lockout()
 PAIR_IP = Window(10, 300)
+# Guessing a pairing code. Eight characters from a 32-glyph alphabet is not
+# guessable inside its five minutes; guessing it FOR FREE is the problem, and
+# until 2026-09-05 the claim endpoint answered an unlimited number of wrong
+# codes to anyone holding an account of their own. Per-IP and per-account,
+# because either one alone is trivially sidestepped by varying the other.
+CLAIM_IP = Window(20, 300)
+CLAIM_USER = Window(20, 300)
+# Device reports ride any response under 400, including /healthz, which takes
+# no token at all. Each one costs a thread and a row on the board. These are
+# generous for a real reader (it reports on the handful of requests a sync
+# makes) and ruinous for a flood.
+REPORT_IP = Window(30, 300)
+GLOBAL_REPORT = Window(240, 60)
 # 6, matching the study bridge rather than the 8 that was here. There is an
 # argument that this service could allow more -- an Instapaper sync is a
 # handful of small calls where an Anki sync can move a collection and rebuild
@@ -134,8 +147,21 @@ async def device_reports(request: Request, call_next):
     device will count as delivered, so a request it retries does not post
     the same crash twice. events.Client.report never raises."""
     response = await call_next(request)
+    # Capped, because this runs on endpoints that need no token: without a
+    # limit an unauthenticated stranger writes to the board as fast as they
+    # can open sockets, and each report costs a thread against pids_limit.
+    # Dropping under flood is the right failure: a report is best-effort by
+    # design and no sync waits on one.
     if response.status_code < 400:
-        events.client_for(request).report(via="instapaper")
+        client = events.client_for(request)
+        # The limiter is consulted only when there is actually something to
+        # relay. Counting REQUESTS instead cost a real device its crash report
+        # in the middle of an ordinary sync: every article download carries the
+        # header, so a 21-article sync spent the whole budget on requests that
+        # were reporting nothing. tests/test_api.py caught it.
+        if client.crash is not None or client.ota is not None:
+            if REPORT_IP.allow(client_ip(request)) and GLOBAL_REPORT.allow("all"):
+                client.report(via="instapaper")
     return response
 
 
@@ -397,6 +423,16 @@ async def pair_claim(request: Request):
     form = await request.form()
     if form.get("csrf") != s["csrf"]:
         raise Unauthorized("stale form; reload the page")
+    # After the session and the CSRF token, so a wrong code costs an account
+    # rather than an anonymous request, and before the guess is answered.
+    if not CLAIM_IP.allow(client_ip(request)) or not CLAIM_USER.allow(s["uid"]):
+        return page(
+            "Slow down",
+            chrome.mark(False) + "<h1>Slow down</h1>"
+            "<p class=lede>Too many codes tried. Wait a few minutes, then ask"
+            " the reader for a fresh one.</p>",
+            step=2,
+        )
     okay = pairing.PAIRINGS.claim(str(form.get("code", "")), s["uid"], s["username"])
     if not okay:
         return page(
@@ -475,6 +511,11 @@ async def start_sync(request: Request, dev=Depends(require_device)):
     try:
         body = json.loads(raw or b"{}")
     except ValueError:
+        return JSONResponse({"error": "Malformed sync payload."}, 400)
+    # json.loads happily returns a list, a string or a number, and .get() on
+    # any of them was an unhandled AttributeError -- a 500 and a stack trace
+    # for a body of "[]".
+    if not isinstance(body, dict):
         return JSONResponse({"error": "Malformed sync payload."}, 400)
 
     have = body.get("have") or []
@@ -559,7 +600,11 @@ async def article_file(bookmark_id: int, bookmark_hash: str, dev=Depends(require
     # on the same door.
     target = st.article_path(bookmark_id, bookmark_hash).resolve()
     base = (st.root / "articles").resolve()
-    if not str(target).startswith(str(base)) or not target.is_file():
+    # is_relative_to, not str.startswith: the string form also accepts a
+    # SIBLING whose name merely begins with base's. Nothing can spell one here
+    # (bookmark_id is an int and the hash is stripped to alphanumerics), so
+    # this is the twin of the study bridge's fix rather than a bug of its own.
+    if not target.is_relative_to(base) or not target.is_file():
         return JSONResponse({"error": "That article is not on the bridge."}, 404)
     return FileResponse(target, media_type="text/plain; charset=utf-8")
 

--- a/server/read-bridge/scripts/deploy.sh
+++ b/server/read-bridge/scripts/deploy.sh
@@ -22,6 +22,36 @@ fi
 printf '%s\n' "$BUILD_ID" > "$SRC/bridge/BUILD"
 echo "shipping build $BUILD_ID"
 
+# ---------------------------------------------------------------------------
+# THE ATTACK SUITE RUNS BEFORE ANYTHING SHIPS.
+#
+# Same precedent as the isolation test below/beside this: a claim about safety
+# that nothing runs is not a claim. The difference is WHEN -- isolation is a
+# property of the deployed box and is checked after, this is a property of the
+# code and is checked before, because a service that fails it must never reach
+# the pi in the first place.
+#
+# Hermetic: its own throwaway data directory and its own fake upstream. It
+# touches nothing live and needs no network.
+# ---------------------------------------------------------------------------
+PY_LOCAL="$SRC/.venv/bin/python"
+if [ ! -x "$PY_LOCAL" ]; then
+  echo "FAILED: no venv at $SRC/.venv, so the attack suite cannot run and this"
+  echo "deploy cannot say whether the service is safe to publish. Create it:"
+  echo "  cd $SRC && uv venv .venv && uv pip install -r requirements.txt"
+  exit 1
+fi
+echo "attacking the build before shipping it ..."
+if ! "$PY_LOCAL" "$SRC/tests/attack_test.py"; then
+  echo
+  echo "FAILED: the attack suite is red. NOTHING WAS DEPLOYED."
+  echo "Each FAIL line above names what an outsider can do to this build."
+  echo "See docs/bridge-security.md; server/verify_attacks.sh proves the"
+  echo "checks themselves still work."
+  exit 1
+fi
+echo
+
 rsync -a --delete \
   --exclude .venv --exclude data/ --exclude .env --exclude __pycache__ \
   --exclude tests \

--- a/server/read-bridge/tests/attack_test.py
+++ b/server/read-bridge/tests/attack_test.py
@@ -78,6 +78,37 @@ def assert_alive(proc, port, what):
         )
 
 
+def _reap(proc):
+    """SIGTERM the process group, then SIGKILL what is left."""
+    import signal
+
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, PermissionError):
+        return
+    # Never signal our own group. Without this line a Popen that did not get
+    # start_new_session=True makes cleanup kill the suite, its shell and
+    # whatever started them -- which is exactly what happened on 2026-09-05
+    # when a formatter reflowed the Popen call and the edit adding
+    # start_new_session silently matched nothing. Absent code compiles; this
+    # is the guard that makes it fail loudly instead.
+    if pgid == os.getpgrp():
+        raise RuntimeError(
+            "refusing to kill my own process group: the child was started "
+            "without start_new_session=True"
+        )
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except (ProcessLookupError, PermissionError):
+            return
+        try:
+            proc.wait(timeout=8)
+            return
+        except subprocess.TimeoutExpired:
+            continue
+
+
 def wait_port(port, timeout=25):
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -296,19 +327,23 @@ def main():
                 ],
                 cwd=ROOT,
                 env=env,
+                # Its own process group, so _reap() can take the WHOLE tree
+                # rather than just the launcher -- and, critically, so that
+                # killpg cannot reach the process running this suite.
+                start_new_session=True,
             )
         )
         wait_port(FAKE_PORT)
         assert_alive(procs[-1], FAKE_PORT, "the fake Instapaper")
         return asyncio.run(main_async())
     finally:
+        # By GROUP, not by process. `python -m anki.syncserver` and uvicorn
+        # both hold their listening socket in a child, so terminating the
+        # launcher leaves the port held -- and the NEXT run then refuses to
+        # start, or worse, attacks whatever is still sitting there. One of
+        # these leaked for two hours on 2026-09-05 and blocked the matrix.
         for p in procs:
-            p.terminate()
-        for p in procs:
-            try:
-                p.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                p.kill()
+            _reap(p)
         shutil.rmtree(tmp, ignore_errors=True)
 
 

--- a/server/read-bridge/tests/attack_test.py
+++ b/server/read-bridge/tests/attack_test.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Run server/attacks.py against read-bridge.
+
+This file is the harness only: a throwaway data directory, a fake Instapaper,
+one victim account with something worth stealing and one attacker holding a
+device token for their OWN account. Every check lives in server/attacks.py and
+is shared with study-bridge, so a fix can never land on one twin alone.
+
+    .venv/bin/python tests/attack_test.py                 hermetic, gates deploy
+    .venv/bin/python tests/attack_test.py --base https://...   live, safe subset
+
+Run: scripts/deploy.sh runs the hermetic form before it ships anything.
+"""
+
+import asyncio
+import json
+import os
+import pathlib
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT.parent))  # server/, for attacks.py
+
+BASE_PORT = int(os.environ.get("BRIDGE_TEST_PORT", "8996"))
+FAKE_PORT = BASE_PORT + 3
+
+VICTIM, VICTIM_PW = "victim@example.com", "victim-pw"
+ATTACKER, ATTACKER_PW = "attacker@example.com", "attacker-pw"
+CONSUMER_KEY, CONSUMER_SECRET = "fake-consumer-key", "fake-consumer-secret"
+
+SENTINEL = "VICTIM-OAUTH-TOKEN-CIPHERTEXT"
+
+
+def port_is_free(port):
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s.bind(("127.0.0.1", port))
+        return True
+    except OSError:
+        return False
+    finally:
+        s.close()
+
+
+def require_free_port(port, what):
+    """Refuse to run against somebody else's server.
+
+    wait_port() proves that A process is listening, never that it is the one
+    this suite started -- and on 2026-09-05 that difference cost an hour: port
+    9003 was held by an orphaned read-bridge from another worktree, four days
+    old, and this suite spent every run signing AnkiWeb credentials into it.
+    Every sign-in failed, which read exactly like a bridge refusing a password.
+    A probe whose passing state is indistinguishable from the symptom proves
+    nothing.
+    """
+    if port_is_free(port):
+        return
+    print(f"port {port} is already in use, so {what} cannot start there and this")
+    print("suite would attack whatever IS listening. Find it and decide:")
+    print(f"  lsof -nP -iTCP:{port} -sTCP:LISTEN")
+    print("Set BRIDGE_TEST_PORT to move this tree's whole slice.")
+    raise SystemExit(2)
+
+
+def assert_alive(proc, port, what):
+    """And that it is still MY process answering, after the wait."""
+    if proc.poll() is not None:
+        raise RuntimeError(
+            f"{what} exited with {proc.returncode} before it could serve anything"
+        )
+
+
+def wait_port(port, timeout=25):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        s = socket.socket()
+        s.settimeout(0.5)
+        try:
+            s.connect(("127.0.0.1", port))
+            s.close()
+            return
+        except OSError:
+            time.sleep(0.2)
+    raise RuntimeError(f"nothing opened port {port}")
+
+
+def fixture_state():
+    """Both accounts exist upstream, so the allowlist is not what refuses a
+    guess: an attack suite whose sign-ins all bounce off an allowlist proves
+    nothing about the sign-in path."""
+    return {
+        "users": {
+            VICTIM: {"password": VICTIM_PW, "token": "tok-v", "secret": "sec-v"},
+            ATTACKER: {"password": ATTACKER_PW, "token": "tok-a", "secret": "sec-a"},
+        },
+        "bookmarks": [],
+    }
+
+
+async def main_async():
+    import httpx
+
+    import attacks
+    from bridge import app as appmod
+    from bridge import pairing, store
+    from bridge.app import app
+
+    def reset_limits():
+        """Every limiter this service holds, emptied. Listed by walking the
+        module rather than by name, so a limiter added later is reset too --
+        a hand-written list would silently leave the new one loaded and make
+        the next check fail for the wrong reason."""
+        from bridge.ratelimit import Lockout, Window
+
+        for value in vars(appmod).values():
+            if isinstance(value, Window):
+                value.hits.clear()
+            elif isinstance(value, Lockout):
+                value._state.clear()
+
+    victim_uid = store.uid_for(VICTIM)
+    attacker_uid = store.uid_for(ATTACKER)
+    for uid in (victim_uid, attacker_uid):
+        store.UserStore(uid).ensure()
+
+    # The victim's secret, where the service really keeps it.
+    victim = store.UserStore(victim_uid)
+    victim.save_state(
+        {
+            "username_enc": "x",
+            "token_enc": SENTINEL,
+            "secret_enc": "x",
+            "status": "ok",
+            "devices": {},
+            "last_sync": None,
+        }
+    )
+    # And an article of the victim's, in case a probe reaches sideways rather
+    # than upwards.
+    art = victim.article_dir(999)
+    art.mkdir(parents=True, exist_ok=True)
+    (art / "aaaa.txt").write_text(SENTINEL)
+
+    # The attacker's own account, CONNECTED. Without this every device call
+    # stops at "this account is not connected yet", which is a 401 for a
+    # reason that has nothing to do with the token -- and the checks about
+    # tokens would pass while proving nothing.
+    f = store.fernet()
+    attacker = store.UserStore(attacker_uid)
+    attacker.save_state({
+        "username_enc": f.encrypt(ATTACKER.encode()).decode(),
+        "token_enc": f.encrypt(b"tok-a").decode(),
+        "secret_enc": f.encrypt(b"sec-a").decode(),
+        "status": "ok",
+        "devices": {},
+        "last_sync": None,
+    })
+    token = "attacker-device-token-0123456789"
+    store.register_device(attacker_uid, pairing.token_hash(token), "X4 Pro")
+
+    svc = attacks.Service(
+        name="read-bridge",
+        cookie="read_session",
+        good_user=ATTACKER,
+        good_password=ATTACKER_PW,
+        sync_path="/api/sync",
+        sync_body=b'{"have": [], "archive": []}',
+        # /api/article/{bookmark_id}/{bookmark_hash}
+        download_template="/api/article/{segments}/{tail}",
+        victim_relative=f"users/{victim_uid}/state.json",
+        sentinel=SENTINEL,
+        victim_uid=victim_uid,
+        attacker_uid=attacker_uid,
+        attacker_token=token,
+        device_paths=[
+            ("POST", "/api/sync", True),
+            ("GET", "/api/sync/status?job=1", False),
+        ],
+        reset=reset_limits,
+    )
+
+    # raise_app_exceptions=False so an unhandled exception in a handler comes
+    # back as the 500 uvicorn would really send, instead of tearing down the
+    # suite. A handler that raises is a finding, not a crashed test run.
+    # A weakening, if one was asked for. Applied to the imported modules only;
+    # nothing here touches a file. See server/weaken.py.
+    if "--weaken" in sys.argv:
+        import weaken
+
+        expected = weaken.apply(sys.argv[sys.argv.index("--weaken") + 1], appmod)
+        if not expected:
+            # Machine-readable, because verify_attacks.sh must not have to
+            # infer this from prose. It means "this service has nothing of
+            # that shape", never "the weakening silently did nothing".
+            print("NOTHING-TO-WEAKEN")
+        print("weakened; these checks must go red:")
+        for name in expected:
+            print(f"  EXPECT-RED: {name}")
+
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://bridge", timeout=60
+    ) as client:
+        svc.client = client
+        report = await attacks.run(svc)
+    return 1 if report.failures else 0
+
+
+async def live_async(base):
+    import httpx
+
+    import attacks
+
+    svc = attacks.Service(
+        name=f"read-bridge at {base}",
+        cookie="read_session",
+        good_user="nobody-attack-suite@example.invalid",
+        good_password="not-a-real-password",
+        sync_path="/api/sync",
+        sync_body=b'{"have": [], "archive": []}',
+        download_template="/api/article/{segments}/{tail}",
+        victim_relative="users/nobody/state.json",
+        sentinel=SENTINEL,
+        attacker_token="not-a-real-token",
+    )
+    svc.device_paths = [
+        ("POST", "/api/sync", True),
+        ("GET", "/api/sync/status?job=1", False),
+    ]
+    async with httpx.AsyncClient(base_url=base, timeout=30) as client:
+        svc.client = client
+        report = await attacks.run(svc, live=True)
+    return 1 if report.failures else 0
+
+
+def main():
+    if "--base" in sys.argv:
+        base = sys.argv[sys.argv.index("--base") + 1]
+        return asyncio.run(live_async(base))
+
+    tmp = tempfile.mkdtemp(prefix="readbridge-attack-")
+    state_file = pathlib.Path(tmp) / "fake.json"
+    state_file.write_text(json.dumps(fixture_state()))
+
+    from cryptography.fernet import Fernet
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "FAKE_INSTAPAPER_STATE": str(state_file),
+            "FAKE_CONSUMER_KEY": CONSUMER_KEY,
+            "FAKE_CONSUMER_SECRET": CONSUMER_SECRET,
+            "READ_DATA": str(pathlib.Path(tmp) / "data"),
+            "READ_FERNET_KEY": Fernet.generate_key().decode(),
+            # OPEN, which is the state this suite exists for. An allowlisted
+            # bridge refuses every attack before it reaches any of the code
+            # under test, and would report a clean run for a service with no
+            # rate limiting at all.
+            "READ_ALLOWLIST": "*",
+            "READ_CONSUMER_KEY": CONSUMER_KEY,
+            "READ_CONSUMER_SECRET": CONSUMER_SECRET,
+            "READ_INSTAPAPER_BASE": f"http://127.0.0.1:{FAKE_PORT}",
+            "PYTHONPATH": str(ROOT),
+        }
+    )
+    # Before the bridge is imported: instapaper.BASE is read at import time and
+    # a stale value would point this suite at the real Instapaper.
+    os.environ.update({k: v for k, v in env.items() if k.startswith("READ_")})
+    os.environ.pop("SUPABASE_URL", None)
+    os.environ.pop("SUPABASE_ANON_KEY", None)
+
+    procs = []
+    try:
+        require_free_port(FAKE_PORT, "the fake Instapaper")
+        procs.append(
+            subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "uvicorn",
+                    "tests.fake_instapaper:app",
+                    "--host",
+                    "127.0.0.1",
+                    "--port",
+                    str(FAKE_PORT),
+                    "--log-level",
+                    "warning",
+                ],
+                cwd=ROOT,
+                env=env,
+            )
+        )
+        wait_port(FAKE_PORT)
+        assert_alive(procs[-1], FAKE_PORT, "the fake Instapaper")
+        return asyncio.run(main_async())
+    finally:
+        for p in procs:
+            p.terminate()
+        for p in procs:
+            try:
+                p.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                p.kill()
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/study-bridge/.gitignore
+++ b/server/study-bridge/.gitignore
@@ -1,2 +1,43 @@
-.venv
+# ma-r-s/crossplay is a PUBLIC repository and this directory is deployed by
+# hand from a developer machine, so the only thing between a maintainer's
+# `git add -A` and their AnkiWeb credentials on GitHub is this file.
+#
+# Until 2026-09-05 this file was two lines (.venv, __pycache__/) and did NOT
+# ignore .env or data/. Nothing had leaked -- deploy.sh excludes both from the
+# rsync TO the pi, which is why it never bit -- but nothing stopped either
+# going INTO git from a dev machine. It is now the read-bridge list, plus the
+# artefacts only this service writes.
+#
+# Every entry below is something this service, its deploy or its tests
+# actually write. Nothing here is speculative, and nothing that is written is
+# missing -- the two halves an ignore file gets wrong.
+
+# Secrets. .env exists on the pi at mode 600 (BRIDGE_FERNET_KEY,
+# BRIDGE_ALLOWLIST, CLOUDFLARE_TUNNEL_TOKEN, the Supabase anon key) and is what
+# `docker compose` substitutes ${VAR} from, so it appears in this directory the
+# moment anyone runs the stack locally. deploy.sh excludes it from the rsync TO
+# the pi; this excludes it from the trip INTO git.
+.env
+.env.*
+!.env.example
+# cloudflared writes these when a tunnel is run credentials-file style rather
+# than token style. Neither belongs to any tracked file here.
+*.pem
+*.key
+
+# The live credential store: users/<uid>/state.json holds every account's
+# Fernet-encrypted AnkiWeb hostKey and the device tokens paired to it.
+data/
+
+# A user's Anki collection and the ingested-review journal. They normally live
+# under data/, but BRIDGE_DATA is a variable and a developer who points it at
+# "." puts a stranger's whole collection in the working tree. The collection is
+# personal data even where it is not a credential.
+*.anki2
+*.anki2-*
+collection.media/
+journal.db
+
+# Local build and tool output.
+.venv/
 __pycache__/

--- a/server/study-bridge/README.md
+++ b/server/study-bridge/README.md
@@ -8,6 +8,20 @@ AnkiWeb with the `anki` library, converts it with the shared converter from
 (Fernet-encrypted at rest) and user collections, and only usernames in
 `BRIDGE_ALLOWLIST` are served, so the hardening bar is Getbooks' or higher.
 
+## Attacking it
+
+The service is open to the world and this repository is public, so nothing here
+may depend on any of its numbers being secret. `docs/bridge-security.md` is the
+threat model, the rate limits and their reasoning, and the Cloudflare rules that
+only Mario can add.
+
+`server/attacks.py` is the executable half: one shared checklist run against
+both bridges (credential stuffing, pairing-code brute force, replay, cross-user
+files and jobs, forged tokens, oversized and malformed bodies), and
+`scripts/deploy.sh` runs it BEFORE it ships anything, so a vulnerable build
+never reaches the pi. `server/verify_attacks.sh` breaks the service on purpose,
+one property at a time, and proves every check can still go red.
+
 ## Isolation
 
 The box also runs Immich, Jellyfin and the *arr stack, so this container is

--- a/server/study-bridge/bridge/app.py
+++ b/server/study-bridge/bridge/app.py
@@ -20,6 +20,7 @@ import json
 import html
 import logging
 import pathlib
+import re
 import secrets
 import struct
 import time
@@ -28,7 +29,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 
 from . import accounts, chrome, decks, engine, events, jobs, pairing, store, wire
-from .ratelimit import Window
+from .ratelimit import Lockout, Window
 from .journal import Journal
 
 log = logging.getLogger("bridge.app")
@@ -38,14 +39,53 @@ MAX_CHOSEN_DECKS = 8
 app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
 
 MAX_SYNC_BODY = 8 * 1024 * 1024  # revlog tails + cards.dat; a 5k-card deck is ~320KB
+# Eight deck names. Anki's own deck-name limit is far under this; the cap is
+# here to bound a hostile client, not to constrain a real one.
+MAX_CHOOSE_BODY = 64 * 1024
+MAX_DECK_NAME = 512
 
 
 # ---------------------------------------------------------------- rate limits
+# The shape here is read-bridge's, arrived at there and ported on 2026-09-05
+# because this service had a weaker one and nobody could say why. See
+# server/attacks.py for the run that found the difference.
 LOGIN_IP = Window(5, 300)  # 5 attempts / 5 min / IP
-LOGIN_USER = Window(3, 900)  # 3 attempts / 15 min / username
+# There is deliberately NO flat per-username Window beside LOGIN_LOCKOUT. There
+# was, and it shadowed nothing here only because there was no lockout to
+# shadow; a flat cap on ATTEMPTS also refuses the legitimate person who mistypes
+# twice and then gets it right. Exponential backoff on FAILURES dominates it:
+# an unlimited number of SUCCESSFUL sign-ins is harmless, because you already
+# have the password.
+LOGIN_LOCKOUT = Lockout()
+# The ceiling with only ONE of it. Per-IP and per-username counters are both
+# defeated by having many of each -- which is precisely what a credential
+# stuffing run has -- and this one is not. Set well above any plausible real
+# rate, so it is a backstop rather than a throttle: a person signs in once and
+# then their reader syncs on a token forever after.
+GLOBAL_LOGIN = Window(30, 60)
 PAIR_IP = Window(10, 300)
+# Guessing a pairing code. Eight characters from a 32-glyph alphabet is not
+# guessable inside its five minutes; guessing it FOR FREE is the problem, and
+# until 2026-09-05 the claim endpoint answered an unlimited number of wrong
+# codes to anyone holding an account of their own. Per-IP and per-account,
+# because either one alone is trivially sidestepped by varying the other.
+CLAIM_IP = Window(20, 300)
+CLAIM_USER = Window(20, 300)
+# Device reports ride any response under 400, including /healthz, which takes
+# no token at all. Each one costs a thread and a row on the board. These are
+# generous for a real reader (it reports on the handful of requests a sync
+# makes) and ruinous for a flood.
+REPORT_IP = Window(30, 300)
+GLOBAL_REPORT = Window(240, 60)
 SYNC_USER = Window(6, 300)
 GLOBAL_SYNC = Window(60, 60)
+
+# A deck slug is what decks.slugify() produces and a build id is
+# f"{int(time.time())}". Anything else was not made by this service, and both
+# reach the filesystem, so they are matched against the shapes their own
+# generators can emit rather than merely inspected for dots.
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+_BUILD_RE = re.compile(r"^[0-9]{1,20}$")
 
 
 def client_ip(request: Request) -> str:
@@ -115,8 +155,21 @@ async def device_reports(request: Request, call_next):
     device will count as delivered, so a request it retries does not post
     the same crash twice. events.Client.report never raises."""
     response = await call_next(request)
+    # Capped, because this runs on endpoints that need no token: without a
+    # limit an unauthenticated stranger writes to the board as fast as they
+    # can open sockets, and each report costs a thread against pids_limit.
+    # Dropping under flood is the right failure: a report is best-effort by
+    # design and no sync waits on one.
     if response.status_code < 400:
-        events.client_for(request).report(via="anki")
+        client = events.client_for(request)
+        # The limiter is consulted only when there is actually something to
+        # relay. Counting REQUESTS instead cost a real device its crash report
+        # in the middle of an ordinary sync: every article download carries the
+        # header, so a 21-article sync spent the whole budget on requests that
+        # were reporting nothing. tests/test_api.py caught it.
+        if client.crash is not None or client.ota is not None:
+            if REPORT_IP.allow(client_ip(request)) and GLOBAL_REPORT.allow("all"):
+                client.report(via="anki")
     return response
 
 
@@ -183,15 +236,30 @@ async def login(request: Request):
     username = str(form.get("username", "")).strip()
     password = str(form.get("password", ""))
     ip = client_ip(request)
-    if not LOGIN_IP.allow(ip) or not LOGIN_USER.allow(username.lower()):
+    key = username.lower()
+    if not LOGIN_IP.allow(ip) or not GLOBAL_LOGIN.allow("all"):
         return page(
             "Slow down",
             chrome.mark(False) + "<h1>Slow down</h1>"
             "<p class=lede>Too many attempts. Wait a few minutes.</p>",
         )
+    # Checked BEFORE the exchange, so a locked-out username costs AnkiWeb
+    # nothing: the whole point is not to relay the attempt at all.
+    waiting = LOGIN_LOCKOUT.locked_for(key)
+    if waiting > 0:
+        return page(
+            "Slow down",
+            chrome.mark(False) + "<h1>Slow down</h1>"
+            f"<p class=lede>Too many failed sign-ins for that account. Try again in"
+            f" {int(waiting // 60) + 1} minute(s).</p>",
+        )
     try:
         st = await asyncio.to_thread(accounts.login, username, password)
     except ValueError as e:
+        # A refusal is what an attacker is fishing for, so it is what the
+        # backoff counts. A bridge fault below is not the user's doing and
+        # does not penalise them.
+        LOGIN_LOCKOUT.record_failure(key)
         return page(
             "Sign in failed",
             chrome.mark(False) + "<h1>Sign in failed</h1>"
@@ -210,6 +278,7 @@ async def login(request: Request):
             "<p class=lede>The bridge hit a problem on its side; nothing about"
             " your account was stored. Try again in a minute.</p>",
         )
+    LOGIN_LOCKOUT.record_success(key)
     resp = RedirectResponse("/devices", status_code=303)
     resp.set_cookie(
         "bridge_session",
@@ -338,6 +407,16 @@ async def pair_claim(request: Request):
     form = await request.form()
     if form.get("csrf") != s["csrf"]:
         raise Unauthorized("stale form; reload the page")
+    # After the session and the CSRF token, so a wrong code costs an account
+    # rather than an anonymous request, and before the guess is answered.
+    if not CLAIM_IP.allow(client_ip(request)) or not CLAIM_USER.allow(s["uid"]):
+        return page(
+            "Slow down",
+            chrome.mark(False) + "<h1>Slow down</h1>"
+            "<p class=lede>Too many codes tried. Wait a few minutes, then ask"
+            " the reader for a fresh one.</p>",
+            step=2,
+        )
     okay = pairing.PAIRINGS.claim(str(form.get("code", "")), s["uid"], s["username"])
     if not okay:
         return page(
@@ -461,11 +540,26 @@ async def list_decks(dev=Depends(require_device)):
 @app.post("/api/decks/choose")
 async def choose_decks(request: Request, dev=Depends(require_device)):
     uid, _ = dev
-    body = await request.json()
+    # Every endpoint that takes a body needs a ceiling on it. This one had
+    # none: eight deck names of any length each went straight into state.json,
+    # so a 12MB post was a 12MB write to the card, repeatable, by anyone
+    # holding a token for their own account.
+    raw = await request.body()
+    if len(raw) > MAX_CHOOSE_BODY:
+        return JSONResponse({"error": "That deck list is too large."}, 413)
+    try:
+        body = json.loads(raw or b"{}")
+    except ValueError:
+        return JSONResponse({"error": "Malformed deck list."}, 400)
+    # Malformed rather than merely unexpected: json.loads happily returns a
+    # list, a string or a number, and .get() on any of them was a 500.
+    if not isinstance(body, dict) or not isinstance(body.get("decks", []), list):
+        return JSONResponse({"error": "Malformed deck list."}, 400)
     # Must equal StudySync::kMaxChosenDecks on the device. The picker enforces
     # the same number, so this truncation should never fire; it is the backstop
-    # for a client that does not.
-    names = [str(n) for n in body.get("decks", [])][:MAX_CHOSEN_DECKS]
+    # for a client that does not. Each name is capped at the longest an Anki
+    # deck path can sensibly be, for the same reason.
+    names = [str(n)[:MAX_DECK_NAME] for n in body.get("decks", [])][:MAX_CHOSEN_DECKS]
     st, state = _user_bits(uid)
     state["chosen_decks"] = names
     st.save_state(state)
@@ -610,9 +704,24 @@ async def sync_status(job: str, dev=Depends(require_device)):
 async def deck_file(slug: str, build: str, path: str, dev=Depends(require_device)):
     uid, _ = dev
     st = store.UserStore(uid)
+    # slug and build are VALIDATED before they become a path, not merely
+    # compared against afterwards. They used to go straight into base, and
+    # the containment check below was then true by construction: dot segments
+    # in them moved the base as well as the target, so ".." twice landed base
+    # on <data>/users/ and every other account's state.json -- their encrypted
+    # AnkiWeb hostKey and their device token hashes -- was one segment away.
+    # The twin never had this because it strips its filename down to
+    # alphanumerics, so the escape cannot be spelled there at all.
+    if not _SLUG_RE.match(slug) or not _BUILD_RE.match(build):
+        return JSONResponse({"error": "No such file."}, 404)
     base = (st.root / "decks" / slug / build).resolve()
     target = (base / path).resolve()
-    if not str(target).startswith(str(base)) or not target.is_file():
+    # Still here, and now it means what it says: base is a directory this
+    # service could itself have created, so containment is a real question.
+    # is_relative_to, not str.startswith: the string form also accepts a
+    # SIBLING whose name merely begins with base's ("decks/a/1" against
+    # "decks/a/12"), which is a different bug wearing the same clothes.
+    if not target.is_relative_to(base) or not target.is_file():
         return JSONResponse({"error": "No such file."}, 404)
     return FileResponse(target)
 

--- a/server/study-bridge/bridge/ratelimit.py
+++ b/server/study-bridge/bridge/ratelimit.py
@@ -1,8 +1,16 @@
-"""Sliding-window rate limiter.
+"""Rate limiting: a sliding-window counter, and a failure-driven lockout.
 
 Its own module so it can be tested without importing the web application: the
 limiter has no business needing FastAPI (or, on the study side, the deck
 converter) to prove it counts correctly.
+
+BYTE-IDENTICAL TWIN of server/read-bridge/bridge/ratelimit.py. Until
+2026-09-05 this file held only Window, and this service's sign-in was guarded
+by a flat per-username cap while its twin had exponential backoff and a global
+ceiling; server/attacks.py found the difference by spraying 80 fresh
+address/account pairs at both and being refused by one of them. Neither
+Dockerfile can COPY a file from outside its own directory, so the module is
+duplicated rather than shared -- a change to either belongs in both.
 """
 
 import time
@@ -51,3 +59,87 @@ class Window:
         hits.append(now)
         self.hits[key] = hits
         return True
+
+# ---------------------------------------------------------------------------
+# Failure-driven backoff, which is a different instrument from the counter
+# above and answers a different question. Window asks "is this key making too
+# many requests"; Lockout asks "is this key getting the password wrong". They
+# are both here because a service that is open to everyone needs both, and
+# because keeping them in one module is what made it obvious that the flat
+# per-username Window and this class were fighting over the same key.
+# ---------------------------------------------------------------------------
+
+
+class Lockout:
+    """Exponential per-key backoff, driven by failures rather than by traffic.
+
+    A Window counts every attempt; this counts only the ones that were WRONG,
+    so a person who signs in successfully is never slowed down no matter how
+    often they do it, and an attacker is slowed by the thing that identifies
+    them as one.
+    """
+
+    # Failures that cost nothing. People mistype passwords and the penalty
+    # should not fall on them: two free attempts covers a typo and a
+    # wrong-saved-password, while an attacker's third guess is already the one
+    # that starts paying. Found by the API suite, which signs in wrongly and
+    # then correctly -- the ordinary shape of a real session -- and was refused
+    # on the correct password until this existed.
+    FREE_FAILURES = 2
+    # First lockout, doubling per consecutive failure after the free ones:
+    # 30s, 1m, 2m, 4m, ...
+    BASE_S = 30.0
+    # Doubling has to stop somewhere or an early mistake locks an account for a
+    # geological interval. Eight failures reaches this; a real person mistyping
+    # twice waits half a minute.
+    MAX_S = 3600.0
+    # Failures older than this are forgiven, so yesterday's typo does not make
+    # today's typo the fifth one.
+    FORGET_S = 86400.0
+    SWEEP_EVERY = 256
+
+    def __init__(self):
+        # key -> [consecutive_failures, last_failure_at]
+        self._state: dict[str, list] = {}
+        self._calls_since_sweep = 0
+
+    def _sweep(self, now: float) -> None:
+        # Same unbounded-key-space problem a Window has once the service is
+        # open: a username tried once and never again would live forever.
+        self._state = {k: v for k, v in self._state.items() if now - v[1] < self.FORGET_S}
+
+    def _penalty(self, failures: int) -> float:
+        charged = failures - self.FREE_FAILURES
+        if charged <= 0:
+            return 0.0
+        return min(self.MAX_S, self.BASE_S * (2 ** (charged - 1)))
+
+    def locked_for(self, key: str, now: float | None = None) -> float:
+        """Seconds still to wait, or 0.0 when the key may try."""
+        now = time.time() if now is None else now
+        entry = self._state.get(key)
+        if not entry:
+            return 0.0
+        failures, last = entry
+        if now - last >= self.FORGET_S:
+            return 0.0
+        remaining = self._penalty(failures) - (now - last)
+        return remaining if remaining > 0 else 0.0
+
+    def record_failure(self, key: str, now: float | None = None) -> None:
+        now = time.time() if now is None else now
+        self._calls_since_sweep += 1
+        if self._calls_since_sweep >= self.SWEEP_EVERY:
+            self._calls_since_sweep = 0
+            self._sweep(now)
+        entry = self._state.get(key)
+        # A failure after the forget window starts the count again rather than
+        # resuming it, or an account probed once a day would eventually lock
+        # permanently on nobody's fault.
+        failures = entry[0] + 1 if entry and now - entry[1] < self.FORGET_S else 1
+        self._state[key] = [failures, now]
+
+    def record_success(self, key: str) -> None:
+        """Clears the count. Only reachable when the password was right, so it
+        cannot be used to reset the penalty from outside."""
+        self._state.pop(key, None)

--- a/server/study-bridge/scripts/deploy.sh
+++ b/server/study-bridge/scripts/deploy.sh
@@ -8,6 +8,36 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SRC="$REPO_ROOT/server/study-bridge"
+# ---------------------------------------------------------------------------
+# THE ATTACK SUITE RUNS BEFORE ANYTHING SHIPS.
+#
+# Same precedent as the isolation test below/beside this: a claim about safety
+# that nothing runs is not a claim. The difference is WHEN -- isolation is a
+# property of the deployed box and is checked after, this is a property of the
+# code and is checked before, because a service that fails it must never reach
+# the pi in the first place.
+#
+# Hermetic: its own throwaway data directory and its own fake upstream. It
+# touches nothing live and needs no network.
+# ---------------------------------------------------------------------------
+PY_LOCAL="$SRC/.venv/bin/python"
+if [ ! -x "$PY_LOCAL" ]; then
+  echo "FAILED: no venv at $SRC/.venv, so the attack suite cannot run and this"
+  echo "deploy cannot say whether the service is safe to publish. Create it:"
+  echo "  cd $SRC && uv venv .venv && uv pip install -r requirements.txt"
+  exit 1
+fi
+echo "attacking the build before shipping it ..."
+if ! "$PY_LOCAL" "$SRC/tests/attack_test.py"; then
+  echo
+  echo "FAILED: the attack suite is red. NOTHING WAS DEPLOYED."
+  echo "Each FAIL line above names what an outsider can do to this build."
+  echo "See docs/bridge-security.md; server/verify_attacks.sh proves the"
+  echo "checks themselves still work."
+  exit 1
+fi
+echo
+
 STAGE="$(mktemp -d)"
 trap 'rm -rf "$STAGE"' EXIT
 
@@ -42,3 +72,50 @@ rsync -a --delete --exclude .env --exclude data/ \
 ssh orange 'mkdir -p /srv/ankibridge/data \
   && docker run --rm -v /srv/ankibridge/data:/data alpine chown 10002:10002 /data'
 ssh orange 'cd /srv/ankibridge && docker compose up -d --build'
+
+# ---------------------------------------------------------------------------
+# ISOLATION IS PART OF DEPLOYING, NOT A STEP AFTERWARDS.
+#
+# read-bridge's deploy has done this since 2026-09-01, when its FIRST deploy
+# came up healthy, serving its pages, and reaching the host's SSH, Immich, the
+# router and a tailnet peer. Nothing about that deploy looked wrong. THIS
+# script never gained the same block: ankibridge-firewall.service exists in
+# scripts/ and has to be installed by somebody remembering to, which is the
+# state read-bridge was in on the day it bit.
+#
+# So this now installs the isolation and REFUSES TO REPORT SUCCESS until the
+# test passes. A deploy that cannot prove it is confined is a failed deploy,
+# whatever the containers say.
+# ---------------------------------------------------------------------------
+
+if ! ssh orange 'sudo -n true' 2>/dev/null; then
+  echo
+  echo "FAILED: no passwordless sudo on the pi, so the network isolation cannot"
+  echo "be installed or verified from here. The containers are RUNNING and"
+  echo "possibly UNCONFINED. Install it by hand before leaving this:"
+  echo "  ssh orange 'sudo /srv/ankibridge/scripts/firewall.sh'"
+  exit 1
+fi
+
+echo "installing the network isolation ..."
+ssh orange 'sudo -n /srv/ankibridge/scripts/firewall.sh' > /dev/null
+
+# Idempotent: writing the same unit twice is free, and a deploy to a rebuilt
+# box must not depend on somebody remembering this once, months ago.
+ssh orange 'sudo -n cp /srv/ankibridge/scripts/ankibridge-firewall.service \
+  /etc/systemd/system/ankibridge-firewall.service \
+  && sudo -n systemctl daemon-reload \
+  && sudo -n systemctl enable ankibridge-firewall.service' > /dev/null
+
+echo "verifying it ..."
+if ssh orange 'bash -s' < "$SRC/scripts/isolation_test.sh"; then
+  echo
+  echo "deployed, and confined."
+else
+  echo
+  echo "FAILED: the containers are running but the isolation test did NOT pass."
+  echo "They may be able to reach the host and the LAN. Investigate before"
+  echo "leaving this; do not treat the running containers as a successful"
+  echo "deploy."
+  exit 1
+fi

--- a/server/study-bridge/tests/attack_test.py
+++ b/server/study-bridge/tests/attack_test.py
@@ -85,6 +85,37 @@ def assert_alive(proc, port, what):
         )
 
 
+def _reap(proc):
+    """SIGTERM the process group, then SIGKILL what is left."""
+    import signal
+
+    try:
+        pgid = os.getpgid(proc.pid)
+    except (ProcessLookupError, PermissionError):
+        return
+    # Never signal our own group. Without this line a Popen that did not get
+    # start_new_session=True makes cleanup kill the suite, its shell and
+    # whatever started them -- which is exactly what happened on 2026-09-05
+    # when a formatter reflowed the Popen call and the edit adding
+    # start_new_session silently matched nothing. Absent code compiles; this
+    # is the guard that makes it fail loudly instead.
+    if pgid == os.getpgrp():
+        raise RuntimeError(
+            "refusing to kill my own process group: the child was started "
+            "without start_new_session=True"
+        )
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.killpg(pgid, sig)
+        except (ProcessLookupError, PermissionError):
+            return
+        try:
+            proc.wait(timeout=8)
+            return
+        except subprocess.TimeoutExpired:
+            continue
+
+
 def wait_port(port, timeout=40):
     deadline = time.time() + timeout
     while time.time() < deadline:
@@ -297,6 +328,9 @@ def main():
                 [sys.executable, "-m", "anki.syncserver"],
                 cwd=str(ROOT),
                 env=env,
+                # Its own process group, so cleanup below can reap the WHOLE
+                # tree rather than just the launcher.
+                start_new_session=True,
                 # Kept, not discarded: a syncserver that comes up and then
                 # refuses everything is indistinguishable from a bridge that
                 # refuses a password, and the difference is in this log.
@@ -308,13 +342,13 @@ def main():
         assert_alive(procs[-1], SYNC_PORT, "the local anki syncserver")
         return asyncio.run(main_async())
     finally:
+        # By GROUP, not by process. `python -m anki.syncserver` and uvicorn
+        # both hold their listening socket in a child, so terminating the
+        # launcher leaves the port held -- and the NEXT run then refuses to
+        # start, or worse, attacks whatever is still sitting there. One of
+        # these leaked for two hours on 2026-09-05 and blocked the matrix.
         for p in procs:
-            p.terminate()
-        for p in procs:
-            try:
-                p.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                p.kill()
+            _reap(p)
         if os.environ.get("ATTACK_KEEP_TMP"):
             print(f"kept: {tmp}")
         else:

--- a/server/study-bridge/tests/attack_test.py
+++ b/server/study-bridge/tests/attack_test.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Run server/attacks.py against study-bridge.
+
+The harness only. Every check lives in server/attacks.py and is shared with
+read-bridge, so a fix can never land on one twin alone -- which is the exact
+shape of the cross-user traversal this suite found on THIS service and not on
+its twin.
+
+Upstream is a real anki.syncserver on loopback with two throwaway accounts, so
+signing in exercises the same code path a real AnkiWeb sign-in does. It never
+points anywhere near a real account.
+
+    .venv/bin/python tests/attack_test.py                 hermetic, gates deploy
+    .venv/bin/python tests/attack_test.py --base https://...   live, safe subset
+"""
+
+import asyncio
+import os
+import pathlib
+import shutil
+import socket
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+HERE = pathlib.Path(__file__).resolve().parent
+ROOT = HERE.parent
+REPO = ROOT.parent.parent
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT.parent))  # server/, for attacks.py
+sys.path.insert(0, str(REPO / "tools_local" / "study"))
+
+BASE_PORT = int(os.environ.get("BRIDGE_TEST_PORT", "8996"))
+SYNC_PORT = BASE_PORT + 7
+
+VICTIM, VICTIM_PW = "victim@example.com", "victim-pw"
+ATTACKER, ATTACKER_PW = "attacker@example.com", "attacker-pw"
+
+SENTINEL = "VICTIM-ANKIWEB-HOSTKEY-CIPHERTEXT"
+
+# [u32 header_len][JSON header][blobs]; an empty deck list is well-formed.
+_HEADER = b'{"decks": []}'
+SYNC_BODY = struct.pack("<I", len(_HEADER)) + _HEADER
+
+
+def port_is_free(port):
+    s = socket.socket()
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s.bind(("127.0.0.1", port))
+        return True
+    except OSError:
+        return False
+    finally:
+        s.close()
+
+
+def require_free_port(port, what):
+    """Refuse to run against somebody else's server.
+
+    wait_port() proves that A process is listening, never that it is the one
+    this suite started -- and on 2026-09-05 that difference cost an hour: port
+    9003 was held by an orphaned read-bridge from another worktree, four days
+    old, and this suite spent every run signing AnkiWeb credentials into it.
+    Every sign-in failed, which read exactly like a bridge refusing a password.
+    A probe whose passing state is indistinguishable from the symptom proves
+    nothing.
+    """
+    if port_is_free(port):
+        return
+    print(f"port {port} is already in use, so {what} cannot start there and this")
+    print("suite would attack whatever IS listening. Find it and decide:")
+    print(f"  lsof -nP -iTCP:{port} -sTCP:LISTEN")
+    print("Set BRIDGE_TEST_PORT to move this tree's whole slice.")
+    raise SystemExit(2)
+
+
+def assert_alive(proc, port, what):
+    """And that it is still MY process answering, after the wait."""
+    if proc.poll() is not None:
+        raise RuntimeError(
+            f"{what} exited with {proc.returncode} before it could serve anything"
+        )
+
+
+def wait_port(port, timeout=40):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        s = socket.socket()
+        s.settimeout(0.5)
+        try:
+            s.connect(("127.0.0.1", port))
+            s.close()
+            return
+        except OSError:
+            time.sleep(0.2)
+    raise RuntimeError(f"nothing opened port {port}")
+
+
+async def main_async():
+    import logging
+
+    import httpx
+
+    # The service's own log, on. A refusal from upstream and a refusal from a
+    # limiter reach this suite as the same page, and only the log tells them
+    # apart -- which is how an hour went into "sign in failed" once already.
+    logging.basicConfig(level=logging.INFO, stream=sys.stderr,
+                        format="    [%(name)s] %(message)s")
+
+    import attacks
+    from bridge import app as appmod
+    from bridge import pairing, store
+    from bridge.app import app
+
+    def reset_limits():
+        """Every limiter this service holds, emptied. Found by walking the
+        module rather than by name, so a limiter added later is reset too --
+        a hand-written list would silently leave the new one loaded and make
+        the next check fail for the wrong reason."""
+        from bridge.ratelimit import Window
+
+        try:
+            from bridge.ratelimit import Lockout
+        except ImportError:
+            Lockout = ()
+        for value in vars(appmod).values():
+            if isinstance(value, Window):
+                value.hits.clear()
+            elif Lockout and isinstance(value, Lockout):
+                value._state.clear()
+
+    victim_uid = store.uid_for(VICTIM)
+    attacker_uid = store.uid_for(ATTACKER)
+    for uid in (victim_uid, attacker_uid):
+        store.UserStore(uid).ensure()
+
+    # The victim's secret, where the service really keeps it.
+    store.UserStore(victim_uid).save_state(
+        {
+            "username_enc": "x",
+            "hostkey_enc": SENTINEL,
+            "status": "ok",
+            "devices": {},
+            "chosen_decks": [],
+            "last_sync": None,
+        }
+    )
+
+    # The attacker's own account, CONNECTED. Without this every device call
+    # stops at "this account is not connected yet", a 401 for a reason that
+    # has nothing to do with the token, and the token checks would pass while
+    # proving nothing.
+    f = store.fernet()
+    store.UserStore(attacker_uid).save_state(
+        {
+            "username_enc": f.encrypt(ATTACKER.encode()).decode(),
+            "hostkey_enc": f.encrypt(b"not-a-real-hostkey").decode(),
+            "endpoint": f"http://127.0.0.1:{SYNC_PORT}/",
+            "status": "ok",
+            "devices": {},
+            "chosen_decks": [],
+            "last_sync": None,
+        }
+    )
+    token = "attacker-device-token-0123456789"
+    store.register_device(attacker_uid, pairing.token_hash(token), "X4 Pro")
+
+    svc = attacks.Service(
+        name="study-bridge",
+        cookie="bridge_session",
+        good_user=ATTACKER,
+        good_password=ATTACKER_PW,
+        sync_path="/api/sync",
+        sync_body=SYNC_BODY,
+        # /api/deck/{slug}/{build}/{path:path}
+        download_template="/api/deck/{segments}/{tail}",
+        victim_relative=f"{victim_uid}/state.json",
+        sentinel=SENTINEL,
+        victim_uid=victim_uid,
+        attacker_uid=attacker_uid,
+        attacker_token=token,
+        device_paths=[
+            ("POST", "/api/sync", True),
+            ("POST", "/api/decks/choose", True),
+            ("GET", "/api/decks", False),
+            ("GET", "/api/sync/status?job=1", False),
+        ],
+        reset=reset_limits,
+    )
+
+    # raise_app_exceptions=False so an unhandled exception in a handler comes
+    # back as the 500 uvicorn would really send, instead of tearing down the
+    # suite. A handler that raises is a finding, not a crashed test run.
+    # A weakening, if one was asked for. Applied to the imported modules only;
+    # nothing here touches a file. See server/weaken.py.
+    if "--weaken" in sys.argv:
+        import weaken
+
+        expected = weaken.apply(sys.argv[sys.argv.index("--weaken") + 1], appmod)
+        if not expected:
+            # Machine-readable, because verify_attacks.sh must not have to
+            # infer this from prose. It means "this service has nothing of
+            # that shape", never "the weakening silently did nothing".
+            print("NOTHING-TO-WEAKEN")
+        print("weakened; these checks must go red:")
+        for name in expected:
+            print(f"  EXPECT-RED: {name}")
+
+    transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="https://bridge", timeout=60
+    ) as client:
+        svc.client = client
+        report = await attacks.run(svc)
+    return 1 if report.failures else 0
+
+
+async def live_async(base):
+    import httpx
+
+    import attacks
+
+    svc = attacks.Service(
+        name=f"study-bridge at {base}",
+        cookie="bridge_session",
+        good_user="nobody-attack-suite@example.invalid",
+        good_password="not-a-real-password",
+        sync_path="/api/sync",
+        sync_body=SYNC_BODY,
+        download_template="/api/deck/{segments}/{tail}",
+        victim_relative="nobody/state.json",
+        sentinel=SENTINEL,
+        attacker_token="not-a-real-token",
+    )
+    svc.device_paths = [
+        ("POST", "/api/sync", True),
+        ("POST", "/api/decks/choose", True),
+        ("GET", "/api/decks", False),
+        ("GET", "/api/sync/status?job=1", False),
+    ]
+    async with httpx.AsyncClient(base_url=base, timeout=30) as client:
+        svc.client = client
+        report = await attacks.run(svc, live=True)
+    return 1 if report.failures else 0
+
+
+def main():
+    if "--base" in sys.argv:
+        base = sys.argv[sys.argv.index("--base") + 1]
+        return asyncio.run(live_async(base))
+
+    tmp = tempfile.mkdtemp(prefix="ankibridge-attack-")
+    # anki.syncserver does not create SYNC_BASE. Without this it starts, opens
+    # its port, and then fails every request -- which reaches the suite as
+    # "sign in failed" and reads exactly like a bridge refusing a password.
+    sync_base = pathlib.Path(tmp) / "syncserver"
+    sync_base.mkdir(parents=True, exist_ok=True)
+
+    from cryptography.fernet import Fernet
+
+    env = dict(os.environ)
+    env.update(
+        {
+            "SYNC_USER1": f"{ATTACKER}:{ATTACKER_PW}",
+            "SYNC_USER2": f"{VICTIM}:{VICTIM_PW}",
+            "SYNC_BASE": str(sync_base),
+            "SYNC_HOST": "127.0.0.1",
+            "SYNC_PORT": str(SYNC_PORT),
+            "PYTHONPATH": os.pathsep.join(
+                [str(ROOT), str(REPO / "tools_local" / "study")]
+            ),
+        }
+    )
+    os.environ.update(
+        {
+            "BRIDGE_DATA": str(pathlib.Path(tmp) / "data"),
+            "BRIDGE_FERNET_KEY": Fernet.generate_key().decode(),
+            # OPEN, which is the state this suite exists for. An allowlisted
+            # bridge refuses every attack before it reaches any of the code
+            # under test, and would report a clean run for a service with no
+            # rate limiting at all.
+            "BRIDGE_ALLOWLIST": "*",
+            "BRIDGE_ANKIWEB_ENDPOINT": f"http://127.0.0.1:{SYNC_PORT}/",
+        }
+    )
+    os.environ.pop("SUPABASE_URL", None)
+    os.environ.pop("SUPABASE_ANON_KEY", None)
+
+    procs = []
+    try:
+        require_free_port(SYNC_PORT, "the local anki syncserver")
+        procs.append(
+            subprocess.Popen(
+                [sys.executable, "-m", "anki.syncserver"],
+                cwd=str(ROOT),
+                env=env,
+                # Kept, not discarded: a syncserver that comes up and then
+                # refuses everything is indistinguishable from a bridge that
+                # refuses a password, and the difference is in this log.
+                stdout=open(pathlib.Path(tmp) / "syncserver.log", "w"),
+                stderr=subprocess.STDOUT,
+            )
+        )
+        wait_port(SYNC_PORT)
+        assert_alive(procs[-1], SYNC_PORT, "the local anki syncserver")
+        return asyncio.run(main_async())
+    finally:
+        for p in procs:
+            p.terminate()
+        for p in procs:
+            try:
+                p.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                p.kill()
+        if os.environ.get("ATTACK_KEEP_TMP"):
+            print(f"kept: {tmp}")
+        else:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/verify_attacks.sh
+++ b/server/verify_attacks.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Does the attack suite actually work? Watch every check go red.
+#
+#   server/verify_attacks.sh [read-bridge|study-bridge]
+#
+# The suite in attacks.py is only worth running if its checks CAN fail. This
+# script proves that they can, one weakening at a time: for each entry in
+# server/weaken.py it breaks the service on purpose, runs the suite, and
+# asserts that exactly the checks that weakening claims to cover went red.
+# Then it runs the suite unweakened and requires it to be green.
+#
+# Two directions, and both matter. A check that stays green under its own
+# weakening does not work. A check that goes red under a weakening it does not
+# claim is either mislabelled or coupled to something it should not be, and
+# either way the map from "this went red" to "this is broken" is wrong -- which
+# is the only thing an attack suite is for.
+#
+# This is not part of deploying (deploy runs attack_test.py itself). It is what
+# you run when you ADD or CHANGE a check, and it is the reason the suite is
+# allowed to gate a deploy at all.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SERVICES=("${1:-read-bridge study-bridge}")
+read -r -a SERVICES <<< "${SERVICES[*]}"
+
+# One port slice per tree, and away from the default: another worktree's stray
+# server on the default slice is how this suite once spent a whole run
+# attacking somebody else's service. attack_test.py refuses rather than allows
+# that now, and this picks a slice unlikely to collide in the first place.
+export BRIDGE_TEST_PORT="${BRIDGE_TEST_PORT:-9200}"
+
+fail=0
+
+for service in "${SERVICES[@]}"; do
+  PY="$HERE/$service/.venv/bin/python"
+  if [ ! -x "$PY" ]; then
+    echo "SKIP $service: no venv (uv venv .venv && uv pip install -r requirements.txt)"
+    continue
+  fi
+  echo "==== $service ===================================================="
+
+  weakenings="$(cd "$HERE" && "$PY" -c 'import sys; sys.path.insert(0, "."); import weaken; print(" ".join(sorted(weaken.WEAKENINGS)))')"
+
+  for w in $weakenings; do
+    out="$(cd "$HERE/$service" && "$PY" tests/attack_test.py --weaken "$w" 2>&1)"
+    rc=$?
+    expected="$(printf '%s\n' "$out" | sed -n 's/^  EXPECT-RED: //p')"
+    actual="$(printf '%s\n' "$out" | sed -n 's/^RED: //p')"
+
+    if printf '%s\n' "$out" | grep -qx "NOTHING-TO-WEAKEN"; then
+      # This service has nothing of that shape to break, and said so in a line
+      # meant to be read by this script rather than inferred from prose. Not a
+      # failure, but it IS a check that has not been seen red here, so it is
+      # named rather than passed over in silence.
+      echo "  n/a  $w -- nothing of that shape on this service; see weaken.py"
+      continue
+    fi
+    if [ -z "$expected" ]; then
+      echo "  FAIL $w -- the weakening applied but named no checks and did not"
+      echo "       print NOTHING-TO-WEAKEN, so it may have done nothing at all"
+      fail=1
+      continue
+    fi
+
+    missing=""
+    while IFS= read -r name; do
+      [ -z "$name" ] && continue
+      printf '%s\n' "$actual" | grep -qxF "$name" || missing="$missing\n    $name"
+    done <<< "$expected"
+
+    extra=""
+    while IFS= read -r name; do
+      [ -z "$name" ] && continue
+      printf '%s\n' "$expected" | grep -qxF "$name" || extra="$extra\n    $name"
+    done <<< "$actual"
+
+    if [ -n "$missing" ]; then
+      echo "  FAIL $w -- these checks stayed GREEN under a weakening that should redden them:"
+      printf "$missing\n"
+      fail=1
+    elif [ -n "$extra" ]; then
+      echo "  FAIL $w -- these checks went red but the weakening does not claim them:"
+      printf "$extra\n"
+      echo "    (either the label is wrong or the check is coupled to something else)"
+      fail=1
+    else
+      echo "  ok   $w -- $(printf '%s\n' "$expected" | grep -c .) check(s) went red, and only those"
+    fi
+    [ "$rc" -eq 0 ] && { echo "  FAIL $w -- the suite exited 0 while red"; fail=1; }
+  done
+
+  out="$(cd "$HERE/$service" && "$PY" tests/attack_test.py 2>&1)"
+  if [ $? -eq 0 ]; then
+    echo "  ok   unweakened -- $(printf '%s' "$out" | tail -1)"
+  else
+    echo "  FAIL unweakened -- the suite is red against the real service:"
+    printf '%s\n' "$out" | grep -E "^  FAIL|^RED:" | sed 's/^/    /'
+    fail=1
+  fi
+done
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "verify_attacks: PASS -- every check was seen failing, and passing"
+else
+  echo "verify_attacks: FAILED"
+fi
+exit $fail

--- a/server/weaken.py
+++ b/server/weaken.py
@@ -1,0 +1,391 @@
+"""Break a bridge on purpose, so its attack suite can be watched going red.
+
+A check that has never failed is not a check. This repository has shipped two
+gates that could not fail and spent a night removing them; adding a third would
+be worse than adding none. So every check in attacks.py has a weakening here
+that must make it red, and running the matrix (server/verify_attacks.sh) is how
+that stays true rather than remaining a claim in a commit message.
+
+The weakenings are applied to the imported module at runtime, never to the file
+on disk. Nothing here can escape the test process, and a weakening that fails to
+apply is an error rather than a silent no-op -- otherwise "the check went green
+under the weakening" would be indistinguishable from "the weakening did
+nothing", which is the same failure the checks themselves exist to prevent.
+
+Each entry names the checks it must redden. verify_attacks.sh asserts exactly
+that, both ways: the named checks go red, and the run without a weakening is
+green.
+"""
+
+WEAKENINGS = {}
+
+
+def weakening(name, reddens):
+    def wrap(fn):
+        fn.reddens = reddens
+        WEAKENINGS[name] = fn
+        return fn
+
+    return wrap
+
+
+def _windows(appmod):
+    from bridge.ratelimit import Window
+
+    found = [v for v in vars(appmod).values() if isinstance(v, Window)]
+    if not found:
+        raise RuntimeError("no Window limiters found to weaken; has app.py moved?")
+    return found
+
+
+def _lockouts(appmod):
+    try:
+        from bridge.ratelimit import Lockout
+    except ImportError:
+        return []
+    return [v for v in vars(appmod).values() if isinstance(v, Lockout)]
+
+
+@weakening(
+    "rate-limits-off",
+    reddens=[
+        "credential stuffing: many passwords, one account, one address",
+        "credential stuffing: many accounts, one address",
+        "credential stuffing: a fresh address AND a fresh account every time",
+        "brute forcing a pairing code is cut off",
+        "an unauthenticated stranger cannot post to the board at will",
+    ],
+)
+def rate_limits_off(appmod):
+    """Every counter says yes. This is the service as it was before any limit
+    existed, and the state a misconfigured limit silently reaches."""
+    for w in _windows(appmod):
+        w.allow = lambda key: True
+    for lk in _lockouts(appmod):
+        lk.locked_for = lambda key, now=None: 0.0
+
+
+@weakening(
+    "global-login-ceiling-off",
+    reddens=["credential stuffing: a fresh address AND a fresh account every time"],
+)
+def global_login_ceiling_off(appmod):
+    """Only the ceiling with one of it. Per-IP and per-username limits stay,
+    which is exactly the shape study-bridge shipped: every other sign-in check
+    still passes and the distributed spray walks straight through."""
+    if not hasattr(appmod, "GLOBAL_LOGIN"):
+        raise RuntimeError("no GLOBAL_LOGIN on this service to weaken")
+    appmod.GLOBAL_LOGIN.allow = lambda key: True
+
+
+@weakening("claim-limit-off", reddens=["brute forcing a pairing code is cut off"])
+def claim_limit_off(appmod):
+    for name in ("CLAIM_IP", "CLAIM_USER"):
+        if not hasattr(appmod, name):
+            raise RuntimeError(f"no {name} on this service to weaken")
+        getattr(appmod, name).allow = lambda key: True
+
+
+@weakening(
+    "report-limit-off",
+    reddens=["an unauthenticated stranger cannot post to the board at will"],
+)
+def report_limit_off(appmod):
+    for name in ("REPORT_IP", "GLOBAL_REPORT"):
+        if not hasattr(appmod, name):
+            raise RuntimeError(f"no {name} on this service to weaken")
+        getattr(appmod, name).allow = lambda key: True
+
+
+@weakening(
+    "path-containment-off",
+    reddens=["one account's device cannot read another account's files"],
+)
+def path_containment_off(appmod):
+    """Put back the bug exactly as it was on study-bridge: the served
+    directory is built from URL segments, and containment is then checked
+    against that same moved directory.
+
+    On READ-BRIDGE this weakening claims nothing, and the reason is the
+    finding. Its route is /api/article/{bookmark_id:int}/{bookmark_hash}: the
+    id is coerced to an integer and a path segment cannot hold a slash, so no
+    dot segment survives ROUTING and the handler is never reached. There is no
+    way to express the attack against it, which is why the twin was safe while
+    this one was not. The traversal check is therefore demonstrated red on
+    study-bridge and passes on read-bridge by construction; that difference is
+    stated rather than hidden, because a weakening that quietly reddens
+    nothing is indistinguishable from a check that does not work.
+    """
+    import pathlib as _pathlib
+    import re as _re
+
+    if not hasattr(appmod, "_SLUG_RE"):
+        print("  (this service has no URL-built path to weaken: its route")
+        print("   coerces the id to an integer, so a traversal cannot be spelled)")
+        return []
+    anything = _re.compile(r"^.*$", _re.S)
+    appmod._SLUG_RE = anything
+    appmod._BUILD_RE = anything
+    _pathlib.Path.is_relative_to = lambda self, other: True
+    return None
+
+
+@weakening(
+    "pairing-not-one-shot",
+    reddens=[
+        "a delivered pairing cannot be replayed",
+        "a pairing code cannot be claimed twice",
+    ],
+)
+def pairing_not_one_shot(appmod):
+    """A code that stays claimable and a poll that keeps answering: two
+    readers, one account, and the second one wins."""
+    from bridge import pairing
+
+    real_poll = pairing.Pairings.poll
+    real_claim = pairing.Pairings.claim
+
+    def poll(self, poll_token):
+        for code, p in list(self._pending.items()):
+            if p["poll_token"] == poll_token and p["claimed_by"] is not None:
+                self._pending[code] = dict(p)  # never consumed
+                return {
+                    "pending": False,
+                    "uid": p["claimed_by"],
+                    "username": p["username"],
+                    "deviceToken": p["device_token"],
+                }
+        return real_poll(self, poll_token)
+
+    def claim(self, code, uid, username):
+        p = self._pending.get(code.strip().upper())
+        if p is not None:
+            p["claimed_by"] = None  # forget that anyone claimed it
+        return real_claim(self, code, uid, username)
+
+    pairing.Pairings.poll = poll
+    pairing.Pairings.claim = claim
+
+
+class _AnyUid(str):
+    """A uid that satisfies `j.uid != uid` for every caller. That comparison
+    IS the ownership check, so this is precisely the check being removed."""
+
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+    def __hash__(self):
+        return hash(str(self))
+
+
+@weakening(
+    "job-owner-check-off",
+    reddens=["a device cannot ask about another account's job"],
+)
+def job_owner_check_off(appmod):
+    """The status endpoint stops asking whose job it is, and hands a summary
+    to whoever guesses the id."""
+    from bridge import jobs
+
+    class AnyJob:
+        uid = _AnyUid("somebody-else")
+        status = "done"
+        summary = {"articles": 3, "applied": 3}
+        message = ""
+
+    real_get = jobs.Jobs.get
+
+    def get(self, job_id):
+        found = real_get(self, job_id)
+        return found if found is not None else AnyJob()
+
+    jobs.Jobs.get = get
+
+
+@weakening(
+    "session-cookie-flags-off",
+    reddens=["the session cookie is HttpOnly, Secure and SameSite"],
+)
+def session_cookie_flags_off(appmod):
+    """The cookie goes out readable by script and over plaintext."""
+    from starlette.responses import Response
+
+    real = Response.set_cookie
+
+    def set_cookie(self, key, value="", **kw):
+        kw["httponly"] = False
+        kw["secure"] = False
+        kw["samesite"] = "none"
+        return real(self, key, value, **kw)
+
+    Response.set_cookie = set_cookie
+
+
+@weakening(
+    "device-auth-off",
+    reddens=[
+        "device endpoints refuse an unauthenticated caller",
+        "a forged bearer token is refused",
+        "a revoked device token stops working immediately",
+    ],
+)
+def device_auth_off(appmod):
+    """Every device endpoint stops asking for a token.
+
+    Through app.dependency_overrides, not by patching require_device: FastAPI
+    captured the function object when the routes were built, so rebinding the
+    module attribute changes nothing a request ever reaches. A weakening that
+    silently does nothing is the failure this whole file exists to prevent.
+    """
+    from bridge import store
+
+    def anybody():
+        """The first account on disk, and a token hash it really holds.
+
+        The hash has to be a REGISTERED one: the sync handler indexes
+        state["devices"][th] directly, so an invented hash is a KeyError and a
+        500 -- which would redden the malformed-body check for a reason that
+        has nothing to do with malformed bodies. A weakening must remove one
+        property and no others, or the matrix stops meaning anything."""
+        root = store.data_root() / "users"
+        uid = "nobody"
+        if root.is_dir():
+            uid = next((d.name for d in sorted(root.iterdir())), "nobody")
+        devices = store.UserStore(uid).load_state().get("devices") or {}
+        return uid, next(iter(devices), "no-device")
+
+    appmod.app.dependency_overrides[appmod.require_device] = anybody
+
+
+@weakening(
+    "body-limits-off",
+    reddens=[
+        "an oversized body is refused rather than buffered",
+        "a malformed body is never a stack trace",
+    ],
+)
+def body_limits_off(appmod):
+    """No ceiling on any body, and the parse raises something the handler does
+    not catch -- which is what a shape assumption really costs: json.loads
+    returning a list where a dict was assumed raised AttributeError, and
+    AttributeError is not ValueError, so it left the handler as a 500."""
+    for name in ("MAX_SYNC_BODY", "MAX_CHOOSE_BODY"):
+        if hasattr(appmod, name):
+            setattr(appmod, name, 1 << 40)
+    import json as _json
+
+    real_loads = _json.loads
+
+    def loads(*a, **k):
+        try:
+            return real_loads(*a, **k)
+        except ValueError as e:
+            # The handlers catch ValueError. Nothing catches this.
+            raise AttributeError(str(e)) from None
+
+    _json.loads = loads
+
+
+@weakening("csrf-off", reddens=["claiming a code needs a session and its CSRF token"])
+def csrf_off(appmod):
+    """The claim form stops checking the token bound to the session."""
+    from starlette.datastructures import FormData
+
+    real_get = FormData.get
+
+    def get(self, key, default=None):
+        if key == "csrf":
+            # Whatever was sent is accepted, including nothing.
+            import json as _json
+            import os
+
+            from cryptography.fernet import Fernet
+
+            return _CSRF_HOLDER.get("value", default)
+        return real_get(self, key, default)
+
+    FormData.get = get
+    _install_csrf_capture(appmod)
+
+
+_CSRF_HOLDER: dict = {}
+
+
+def _install_csrf_capture(appmod):
+    """Remember the CSRF the session really holds, so the weakened form
+    always 'matches' it however the caller spelled theirs."""
+    real_unseal = appmod._unseal
+
+    def unseal(cookie):
+        data = real_unseal(cookie)
+        if data and "csrf" in data:
+            _CSRF_HOLDER["value"] = data["csrf"]
+        return data
+
+    appmod._unseal = unseal
+
+
+def _replace_route(appmod, path, handler):
+    """Swap one route's endpoint in place, keeping its dependencies."""
+    from fastapi import Depends
+
+    for route in appmod.app.routes:
+        if getattr(route, "path", None) == path:
+            import inspect
+
+            params = list(inspect.signature(handler).parameters)
+            if "dev" in params:
+                handler.__signature__ = inspect.Signature(
+                    [
+                        inspect.Parameter(
+                            n,
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                            default=(
+                                Depends(appmod.require_device)
+                                if n == "dev"
+                                else inspect.Parameter.empty
+                            ),
+                            annotation=(str if n != "dev" else inspect.Parameter.empty),
+                        )
+                        for n in params
+                    ]
+                )
+            route.endpoint = handler
+            route.dependant = None
+            from fastapi.dependencies.utils import get_dependant
+
+            route.dependant = get_dependant(path=route.path_format, call=handler)
+            route.app = None
+            from fastapi.routing import get_request_handler
+
+            route.app = get_request_handler(
+                dependant=route.dependant,
+                body_field=route.body_field,
+                status_code=route.status_code,
+                response_class=route.response_class,
+                response_field=route.secure_cloned_response_field,
+                response_model_include=route.response_model_include,
+                response_model_exclude=route.response_model_exclude,
+                response_model_by_alias=route.response_model_by_alias,
+                response_model_exclude_unset=route.response_model_exclude_unset,
+                response_model_exclude_defaults=route.response_model_exclude_defaults,
+                response_model_exclude_none=route.response_model_exclude_none,
+                dependency_overrides_provider=route.dependency_overrides_provider,
+            )
+            return
+    raise RuntimeError(f"no route {path} to weaken")
+
+
+def apply(name, appmod):
+    if name not in WEAKENINGS:
+        raise SystemExit(
+            f"unknown weakening {name!r}; have: {', '.join(sorted(WEAKENINGS))}"
+        )
+    fn = WEAKENINGS[name]
+    own = fn(appmod)
+    # A weakening may return its own list (usually empty) when this service
+    # has nothing of that shape to break; otherwise the declared list stands.
+    return fn.reddens if own is None else own


### PR DESCRIPTION
Card #252. Both bridges are open to the world and this repository is public, so
nothing about them may rest on a number being unknown. This is the review in
executable form, plus what it found.

## 1. The gitignore hole -- do this bit first, it needs no host

`server/study-bridge/.gitignore` was two lines (`.venv`, `__pycache__/`) and
did **not** ignore `.env` or `data/`. Its `.env` holds `BRIDGE_FERNET_KEY` and
the Cloudflare tunnel token; `data/users/<uid>/state.json` holds every account's
encrypted AnkiWeb hostKey. `server/board/` had no ignore file at all.

**Nothing has leaked.** `git ls-files` under `server/` matches no `.env`,
`data/`, `.pem`, `.key`, `.anki2` or `journal.db`, and did not before this
branch either -- both deploy scripts exclude `.env` and `data/` from the rsync
to the pi, which is why it never bit. It was latent, and one `git add -A` wide.

Verified by decoy, not by reading: twelve files a maintainer could plausibly
create were written with placeholder content, and `git check-ignore -v` names
the rule for every one while `git add -An` picks up only the three `.gitignore`
files. With the old study-bridge file restored, `git add -An` stages seven of
them, `.env` and `state.json` included.

Entries are what each service actually writes, not the twin's list copied
across: study-bridge also gets `*.anki2`, `journal.db` and `collection.media/`,
because `BRIDGE_DATA` is a variable and a developer who points it at `.` puts a
stranger's whole collection in the working tree.

## 2. What the attack suite found

All verbatim against the code this branch started from.

**study-bridge, cross-user path traversal.** A device token for *any* account
could read *any other* account's files:

```
GET /api/deck/%2E%2E/%2E%2E/<victim_uid>/state.json
-> {"hostkey_enc": "...", "devices": {...}, "chosen_decks": [], ...}
```

`/api/deck/{slug}/{build}/{path}` built the served directory out of URL
segments and only *then* asked whether the target was inside it -- true by
construction, because dot segments move the base as well as the target. Two of
them landed the base on `<data>/users/`, one segment from every account's
encrypted AnkiWeb hostKey, their device token hashes and their whole
collection.

read-bridge was safe, and the reason is the lesson: its route takes an `int` id
and strips the filename to alphanumerics, so the escape cannot be spelled at
all. Same two files, same author, one sanitised and one did not.

**study-bridge, no global sign-in ceiling.** 80 of 80 sprays through, each with
a fresh address *and* a fresh account, defeating per-IP and per-username limits
by never repeating either key. That is the shape of a real credential-stuffing
run. read-bridge had `GLOBAL_LOGIN` and an exponential `Lockout`; study-bridge
had a flat per-username window. Ported; `ratelimit.py` is now a byte-identical
twin.

**Both, unlimited pairing-code guessing.** 60 of 60 wrong codes answered.
32^8 over five minutes is not guessable, but an endpoint answering unlimited
guesses is an unlimited oracle over every pending code at once, and costs the
attacker one account of their own.

**Both, unauthenticated writes to the board.** 120 of 120 crash reports relayed
from `GET /healthz`, which takes no token. One thread and one Supabase row
each, against `pids_limit` 128.

**Both, 500s on malformed bodies**, and study-bridge's `/api/decks/choose` had
no body ceiling at all -- a 12MB post was a 12MB write to the card.

## 3. The suite, and why it is allowed to gate a deploy

`server/attacks.py` is **one** checklist run against **both** services. Every
security bug these twins have had was a fix that landed on one and not the
other, including the worst thing above. What differs is a `Service` profile.

`server/weaken.py` breaks a service on purpose, one property at a time, and
`server/verify_attacks.sh` asserts that **exactly** the checks a weakening
claims go red -- both directions, because a check that stays green under its
own weakening does not work, and one that reddens under a weakening it does not
claim means the map from red to broken is wrong.

```
read-bridge   11 weakenings: 10 ok, 1 n/a   unweakened: 44 checks, 0 failed
study-bridge  11 weakenings: 11 ok          unweakened: 54 checks, 0 failed
verify_attacks: PASS -- every check was seen failing, and passing
```

The one honest gap is named in `weaken.py`: `path-containment-off` reddens
nothing on read-bridge, because its route's own types make the attack
unspellable. That check passes there by construction rather than by
demonstration, and the script prints `n/a` rather than a green tick.

Wired into both deploy scripts **before** the rsync, following
`isolation_test.sh`'s precedent but before rather than after: a service that
fails must never reach the pi. The gate was watched refusing a red suite and
passing a green one.

**study-bridge's deploy also gains the isolation block read-bridge has had
since 2026-09-01 and this one never got.** It installs `firewall.sh` and its
systemd unit and refuses to report success until `isolation_test.sh` passes.
Same gap, same box, same reason nobody noticed.

## 4. What Mario has to do by hand

**Add one Cloudflare rate limiting rule.** It cannot be done from here: the
tunnel is token-managed, so zone rules live in the dashboard, there is no `cf`
CLI in this workspace and no API token for one. The exact expression, rate,
action and reasoning are in `docs/bridge-security.md`; recorded as a `mario`
blocker on #252. If he never does it, the app-layer limits stand alone -- every
attack in the suite is still refused, it just costs the pi a socket and a
thread instead of costing Cloudflare nothing.

The doc also says what **not** to turn on: Bot Fight Mode, and a managed
challenge on any `/api/` rule. The readers are non-browser clients with no
JavaScript; either one silently breaks every sync on every device.

## 5. Not verified

- **Nothing was deployed and no live service was attacked.** Every result here
  is against the real ASGI app with a real fake upstream, on this Mac. A
  `--base <url>` mode exists for a live run and deliberately skips the floods,
  which would spend a shared limiter and lock real accounts out.
- The pi was unreachable during this work (power cut at Mario's place), so the
  deploy is left for the morning and this branch is code only.
- The Cloudflare rules are unapplied and unverifiable from here.
- **In-memory limiters reset on restart**, so a restart loop resets the backoff.
  Persisting the lockout is a different change and is not made here.
- `/api/pair/poll` stays unlimited on purpose: a reader polls it every second
  or two for five minutes, so any tight limit breaks pairing.

`server/read-bridge/README.md` and `scripts/DEPLOY-RUNBOOK.md` are deliberately
untouched -- card #269 was rewriting them, and this branch rebased onto its
merge with no conflict.

Gate, verbatim last line:

```
HOST GREEN, DEVICE BUILDS SKIPPED (gh_release_x4pro gh_release_sticky) -- nothing in this diff reaches a device image, so none was built.
```
