### PR TITLE
Persist Toy Battle & Jaipur record lines; make Toy Battle's HOW IT ENDED tappable

### DIFF
--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -24,6 +24,7 @@
 #include "../../src/apps_local/hackernews/HackerNewsScreens.h"
 #include "../../src/apps_local/insider/InsiderScreens.h"
 #include "../../src/apps_local/instapaper/InstapaperScreens.h"
+#include "../../src/apps_local/jaipur/JaipurScreens.h"
 #include "../../src/apps_local/knucklebones/KnucklebonesScreens.h"
 #include "../../src/apps_local/link/LinkScreens.h"
 #include "../../src/apps_local/minesweeper/MinesweeperScreens.h"
@@ -5627,6 +5628,22 @@ void testToyBattleShell() {
     CHECK(out.target.drew("HOW TO PLAY"));
     // A save that is offered has to say what it is offering.
     CHECK(out.target.drew("CONTINUE") == (save != 0));
+    // The record line carries the tally it is handed. It read a permanent
+    // "0 PLAYED 0 WON" for the app's whole life because the counters were never
+    // persisted (#195): here the model has them, and they have to reach ink.
+    CHECK(out.target.drew("3 PLAYED   2 WON"));
+  }
+
+  {
+    // A player who has never finished a game gets a sentence, not three noughts.
+    tbui::MenuModel model;
+    model.preview = &preview;
+    model.played = 0;
+    model.won = 0;
+    Rendered out;
+    buildTbMenu(out, model);
+    CHECK(out.target.drew("NO BATTLES YET"));
+    CHECK(!out.target.drew("0 PLAYED   0 WON"));
   }
 
   for (int link = 0; link < 2; ++link) {
@@ -5892,7 +5909,102 @@ void testTheFinishedBoardCarriesItsOwnEnding() {
     CHECK(!out.target.drew("DRAW 2"));
     CHECK(!out.target.drew("SKIP"));
     CHECK(!out.target.drew("WAIT"));
+
+    // The way on has to ANSWER, not just draw (#197): a tap where HOW IT ENDED
+    // sits routes to ActionResult, and the ? beside it to ActionBrief. Drawn
+    // and dead is this fork's "a silent screen reads as a crash". The Activity's
+    // gameLoop() no longer returns before this route on a finished board.
+    const FakeTarget::TextRun* how = out.target.find("HOW IT ENDED");
+    CHECK(how != nullptr);
+    if (how != nullptr) {
+      const fui::ActionEvent hit = out.tap(how->rect.x + how->rect.width / 2, how->rect.y + how->rect.height / 2);
+      CHECK(hit.action == tbui::ActionResult);
+    }
+    const FakeTarget::TextRun* brief = out.target.find("?");
+    CHECK(brief != nullptr);
+    if (brief != nullptr) {
+      const fui::ActionEvent hit =
+          out.tap(brief->rect.x + brief->rect.width / 2, brief->rect.y + brief->rect.height / 2);
+      CHECK(hit.action == tbui::ActionBrief);
+    }
   }
+}
+
+void buildTbResult(Rendered& out, const tbui::ResultModel& model) {
+  const fui::DeviceContext ctx = device();
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(out.target, ctx, noInput, out.interactions);
+  toybox::Screen screen(frame, toybox::themeTokens());
+  tbui::buildResult(screen, model);
+}
+
+// HOW IT ENDED opens the Result screen, which was unreachable dead code until
+// #197 routed its button -- so buildResult() had never drawn and nothing tested
+// it. It names which of the three endings happened, and its two buttons answer.
+void testTheResultScreenReads() {
+  toybattle::Game game;
+  game.newGame(11u, static_cast<int>(toybattle::TerrainId::CastleField), 0, true);
+  // Seat 0 captures an H.Q., the same construction the finished-board test uses.
+  const toybattle::Terrain& b = game.board();
+  int hq = -1;
+  for (int s = b.baseCount; s < b.slotCount(); ++s) {
+    if (b.hqOwner(s) == 1) hq = s;
+  }
+  CHECK(hq >= 0);
+  game.placeSlot[game.placementCount] = static_cast<uint8_t>(hq);
+  game.placeTile[game.placementCount] = static_cast<uint8_t>((0 << 3) | static_cast<int>(toybattle::Troop::Roxy));
+  ++game.placementCount;
+  game.winner = 0;
+  game.ending = static_cast<uint8_t>(toybattle::Ending::HqCaptured);
+  game.phase = static_cast<uint8_t>(toybattle::Phase::GameOver);
+
+  tbui::ResultModel model;
+  model.game = game;
+  model.seat = 0;
+  Rendered out;
+  buildTbResult(out, model);
+
+  CHECK(out.interactions.count() <= toybox::kMaxInteractions);
+  CHECK(out.target.drew("YOU WIN"));
+  CHECK(out.target.drew("YOU TOOK THEIR H.Q."));
+  CHECK(out.target.drew("DONE"));
+  CHECK(out.target.drew("PLAY AGAIN"));
+
+  const FakeTarget::TextRun* done = out.target.find("DONE");
+  CHECK(done != nullptr);
+  if (done != nullptr) {
+    const fui::ActionEvent hit = out.tap(done->rect.x + done->rect.width / 2, done->rect.y + done->rect.height / 2);
+    CHECK(hit.action == tbui::ActionDone);
+  }
+  const FakeTarget::TextRun* again = out.target.find("PLAY AGAIN");
+  CHECK(again != nullptr);
+  if (again != nullptr) {
+    const fui::ActionEvent hit = out.tap(again->rect.x + again->rect.width / 2, again->rect.y + again->rect.height / 2);
+    CHECK(hit.action == tbui::ActionAgain);
+  }
+}
+
+void buildJaipurStart(Rendered& out, const jaipurui::StartModel& model) {
+  const fui::DeviceContext ctx = device();
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(out.target, ctx, noInput, out.interactions);
+  toybox::Screen screen(frame, toybox::themeTokens());
+  jaipurui::buildStartMenu(screen, model);
+}
+
+// Jaipur's front door drew "0 PLAYED 0 WON" for the app's whole life because
+// startModel() never set the counters and the activity kept no tally (#196).
+// With a real tally on the model, the record line has to print it.
+void testJaipurRecordLine() {
+  jaipurui::StartModel model;
+  model.played = 12;
+  model.won = 5;
+  Rendered out;
+  buildJaipurStart(out, model);
+  CHECK(out.interactions.count() <= toybox::kMaxInteractions);
+  CHECK(out.interactions.count() > 0);
+  CHECK(out.target.drew("12 PLAYED   5 WON"));
+  CHECK(!out.target.drew("0 PLAYED   0 WON"));
 }
 
 // Playing the other side has to be the same game seen from the other chair, not
