### PR TITLE
fix(study site): stop the wizard overflowing a phone, and drop-once (#287, #38)

### DIFF
--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -650,6 +650,17 @@ awk '/^\.study-preview-frame \{/,/^}/' "$SCSS" | grep -q -- 'var(--preview-chrom
 grep -q 'window.scrollTo' "$ROOT/site/study/study.js" \
   && ok || bad "study.js never resets the page scroll, so a step arrives at the previous step's offset"
 
+# A deck dropped on the zone must run the open-and-convert pipeline ONCE. Two
+# drop listeners reach takeFile -- one on the dropzone, one on document for a
+# deck dropped anywhere on the page -- and a drop on the zone bubbles to both,
+# so the zone's handler has to stop the bubble or the pipeline fires twice.
+# That it fires exactly once was counted in a browser (twice without the guard,
+# once with it); only the guard's presence can be checked here. Scoped to the
+# zone's own drop handler so a stray stopPropagation elsewhere cannot satisfy it.
+awk '/dropzone\.addEventListener\("drop"/,/\}\);/' "$ROOT/site/study/study.js" \
+  | grep -q 'stopPropagation' \
+  && ok || bad "study.js's dropzone drop handler does not stopPropagation, so a dropped deck bubbles to the document handler and runs the pipeline twice"
+
 # -- the emulator, which is no longer in the repository -----------------------
 #
 # site/emulator/ is 3.7MB of generated wasm that used to be committed on every

--- a/host-tests/site/study_layout.py
+++ b/host-tests/site/study_layout.py
@@ -1,5 +1,5 @@
-"""The study wizard's steps must stay in normal flow, and the page must be
-allowed to grow.
+"""The study wizard's steps must stay in normal flow, the page must be allowed
+to grow, and it must fit the width of a phone.
 
 WHAT WENT WRONG. `.wiz-step` was `position: absolute` inside a `min-height: 0`
 row and `.study-body` clamped the page to `100vh` with `overflow: hidden`, so a
@@ -83,6 +83,13 @@ if step_class:
 if not container_class:
     say("study/index.html's steps have no classed <div> around them, so the step container cannot be found")
 
+# The stepper is whatever element wraps the numbered step buttons.
+m = re.search(r"<(?:nav|ol|ul|div)[^>]*\bclass=\"([^\"]+)\"[^>]*>\s*(?:<!--.*?-->\s*)*<button[^>]*\bdata-step=",
+              html, flags=re.S)
+stepper_class = m.group(1).split()[0] if m else None
+if not stepper_class:
+    say("study/index.html has no element wrapping the data-step buttons, so the stepper cannot be found")
+
 
 # -- their rule blocks -------------------------------------------------------
 
@@ -132,6 +139,49 @@ if cont is not None:
     if rows and "minmax(0" in rows.group(1).replace(" ", ""):
         say(f".{container_class} (step container) sizes its row with minmax(0, ...), which lets it be "
             "shorter than the step again -- the clip under another name")
+
+# -- the 320px overflow: floor the column, let the stepper reflow -------------
+#
+# WHAT WENT WRONG. .wizard is a grid that declares no column of its own, so its
+# single implicit column is `auto` and takes its minimum from the widest child.
+# That child is the stepper, a nowrap flex row of four chips measuring ~342px,
+# so on a 320px phone the column cannot shrink: every child starts at x=20 and
+# the page is 42px wider than the screen, with the "Write" chip, the Invert
+# toggle and the dropzone's right border all off-screen.
+#
+# TWO PROPERTIES fix it and both are checked. The column must be FLOORED with
+# `grid-template-columns: minmax(0, ...)`; a bare `1fr` or `auto` keeps the
+# min-content floor and still overflows, so the value is checked, not just the
+# property. With the column floored the nowrap stepper would still overflow its
+# own box, so the stepper must be allowed to REFLOW -- flex-wrap:wrap drops the
+# fourth chip to a second line, or an overflow on the stepper scrolls it.
+#
+# WHAT THIS CANNOT SEE, plainly: that the page actually stops overflowing at
+# 320 and 360. That is a browser measurement (document.scrollWidth ==
+# clientWidth, both themes) and it was made in one; nothing here can.
+wiz_decls = block(wizard_class) if wizard_class else None
+if wiz_decls is not None:
+    cols = re.search(r"grid-template-columns\s*:([^;]*)", wiz_decls)
+    if not cols:
+        say(f".{wizard_class} (wizard) sets no grid-template-columns, so its implicit auto column "
+            "takes the stepper's width and overflows a phone")
+    elif "minmax(0" not in cols.group(1).replace(" ", ""):
+        say(f".{wizard_class} (wizard) does not floor its column with minmax(0, ...), so the column "
+            "keeps its min-content floor and the page overflows a phone")
+
+if stepper_class:
+    step_decls = block(stepper_class)
+    if step_decls is None:
+        say(f"study.css has no `.{stepper_class}` rule, and study/index.html says it wraps the steps")
+    else:
+        have = props(step_decls)
+        wrap = re.search(r"flex-wrap\s*:([^;]*)", step_decls)
+        wraps = bool(wrap and "nowrap" not in wrap.group(1) and "wrap" in wrap.group(1))
+        scrolls = any(p == "overflow" or p.startswith("overflow-") for p in have)
+        if not wraps and not scrolls:
+            say(f".{stepper_class} (stepper) neither wraps nor scrolls, so its nowrap chips overflow "
+                "the floored column and the page scrolls sideways on a phone")
+
 
 for line in problems:
     print(line)

--- a/site/study/study.css
+++ b/site/study/study.css
@@ -46,6 +46,12 @@
   margin-inline: auto;
   padding: 0 var(--gutter);
   display: grid;
+  /* The single column is explicit and floored at 0, not the implicit auto
+     track: an auto column takes its min size from the stepper's max-content
+     (four nowrap chips, wider than a 320px phone) and pushes the whole page
+     wider than the viewport. minmax(0, 1fr) lets the column shrink to the
+     window so the stepper fits inside it instead of overflowing it. */
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto auto 1fr auto;
   gap: 0.4rem;
 }
