### PR TITLE
fix(murdle): move the refusal band between the grid and the key (#293)

### DIFF
--- a/docs/apps/murdle.md
+++ b/docs/apps/murdle.md
@@ -353,14 +353,22 @@ and the refusal is three words: `ALREADY TICKED ELSEWHERE`. Changing your mind
 costs two more taps than it did -- clear the old lock, then rule the new square
 out and lock it in -- and every one of them is the player's own.
 
-**The refusal has a band of its own, reserved whether it says anything or not.**
-It used to appear above the grid only when there was something to say, which
-pushed the board down the moment a tap was refused and pulled it back up on the
-next tap. On a panel that takes a second to answer, that is the one surface
-being read by position moving under the reader's finger. The band is **one line**
-of the tile cut, measured against the real face in `host-tests/murdle`; the grid
-is width-bound at every tier, so it pays for the band out of the slack the key
-was spreading into and loses no cell size.
+**The refusal has a band of its own, reserved whether it says anything or not,
+and it sits between the grid and the key.** It used to appear above the grid
+only when there was something to say, which pushed the board down the moment a
+tap was refused and pulled it back up on the next tap. On a panel that takes a
+second to answer, that is the one surface being read by position moving under
+the reader's finger. Reserving the band stopped the movement; putting it
+between the grid and the key rather than above the grid is where Mario wanted
+it (2026-09-05) -- a refusal sends the player to the key to check, so the
+message reads next to the thing it points at. The band is reserved off the
+**bottom** of the grid's room, so the grid draws at the top of the face and the
+reserved height falls in the gap above the key; the grid is top-anchored and
+width-bound at every tier, so its origin and every cell stay put whether or not
+a notice shows, and the key keeps the top and height it always had. The band is
+**one line** of the tile cut, measured against the real face in
+`host-tests/murdle`; it pays for itself out of the slack the key was spreading
+into and loses no cell size.
 
 One line is what makes reserving it on every frame the right trade, and getting
 there is why the wording is three words. The refusal used to name both blocking

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -4100,6 +4100,13 @@ void testMurdleRefusalDoesNotMoveTheGrid() {
   // AND its cell was re-measured against a shorter area. On this panel that is
   // a full refresh of the one surface being read by position.
   //
+  // Mario, 2026-09-05: the fixed band was in the wrong place -- "on top of the
+  // screen" -- and he wants it "between the board and between the bottom names
+  // of the objects, people, places, and motives". So the band now sits BETWEEN
+  // the grid and the key, and this test pins all three facts that made the move
+  // safe: the grid does not move whether or not a notice shows (no-jump), the
+  // band draws below the grid and above the key, and the key does not move.
+  //
   // Every tier, because the cell size is the min of a width fit and a height
   // fit and only the height fit moves: a tier that happened to be height-bound
   // would shrink where the others do not.
@@ -4131,27 +4138,37 @@ void testMurdleRefusalDoesNotMoveTheGrid() {
     CHECK(after.gutter == before.gutter);
     CHECK(after.headerH == before.headerH);
 
+    // The bottom edge of the last grid cell, and the top of the first key row.
+    // The band has to fall strictly between them: below the grid, above the
+    // key. Reserving the band off the bottom of the grid's room puts it there.
+    const int16_t gridCellsBottom = static_cast<int16_t>(after.originY + after.groups * after.items * after.cell);
+    const int16_t lineH = with.target.lineHeight(toybox::kTileFont);
+    int16_t firstKeyRowY = 0x7fff;
+    for (const auto& run : with.target.texts) {
+      if (run.text.find('=') != std::string::npos && run.rect.y < firstKeyRowY) firstKeyRowY = run.rect.y;
+    }
+    CHECK(firstKeyRowY != 0x7fff);  // the key really drew
+
     // The notice really drew, or every check above is satisfied by a screen
     // that simply threw the message away.
-    const fui::Rect grid = fui::makeRect(after.originX, static_cast<int16_t>(after.originY - after.headerH), 1, 1);
     int noticeRuns = 0;
     for (const auto& run : with.target.texts) {
       if (run.text.find(murdletext::kBlockedNotice) == std::string::npos) continue;
       ++noticeRuns;
-      // And it drew ABOVE the grid rather than over the column labels, which is
-      // the way a reserved band goes wrong that a moved origin does not.
-      CHECK(run.rect.y + run.rect.height <= grid.y);
+      // BETWEEN THE GRID AND THE KEY. The band starts 8px under the last grid
+      // cell -- the reserved gap it has always carried -- and its foot clears
+      // the top of the first key row. Above the grid (the old placement) or
+      // over the key both fail here.
+      CHECK(run.rect.y == gridCellsBottom + 8);
+      CHECK(run.rect.y >= gridCellsBottom);
+      CHECK(run.rect.y + run.rect.height <= firstKeyRowY);
       // The box the wrap sees, tied to the number host-tests/murdle measures
       // the worst-case notice against rather than written down twice. This IS
       // the body width: paragraph() draws each line into the rect it was given.
       CHECK(run.rect.width == 448);
-      // THE BAND IS ONE LINE, and this is the assertion that says so. Mario,
-      // 2026-09-05: the two-line band "moved [the board] down which now looks
-      // awful, specially when no message is showing" -- it is reserved on every
-      // frame, so a second line is a line of dead space on every frame of the
-      // face. The gap from the top of the notice to the top of the grid IS the
-      // band, plus the 8px it has always carried.
-      CHECK(grid.y - run.rect.y == with.target.lineHeight(toybox::kTileFont) + 8);
+      // THE BAND IS ONE LINE. Reserved on every frame, so a second line is a
+      // line of dead space on every frame of the face.
+      CHECK(run.rect.height == lineH);
     }
     // One run, because the message is one line. Two runs is the wording that
     // wrapped, which is the other half of what made the band cost two lines.
@@ -4160,6 +4177,27 @@ void testMurdleRefusalDoesNotMoveTheGrid() {
     // The quiet render says nothing in the band it reserved.
     for (const auto& run : without.target.texts) {
       CHECK(run.text.find(murdletext::kBlockedNotice) == std::string::npos);
+    }
+
+    // NO JUMP, proved on the drawn rects and not just the layout struct: the
+    // only difference between the quiet render and the one carrying a notice is
+    // the single notice run inserted between the grid and the key. Every other
+    // run -- every grid label AND every key row -- is at a byte-identical rect,
+    // so neither the grid nor the key moves when a tap is refused or cleared.
+    std::vector<const FakeTarget::TextRun*> quietRuns;
+    for (const auto& run : without.target.texts) quietRuns.push_back(&run);
+    std::vector<const FakeTarget::TextRun*> loudRuns;
+    for (const auto& run : with.target.texts) {
+      if (run.text.find(murdletext::kBlockedNotice) != std::string::npos) continue;
+      loudRuns.push_back(&run);
+    }
+    CHECK(loudRuns.size() == quietRuns.size());
+    for (size_t i = 0; i < loudRuns.size() && i < quietRuns.size(); ++i) {
+      CHECK(loudRuns[i]->text == quietRuns[i]->text);
+      CHECK(loudRuns[i]->rect.x == quietRuns[i]->rect.x);
+      CHECK(loudRuns[i]->rect.y == quietRuns[i]->rect.y);
+      CHECK(loudRuns[i]->rect.width == quietRuns[i]->rect.width);
+      CHECK(loudRuns[i]->rect.height == quietRuns[i]->rect.height);
     }
 
     // The key still gets room under the grid. The band is paid for out of that

--- a/src/apps_local/murdle/MurdleScreens.cpp
+++ b/src/apps_local/murdle/MurdleScreens.cpp
@@ -678,18 +678,28 @@ CaseReport buildCase(toybox::Screen& screen, const CaseModel& model) {
 
   if (model.face == Face::Grid) {
     // The notice band is reserved on EVERY render of this face, empty or not,
-    // for the same reason the pager strip below is. Taking it only when there
-    // is something to say moved the grid down the moment a tap was refused and
-    // back up when the next tap cleared it, which on this panel is a full
-    // refresh of the one surface the player is reading by position. It also
-    // re-measured the cell against a shorter area, which every tier survived
-    // only because every tier is width-bound today.
+    // for the same reason the pager strip is. Taking it only when there is
+    // something to say moved the grid the moment a tap was refused and back
+    // when the next tap cleared it, which on this panel is a full refresh of
+    // the one surface the player is reading by position. It also re-measured
+    // the cell against a shorter area, which every tier survived only because
+    // every tier is width-bound today.
     //
     // The band comes out of the grid's own room rather than the key's. The key
-    // is what the message's names have to be looked up in, so squeezing it to
-    // make space for the message would take away the thing the message sends
-    // you to -- and the grid is width-bound at every tier, so it loses no cell
-    // size to this, only the slack the key was spreading into.
+    // is what a refusal sends the player to check, so squeezing it to make
+    // space for the message would take away the thing the message points at --
+    // and the grid is width-bound at every tier, so it loses no cell size to
+    // this, only the slack the key was spreading into.
+    //
+    // It sits BETWEEN the grid and the key, not above the grid: the band is
+    // reserved off the BOTTOM of the grid's room rather than the top, so the
+    // grid draws at the top of the face and the reserved height falls in the
+    // gap above the key. The grid is top-anchored and width-bound, so shrinking
+    // its area from the bottom leaves originY -- and every cell -- exactly
+    // where it was whether or not a notice is showing, which is the no-jump
+    // property the reservation exists for. The key keeps the same top and
+    // height it had when the band lived up top, because the band is the same
+    // size and now sits directly above the key instead of above the grid.
     //
     // ONE LINE, measured rather than chosen, and the reason the band is cheap
     // enough to keep. blockedLine says murdletext::kBlockedNotice and nothing
@@ -702,14 +712,11 @@ CaseReport buildCase(toybox::Screen& screen, const CaseModel& model) {
     // room on every frame to say something on a handful of them.
     constexpr int kNoticeLines = 1;
     const int16_t noticeH = static_cast<int16_t>(screen.target().lineHeight(toybox::kTileFont) * kNoticeLines + 8);
-    // Top of the band rather than centred in it, so the message starts on the
-    // row the band starts on however tall the band is sized.
-    if (model.notice != nullptr && model.notice[0] != '\0') {
-      paragraph(screen, styled(toybox::kTileFont, fui::TextAlign::Center), model.notice,
-                fui::makeRect(body.x, body.y, body.width, noticeH), true);
-    }
-    body = fui::makeRect(body.x, static_cast<int16_t>(body.y + noticeH), body.width,
-                         static_cast<int16_t>(body.height - noticeH));
+    // The full body bottom, kept before the grid's room is shortened: the key
+    // still reaches it, so it keeps the room it had and the band is paid for
+    // out of the grid's slack, not the key's.
+    const int16_t bodyBottom = body.bottom();
+    body = fui::makeRect(body.x, body.y, body.width, static_cast<int16_t>(body.height - noticeH));
     layout = layoutGrid(screen, puzzle, body);
     drawGrid(screen, puzzle, *model.marks, layout);
     screen.frame().hit(fui::makeRect(static_cast<int16_t>(layout.originX - layout.gutter),
@@ -718,8 +725,15 @@ CaseReport buildCase(toybox::Screen& screen, const CaseModel& model) {
                                      static_cast<int16_t>(layout.headerH + layout.groups * layout.items * layout.cell)),
                        ActionGrid, 0);
     const int16_t gridBottom = static_cast<int16_t>(layout.originY + layout.groups * layout.items * layout.cell + 8);
-    drawLegend(screen, puzzle,
-               fui::makeRect(body.x, gridBottom, body.width, static_cast<int16_t>(body.bottom() - gridBottom)));
+    // The refusal band, in the gap the grid gave up. Top of the band rather
+    // than centred in it, so the message starts on the row the band starts on
+    // however tall the band is sized.
+    if (model.notice != nullptr && model.notice[0] != '\0') {
+      paragraph(screen, styled(toybox::kTileFont, fui::TextAlign::Center), model.notice,
+                fui::makeRect(body.x, gridBottom, body.width, noticeH), true);
+    }
+    const int16_t keyTop = static_cast<int16_t>(gridBottom + noticeH);
+    drawLegend(screen, puzzle, fui::makeRect(body.x, keyTop, body.width, static_cast<int16_t>(bodyBottom - keyTop)));
   } else {
     // The pager strip always comes out of the text area, even on a face that
     // turns out to be one page. Reserving it only when pages > 1 would need the


### PR DESCRIPTION
Card #293. Second half of the refusal-notice fix Mario has already seen. PR #95 made the "already ticked" notice one line (`ALREADY TICKED ELSEWHERE`) and kept the reserved no-jump band; this moves it to where he wants it.

**What he asked for.** On the shipped one-line notice: it reads "on top of the screen", and he wants it "between the board and between the bottom names of the objects, people, places, and motives" -- below the grid, above the key.

**The change.** The band was reserved off the TOP of the grid face's body, so the grid sat one band lower and the message drew above it. It is now reserved off the BOTTOM of the grid's room: the grid draws at the top of the face, the reserved height falls in the gap above the key, and drawing goes grid, then notice, then key. One `MurdleScreens.cpp` block; the key is drawn separately from `layoutGrid()`, so only the band's rect moved.

**Both earlier properties survive, by construction:**
- **No-jump (#246/#75):** the band is still reserved on every render, empty or not. The grid is top-anchored and width-bound at every tier, so the grid's area keeps the same height (`H - noticeH`) and only its `originY` -- unchanged between quiet and refused because the reservation is unconditional. The grid does not move when a tap is refused or cleared.
- **Height from the grid's slack, not the key's:** `keyTop = gridBottom + noticeH` works out to the exact top the key had when the band lived up top, and the key still reaches the full body bottom. The key does not shrink or move.

**Test.** `host-tests/ui` `testMurdleRefusalDoesNotMoveTheGrid` rewritten to pin all three, across all four tiers:
- the drawn text rects are byte-identical between the quiet render and the one carrying a notice, except for the single notice run inserted between grid and key (no-jump, proved on the rects, not just the layout struct);
- the notice's y is strictly between the grid's bottom cell and the first key row;
- the band is one line.
Watched it go red on the reverted source (8 failures, the placement assertions) and green with the fix. Full `check.sh --committed`: **all green** (host suites + `gh_release_x4pro` / `gh_release_sticky` device builds; flash 77.6% / 76.3%).

**Simulator evidence (Elementary).** Rendered quiet and notice states and measured the BMPs: grid horizontal lines pixel-identical with and without the notice (`[328, 457, 589, 721, 853, 985, 1114]`), key rows identical, and the notice band appears only in the notice shot at image y 1142-1167 -- between the grid bottom (1114) and the first key row (1220).

**Not verified: on hardware.** The desk unit is wedged tonight. The one thing only the panel can settle is the new mid-screen reading position (the tapping hand is over the band) -- recorded as a `mario` blocker on the card.

Docs: `docs/apps/murdle.md` updated to the new placement.

Note: local gate flagged the browser/emulator artifact as stale (expected off `xteink`); CI rebuilds and commits `site/emulator/` after merge.