@@ -8891,6 +9003,8 @@ int main() {
   testTheSeaSaltTutorialPagesAndEnds();
   testEitherSideSeesItsOwnHqAtTheBottom();
   testTheFinishedBoardCarriesItsOwnEnding();
+  testTheResultScreenReads();
+  testJaipurRecordLine();
   testEveryRulesPositionCouldExist();
   testTheTerrainCardNeverTruncatesWhatItDraws();
   testNoRulesPageDrawsOverItsOwnButtons();

--- a/src/apps_local/jaipur/JaipurActivity.cpp
+++ b/src/apps_local/jaipur/JaipurActivity.cpp
@@ -138,6 +138,11 @@ constexpr char kSavePath[] = "/.crosspoint/jaipur.sav";
 // correct v2 one. Version 3: Game grew a record of the last move.
 constexpr int kSaveVersion = 3;
 
+// The record line's own file, kept apart from kSavePath because that one is
+// removed at GameOver. Text and versioned, the way battleship writes bship.cfg.
+constexpr char kStatsPath[] = "/.crosspoint/jaipur.stats";
+constexpr int kStatsVersion = 1;
+
 char hexDigit(const int value) { return static_cast<char>(value < 10 ? '0' + value : 'A' + value - 10); }
 
 int hexValue(const char c) {
@@ -198,6 +203,7 @@ void JaipurActivity::onEnter() {
   // Mixed from the clock, so two games in a row are not the same game.
   seed = toybox::seed();
 
+  loadStats();
   hasSavedGame = loadGame();
   goToMenu();
 }
@@ -254,6 +260,7 @@ void JaipurActivity::onMatchStart(const bool goesFirst) {
   game.newGame(nextSeed(), 0);
   if (goesFirst) link.play(game);
   clearSelection();
+  recorded = false;
   view = View::Board;
   requestUpdate();
 }
@@ -1103,7 +1110,42 @@ jaipurui::StartModel JaipurActivity::startModel() const {
   model.hasSavedGame = hasSavedGame;
   model.continueDetail = continueDetail;
   model.selected = menuSelected;
+  model.played = played;
+  model.won = won;
   return model;
+}
+
+void JaipurActivity::recordResult() {
+  if (recorded) return;
+  recorded = true;
+  ++played;
+  // matchWinner() is -1 until a seat holds two seals, and exactly one does at
+  // GameOver, so this is "did the human win the match".
+  if (game.matchWinner() == seat) ++won;
+  // Straight to the card, at the finish: a wake is a chip reset, so anything
+  // not written before the player looks away can be lost.
+  saveStats();
+}
+
+void JaipurActivity::saveStats() const {
+  char line[48];
+  std::snprintf(line, sizeof(line), "%d %d %d\n", kStatsVersion, played, won);
+  Storage.writeFile(kStatsPath, String(line));
+}
+
+void JaipurActivity::loadStats() {
+  // Absent on every device that ran an earlier build: that is zero games, not
+  // an error, and jaipur.sav (a different file) still loads on its own.
+  if (!Storage.exists(kStatsPath)) return;
+  char buffer[48] = {};
+  if (Storage.readFileToBuffer(kStatsPath, buffer, sizeof(buffer)) == 0) return;
+  int version = 0;
+  int storedPlayed = 0;
+  int storedWon = 0;
+  if (std::sscanf(buffer, "%d %d %d", &version, &storedPlayed, &storedWon) < 3) return;
+  if (version != kStatsVersion) return;
+  played = storedPlayed;
+  won = storedWon;
 }
 
 jaipurui::BoardModel JaipurActivity::boardModel() {
@@ -1261,6 +1303,7 @@ void JaipurActivity::startNewGame() {
   game.newGame(nextSeed(), 0);
   clearSelection();
   hasSavedGame = true;
+  recorded = false;
   report[0] = '\0';
 
   view = View::Board;
@@ -1477,6 +1520,14 @@ void JaipurActivity::gameLoop() {
     playOpponentTurn();
     return;
   }
+
+  // A solo match that has just ended: count it while it is still in RAM, since
+  // saveGame() removes a GameOver save so it is never reloaded. recordResult
+  // latches, and a link match is counted through onMatchEnded() instead (the
+  // link layer stops calling this once the game is over). Runs regardless of
+  // view: the finished game sits on View::RoundOver, but Back to the menu keeps
+  // it in RAM, and this must not depend on which screen is up.
+  if (!inMatch() && game.currentPhase() == jaipur::Phase::GameOver) recordResult();
 
   switch (view) {
     case View::Menu:

--- a/src/apps_local/jaipur/JaipurActivity.h
+++ b/src/apps_local/jaipur/JaipurActivity.h
@@ -49,11 +49,11 @@ class JaipurActivity final : public linkplay::LinkActivity {
   void onRematch() override;
   void onLinkEnded() override;
   bool matchGameOver() const override { return game.currentPhase() == jaipur::Phase::GameOver; }
-  // Nothing to record: Jaipur keeps no played/won counter (its menu draws one,
-  // and it has never been anything but zero -- filed separately). The screen
-  // half applies though: viewForPhase() puts View::RoundOver up at GameOver,
-  // and until now nobody ever saw it in a match. See link/LinkEndgame.h.
-  void onMatchEnded() override {}
+  // Counted here for a link match, and nowhere else in one: the link layer
+  // stops running gameLoop() the moment the game ends (it puts up its own
+  // endgame screen), so the solo path's GameOver check in gameLoop() never
+  // fires for a match. See link/LinkEndgame.h.
+  void onMatchEnded() override { recordResult(); }
   // The link screen's ornament, and after a match its result: it takes the
   // screen the moment the game ends, so this is where the final position is
   // reported.
@@ -163,6 +163,14 @@ class JaipurActivity final : public linkplay::LinkActivity {
   void saveGame() const;
   void refreshContinueDetail();
 
+  // The record line under the front-door title. Counted once per finished match
+  // (recordResult latches on `recorded`) and kept in jaipur.stats, its own
+  // file: jaipur.sav is removed at GameOver, so a finished game is never
+  // reloaded and the count cannot live in it. The pattern is battleship's.
+  void recordResult();
+  void saveStats() const;
+  void loadStats();
+
   jaipur::Game game;
   linkplay::Play<jaipur::Game> link;
 
@@ -172,6 +180,14 @@ class JaipurActivity final : public linkplay::LinkActivity {
   int tutorialPage = 0;
   bool hasSavedGame = false;
   uint32_t seed = 1;
+
+  // The front-door tally. Loaded once on entry, incremented when a match ends.
+  int played = 0;
+  int won = 0;
+  // One finish is counted once. A finished match sits on screen for a while
+  // (the round-over view, or the link endgame hold), so the loop sees GameOver
+  // on many passes; this latches the count to the first of them.
+  bool recorded = false;
 
   // Set when the opponent owes a move, consumed on the next loop pass.
   bool opponentPending = false;

--- a/src/apps_local/toybattle/ToyBattleActivity.cpp
+++ b/src/apps_local/toybattle/ToyBattleActivity.cpp
@@ -8,6 +8,7 @@
 #include "../Shelf.h"
 #include "../ui/Toybox.h"
 #include "../ui/ToyboxFonts.h"
+#include "../ui/ToyboxFormat.h"
 #include "../ui/ToyboxTheme.h"
 #include "ToyBattleScreens.h"
 
@@ -15,6 +16,10 @@ namespace tb = toybattle;
 
 // The fork-local convention, the pattern knucklebones.sav set.
 static constexpr char kSavePath[] = "/.crosspoint/toybattle.sav";
+// A separate file for the record line, because kSavePath is removed the moment
+// a game ends. Text and versioned, the way battleship writes bship.cfg.
+static constexpr char kStatsPath[] = "/.crosspoint/toybattle.stats";
+static constexpr int kStatsVersion = 1;
 
 std::unique_ptr<Activity> ToyBattleActivity::create(GfxRenderer& renderer, MappedInputManager& mappedInput) {
   return std::make_unique<ToyBattleActivity>(renderer, mappedInput);
@@ -27,6 +32,7 @@ void ToyBattleActivity::onEnter() {
   // moment the app appears.
   hasSave = loadGame();
   dealt = hasSave;
+  loadStats();
   screen = tb::Screen::Menu;
   menuSelected = 0;
   refreshSaveLine();
@@ -190,6 +196,9 @@ void ToyBattleActivity::recordResult() {
   recorded = true;
   ++played;
   if (game.winner == seat) ++won;
+  // Written here, at the finish, rather than in onExit: a chip-reset wake loses
+  // anything not on the card, so the count reaches disk the moment it changes.
+  saveStats();
   hasSave = false;
   if (Storage.exists(kSavePath)) Storage.remove(kSavePath);
   requestUpdate();
@@ -260,10 +269,14 @@ void ToyBattleActivity::gameLoop() {
     // but Back". That was the real objection and it is answered by giving the
     // action bar a way on rather than by taking the board away.
     //
-    // Still the one place a result is recorded and the save is cleared: a
-    // finished game must not be offered as one to continue.
+    // The one place a result is recorded and the save is cleared: a finished
+    // game must not be offered as one to continue. recordResult() latches, so
+    // running it every pass is a no-op after the first.
     recordResult();
-    return;
+    // No return: the finished board's action bar (HOW IT ENDED, ?) is the only
+    // way on and has to answer a tap. Falling through reaches interactions.route
+    // below; the brain and the board's own hit-testing are both gated on
+    // Phase::Playing (and canAct()), so only the registered controls are live.
   }
 
   // The brain only plays when there is nobody on the other end. In a match the
@@ -706,6 +719,30 @@ bool ToyBattleActivity::loadGame() {
   seat = saved.seat;
   preview = saved.game;
   return true;
+}
+
+void ToyBattleActivity::saveStats() const {
+  // "%d %d %d\n"
+  constexpr int kLineChars =
+      toybox::kIntChars + toybox::kIntChars + toybox::kIntChars + toybox::literalChars("  \n") + 1;
+  char line[kLineChars];
+  std::snprintf(line, sizeof(line), "%d %d %d\n", kStatsVersion, played, won);
+  Storage.writeFile(kStatsPath, String(line));
+}
+
+void ToyBattleActivity::loadStats() {
+  // No file is the ordinary state on every device that ran a build before this
+  // one: leave the counters at zero rather than treat its absence as an error.
+  if (!Storage.exists(kStatsPath)) return;
+  char buffer[48] = {};
+  if (Storage.readFileToBuffer(kStatsPath, buffer, sizeof(buffer)) == 0) return;
+  int version = 0;
+  int storedPlayed = 0;
+  int storedWon = 0;
+  if (std::sscanf(buffer, "%d %d %d", &version, &storedPlayed, &storedWon) < 3) return;
+  if (version != kStatsVersion) return;
+  played = storedPlayed;
+  won = storedWon;
 }
 
 void ToyBattleActivity::onExit() {

--- a/src/apps_local/toybattle/ToyBattleActivity.h
+++ b/src/apps_local/toybattle/ToyBattleActivity.h
@@ -102,6 +102,12 @@ class ToyBattleActivity final : public linkplay::LinkActivity {
   void requestNewGame();
   void saveGame();
   bool loadGame();
+  // Played/won live in their own file, not in toybattle.sav: the save is
+  // deleted the instant a game finishes (recordResult()), which is the same
+  // moment the counters change, so a counter folded into it would be erased by
+  // the write that incremented it. Same shape as battleship's bship.cfg.
+  void saveStats() const;
+  void loadStats();
 
   // The shared state is `Game` itself, which is already the wire format: 148
   // bytes, trivially copyable, with an exact-size assert. Nothing is serialised


### PR DESCRIPTION
Fixes three visible defects across two games: cards #195/#217, #196, #197/#218.

## #195/#217 — Toy Battle PLAYED / WON always 0
The counters were incremented and written to RAM but never persisted, and they
cannot live in `toybattle.sav`: `recordResult()` deletes that file the instant a
game ends, the same write that bumps the counter (the #217 correction). Fixed
with a separate versioned text file `/.crosspoint/toybattle.stats`, following
battleship's `bship.cfg`: `loadStats()` in `onEnter()`, `saveStats()` in
`recordResult()` (at the finish, not `onExit()`, because a wake is a chip reset).
`toybattle.sav`'s format is untouched, so an existing resume game still loads; a
device with no `.stats` reads 0/0 ("NO BATTLES YET").

## #196 — Jaipur permanent "0 PLAYED 0 WON"
The activity kept no tally at all and `startModel()` never set the counters.
Added `played`/`won` and a `recordResult()` latched on `recorded`, counted for a
solo match in `gameLoop()` at `GameOver` and for a link match through
`onMatchEnded()` (an empty override before this — the link layer stops calling
`gameLoop()` once the game ends). `game.matchWinner()==seat` is the win test.
`jaipur.stats` mirrors the Toy Battle file; `jaipur.sav` (removed at GameOver, so
a finished game is never reloaded) is untouched, and a device with no `.stats`
reads 0/0.

## #197/#218 — Toy Battle HOW IT ENDED never tappable
`gameLoop()` returned in the finished-board branch, 66 lines above
`interactions.route()`, so the tap was never routed and the whole `Screen::Result`
was unreachable dead code. Removed the early `return` so a finished board falls
through to routing; the brain and the board's own hit-testing are gated on
`Phase::Playing` / `canAct()`, so only the action bar is live
(HOW IT ENDED → Result, ? → Brief).

## Migration
No reinterpretation of any existing save: both `.sav` formats are byte-identical,
and the new `.stats` files are simply absent on every device that ran an earlier
build (read as 0/0). Verified an old-format save path stays intact — the existing
`toybattle` decode round-trip test is unchanged and green.

## Tests / verification
- `host-tests/ui`: both record lines assert their rendered text (incl. Toy
  Battle's "NO BATTLES YET" zero case, and `!drew("0 PLAYED   0 WON")`); the
  finished board now routes `ActionResult`/`ActionBrief`; `buildResult()` gets
  its first-ever test (DONE/PLAY AGAIN route). Full ui suite green.
- Simulator, verified by looking: with a seeded record the front doors show
  "7 PLAYED   3 WON" (Toy Battle) and "12 PLAYED   5 WON" (Jaipur), cleanly
  placed, nothing overlapping. With the src fix stashed and the same seed, the
  same front doors read "NO BATTLES YET" / "0 PLAYED   0 WON" — the red→green.
- `./scripts_local/check.sh --committed`: `all green` (host suites, both device builds gh_release_x4pro+gh_release_sticky, and the release suite all ok; only a browser-artifact STALE notice, which is warning-only off xteink and rebuilt by CI after merge)

## Owed on hardware (no device tonight)
A real-finger tap on the finished Toy Battle board (#197): the ui suite proves
the screen registers and routes the button and the Activity now falls through to
routing, but the simulator does not run InputManager, so the physical tap is
still owed.