@@ -67,6 +73,11 @@
 
 .wiz-stepper {
   display: flex;
+  /* Wrap on a phone too narrow for four chips in a row: the grid column above
+     is floored at 0 so it no longer stretches to the stepper's width, which
+     leaves the nowrap chips overflowing the viewport unless they can fall to a
+     second line. At any width wide enough for one row this is inert. */
+  flex-wrap: wrap;
   gap: 0.5rem;
   border-bottom: 1px solid var(--edge);
   padding-bottom: 0.5rem;

--- a/site/study/study.js
+++ b/site/study/study.js
@@ -1075,6 +1075,11 @@ worker.onmessage = function (event) {
     });
   });
   dropzone.addEventListener("drop", function (event) {
+    // Stop the document-level drop handler below from also firing on this same
+    // drop: without it a deck dropped on the zone bubbles up and runs takeFile
+    // a second time. Drops elsewhere on the page never reach here, so the
+    // page-wide fallback still works.
+    event.stopPropagation();
     var file = event.dataTransfer && event.dataTransfer.files[0];
     takeFile(file);
   });


### PR DESCRIPTION
Two pre-existing bugs on the public /study/ page. Browser work only; no device image is touched (the gate skipped device builds for that reason).

## #287 -- /study/ overflows its viewport at 320px and cuts step 4's controls
`main.wizard` is a grid with no column of its own, so its single implicit column is `auto` and takes its minimum from the widest child: the stepper, a nowrap flex row of four chips measuring ~342px. On a 320px phone the column cannot shrink below that, so every child sits in a 342px track and the page is 42px wider than the screen, pushing the "4 Write" chip, the Invert toggle and the dropzone's right border off-screen.

Fix is two properties:
- `.wizard { grid-template-columns: minmax(0, 1fr) }` -- floors the column at 0 so it shrinks to the window (a bare `1fr`/`auto` keeps the min-content floor and would still overflow).
- `.wiz-stepper { flex-wrap: wrap }` -- with the column floored the nowrap chips would still overflow their own box, so the fourth chip falls to a second line instead. Inert at any width wide enough for one row.

The reviewer's proposed one-liner (`minmax(0, 1fr)` alone) was verified insufficient: it fixes the dropzone and footer but the stepper still overflows by 42px. Both properties are needed.

Verified in a real browser (local `serve.py`), before and after, at 320 and 360, light and dark:
- before: `document.scrollWidth` 362 vs `clientWidth` 320 (42px overflow); Write/Invert/dropzone all end at x=362.
- after: `scrollWidth == clientWidth` at 320 and 360; all controls on-screen; stepper wraps to 2 rows on a phone, stays 1 row at 1000px.

## #38 -- dropping a file runs the open-and-convert pipeline twice
Two `drop` listeners reach `takeFile`: the dropzone's own (`study.js:1077`) and a document-level one (`:1115`) that exists so a deck dropped anywhere on the page still counts. A drop on the zone fires the zone handler, then bubbles to `document` and fires that one too.

Fix: `event.stopPropagation()` in the zone's drop handler. Drops elsewhere on the page still reach the document handler; the file-picker `change` path is untouched.

Verified in a browser by counting `takeFile` calls (temporary instrumentation, removed): drop-on-zone twice before / once after; drop-elsewhere once; file-picker once.

## Tests
- `host-tests/site/study_layout.py`: adds the overflow mechanism (wizard column floored with `minmax(0`, stepper reflows via `flex-wrap`/overflow), deriving the stepper class from the markup. Fails if either regresses; verified by reverting each fix.
- `host-tests/site/run.sh`: a guard that the zone's drop handler stops propagation, scoped to that handler.
- The pixel overflow and the once-vs-twice count are browser facts; the suite states plainly it cannot see them, matching how it already documents reachability.
- `host-tests/site`: 200 checks, 0 failed. `./scripts_local/check.sh --committed`: `HOST GREEN, DEVICE BUILDS SKIPPED`.

Not verified: hardware (site-only, N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)