### PR TITLE
fix(hackernews): keep the reader in place on a full card, and give its band a real shrink ladder (#40, #268)

### DIFF
--- a/host-tests/fittedtitle/test_fittedtitle.cpp
+++ b/host-tests/fittedtitle/test_fittedtitle.cpp
@@ -507,7 +507,7 @@ void hackerNewsReader() {
   for (int i = 0; i < fitted::kHnHeadlineCount; ++i) {
     const std::string headline = utf8FoldTypography(fitted::kHnHeadlines[i]);
     for (int variant = 0; variant < 3; ++variant) {
-      Paint paint("readingFaces");
+      Paint paint("readerFaces");
       toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
       toybox::Screen screen(frame);
       toybox::WrappedText wrap;
@@ -527,16 +527,22 @@ void hackerNewsReader() {
       expectWhole(tally, paint.target, headline);
     }
   }
-  // TEN, and they are a decision rather than a bug. The only cut smaller than
-  // this band's reading face is the SMALL slot, which readingFaces binds to
-  // toybox_10 -- a 21px Jersey line box in a 76px band. Stepping down would
-  // rescue these ten and leave the other seventy-eight elided anyway, so the
-  // band would set some headlines in a display cut a third the height of the
-  // rest for no gain a reader could name. The fork's rule says step down; this
-  // band has nothing worth stepping down TO, which is a face-binding question
-  // (readerFaces, or reading_serif_11 in a slot) and not this function's.
-  // Card #268. Pinned so the number cannot drift in either direction unnoticed.
-  report(tally, 10, "no cut between reading_serif_14 and toybox_10 is bound on this band -- card #268");
+  // ZERO avoidable, now that the reader binds readerFaces (card #268). The band
+  // steps its headline down through real reading cuts -- bold 16 -> 14 -> 11 --
+  // instead of falling straight to an ellipsis with nothing worth shrinking to.
+  // The ten that used to be a KEPT exception here fit only toybox_10, the Jersey
+  // tile cut readingFaces bound in the SMALL slot, which has no business setting
+  // prose; readerFaces puts reading_serif_11 there instead, so four of the ten
+  // now fit whole and the rest join the residual, showing more of themselves
+  // before the ellipsis than reading_serif_14 did.
+  //
+  // The residual stays high because the band is ONE line and a Hacker News
+  // headline is a whole sentence: no single-line cut this fork owns holds "New
+  // Mexico court orders Meta to pay $567m over harms to children's mental
+  // health". That is the same class as the xkcd bar's residual below -- a second
+  // line, not a smaller cut, is what would take it -- and like it, it is
+  // reported, not gated. Gating avoidable at 0 is the fix this card asked for.
+  report(tally);
 }
 
 void xkcdReaderBar() {

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -3215,6 +3215,37 @@ void testHnReaderShowsWhereYouAre() {
   CHECK(!drewText(out, "ARTICLE"));
 }
 
+// A card that would not take a save says so OVER the reader, not by replacing
+// it. Card #40: a failed save called showNotice(), which switched the Activity
+// to its full-screen Notice phase and threw the reader out of the page it was
+// on -- for the one failure that leaves what you were reading perfectly intact.
+// buildReader now draws the refusal from the model as a transient toast, so the
+// reader's own chrome is still there beneath it and nothing navigated away.
+void testHnReaderSaveFailedToastStaysOnTheReader() {
+  Rendered out;
+  hnui::ReaderModel model = articleModel();
+  model.canSave = true;
+  model.saveNotice = "Not saved: the card is full.";
+  buildHnReader(out, model);
+
+  // The refusal is on the page.
+  CHECK(drewText(out, "card is full"));
+  // And the reader is STILL the reader underneath it: the swap control, the
+  // page label and the save mark are all drawn, which a full-screen notice
+  // would not carry. That is the whole of #40 -- an overlay, not a new screen.
+  CHECK(drewText(out, "COMMENTS"));
+  CHECK(drewText(out, "1/3"));
+  CHECK(saveMarkIn(out) != nullptr);
+
+  // The ordinary paint, with nothing refused, is clean: the toast is drawn only
+  // when the model carries a reason.
+  Rendered clean;
+  hnui::ReaderModel plain = articleModel();
+  plain.canSave = true;
+  buildHnReader(clean, plain);
+  CHECK(!drewText(clean, "card is full"));
+}
+
 void testHnFitLines() {
   // The fake target bills every character at 10px, so the arithmetic here is
   // exact: a 200px line holds 20 characters.
@@ -8964,6 +8995,7 @@ int main() {
   testHnEmptyStateStacksWithoutOverlap();
   testHnFitLines();
   testHnReaderShowsWhereYouAre();
+  testHnReaderSaveFailedToastStaysOnTheReader();
   testHnSaveMarkIsLoudestWhenSaved();
   testHnAThreadCanBeKept();
   testTheColumnYouTapIsTheColumnTheRulesGet();

--- a/src/apps_local/hackernews/HackerNewsActivity.cpp
+++ b/src/apps_local/hackernews/HackerNewsActivity.cpp
@@ -635,6 +635,8 @@ void HackerNewsActivity::showDocument(const char* title, const bool comments) {
   readingComments_ = comments;
   topLine_ = 0;
   phase_ = Phase::Reading;
+  // A freshly opened piece carries no stale "not saved" toast (card #40).
+  saveFailedNotice_ = false;
   // Line counts need a draw target, which only exists inside render(). The
   // first paint fills them in; until then the label reads as one page, which is
   // what a document that has not been measured looks like.
@@ -653,16 +655,29 @@ void HackerNewsActivity::saveCurrentArticle() {
   if (readerUrl_.empty() || document_.empty()) return;
   const std::string title = readingComments_ ? hn::savedThreadTitle(readerTitle_) : readerTitle_;
   if (!library_.save(readerUrl_, title, document_)) {
-    showNotice("NOT SAVED", "The card would not take it. There may be no room left.", false);
+    // A full card, said OVER the page rather than in place of it. showNotice()
+    // switched phase_ to Notice, which replaced the reader with a full-screen
+    // message and lost the reading position (card #40) -- the one thing a
+    // reader must not do when it merely could not KEEP a copy of what you are
+    // already reading. So the reader stays put; a transient toast says the save
+    // did not take, and the reader's next input clears it. Nothing was written,
+    // so the shelf is unchanged and there is no row to invalidate.
+    saveFailedNotice_ = true;
+    requestUpdate();
+    return;
   }
   // The shelf gained a row while the view did not change, which is the one
-  // staleness rowsStale() cannot see on its own.
+  // staleness rowsStale() cannot see on its own. Any stale "not saved" toast
+  // goes with it: this one took.
+  saveFailedNotice_ = false;
   rows_.invalidate();
   requestUpdate();
 }
 
 void HackerNewsActivity::unsaveCurrentArticle() {
   if (readerUrl_.empty()) return;
+  // Any action on the reader clears the transient save toast (card #40).
+  saveFailedNotice_ = false;
   library_.remove(readerUrl_);
   rows_.invalidate();
   // Removing what you are reading leaves the reader on something the shelf no
@@ -711,6 +726,8 @@ void HackerNewsActivity::returnToList() {
   }
   readingSaved_ = false;
   phase_ = Phase::List;
+  // Leaving the reader drops its transient save toast (card #40).
+  saveFailedNotice_ = false;
   requestUpdate();
 }
 
@@ -731,6 +748,9 @@ void HackerNewsActivity::pageList(const int delta) {
 
 void HackerNewsActivity::turnPage(const int delta) {
   if (phase_ != Phase::Reading || visibleLines_ == 0) return;
+  // Turning the page is an input on the reader, so it clears the transient
+  // save toast (card #40): you have acknowledged it by reading on.
+  saveFailedNotice_ = false;
   const uint32_t span = visibleLines_;
   const uint32_t maxTop = lineCount_ > span ? lineCount_ - span : 0;
 
@@ -760,7 +780,15 @@ void HackerNewsActivity::render(RenderLock&&) {
   // board, and at the 20px UI cut a 480px panel holds about 28 characters a
   // line: an article became forty page taps and half the headlines on the front
   // page could not finish.
-  fui::GfxRendererTarget target = toybox::makeTarget(renderer, toybox::readingFaces());
+  //
+  // The reader takes a DIFFERENT set: its band carries a story's headline, which
+  // is somebody else's sentence, so readerFaces() gives the band a real reading
+  // ladder to shrink through (bold 16 -> 14 -> 11) instead of stepping down to
+  // the Jersey tile cut a prose headline has no business wearing (card #268).
+  // Every other phase keeps readingFaces(), where the band is the app's own name
+  // in the display cut -- the fork's shared chrome, not the story's voice.
+  const toybox::Faces faces = phase_ == Phase::Reading ? toybox::readerFaces() : toybox::readingFaces();
+  fui::GfxRendererTarget target = toybox::makeTarget(renderer, faces);
   const fui::DeviceContext device = target.deviceContext();
   const fui::ThemeTokens& tokens = toybox::themeTokens();
   const fui::InputSnapshot noInput{};
@@ -934,6 +962,9 @@ void HackerNewsActivity::render(RenderLock&&) {
       // was. Empty only until the first fetch has answered.
       model.canSave = !readerUrl_.empty();
       model.saved = model.canSave && library_.contains(readerUrl_);
+      // A save the card just refused, drawn as a toast over the page instead of
+      // a full-screen notice that would have lost the reader's place (card #40).
+      model.saveNotice = saveFailedNotice_ ? "Not saved: the card is full." : nullptr;
       // The count the panel was drawn from; see the twin in
       // InstapaperActivity.cpp. No reading position goes anywhere from here,
       // but the page label and the forward control were both computed from

--- a/src/apps_local/hackernews/HackerNewsActivity.h
+++ b/src/apps_local/hackernews/HackerNewsActivity.h
@@ -134,6 +134,12 @@ class HackerNewsActivity final : public Activity {
   // Whether the reader was opened out of the library rather than off the front
   // page. Back honours it: a saved article returns to the shelf it came from.
   bool readingSaved_ = false;
+  // The last save in the reader was refused (a full card). Draws a transient
+  // toast over the reader instead of ejecting to a full-screen notice (card
+  // #40). Set by saveCurrentArticle on failure, and cleared by the reader's
+  // next input -- a page turn, an unsave, or leaving -- so it acknowledges the
+  // failure once and gets out of the way.
+  bool saveFailedNotice_ = false;
   hn::Library library_;
   bool articleAvailable_ = false;
   uint32_t topLine_ = 0;

--- a/src/apps_local/hackernews/HackerNewsScreens.cpp
+++ b/src/apps_local/hackernews/HackerNewsScreens.cpp
@@ -301,41 +301,26 @@ uint32_t readerLineCount(const fui::DrawTarget& target, const fui::DeviceContext
 }
 
 uint32_t buildReader(toybox::Screen& screen, const ReaderModel& model, ReaderBody& body) {
-  // The band carries the story's own headline. Within this app chrome is
-  // Jersey and content is the reading face, and a title is content --
-  // somebody's sentence, in its own case -- so the band borrows the reading
-  // cut in paper, the way a book's running header borrows the text's. Fitted
-  // to the room the page label leaves; fitLines marks the cut when a headline
-  // will not go.
-  fui::TextStyle bandTitle = screen.theme().bodyText;
-  bandTitle.color = fui::Color::White;
+  // The band carries the story's own headline. Within this app chrome is the
+  // display cut and content is the reading face, and a title is content --
+  // somebody's sentence, in its own case -- so the band takes the bold reading
+  // cut (the title slot under readerFaces): big enough to read as a headline,
+  // and the top of a ladder that steps DOWN through real reading cuts
+  // (bold 16 -> 14 -> 11) as the sentence grows.
+  //
+  // The headline is handed over WHOLE, not pre-fitted here. headerBand() runs it
+  // through toybox::fittedTitle, which walks that ladder against the room the
+  // component really leaves -- headerTitleWidth() already subtracts the SAVE
+  // control and the page label -- and marks the cut with an ellipsis only when
+  // the smallest reading cut still overflows one line. Fitting it a second time
+  // here, to a room hand-summed from those same terms, is exactly the drift that
+  // once shortened a headline to a room ninety pixels too wide and let the
+  // component cut it AGAIN: two ellipses on the one screen whose title is always
+  // somebody else's sentence. One fitter, in one place (card #268).
+  fui::TextStyle bandTitle = screen.theme().titleText;  // bold reading cut, already White
+  bandTitle.align = screen.theme().headerTitleAlign;
   bandTitle.maxLines = 1;
-  const fui::TextStyle& labelStyle = screen.theme().smallText;
-  const int16_t labelWidth =
-      model.pageLabel != nullptr && model.pageLabel[0] != '\0'
-          ? static_cast<int16_t>(screen.target().measureText(labelStyle.font, model.pageLabel, labelStyle).width +
-                                 toybox::kGutter)
-          : 0;
-  // The SAVE control is in the band too, and it was in NEITHER term of this
-  // sum. The component reserves `label + 20 + icon + 4`, then another 8 of
-  // gutter (components/controls/header.h), so a headline was fitted to a room
-  // about ninety pixels wider than the one it is drawn into -- and then cut a
-  // second time by the component, with a second ellipsis, on the one screen in
-  // this fork whose title is always somebody else's sentence. Instapaper's twin
-  // has no trailing control and so had no second term to forget.
-  int16_t saveWidth = 0;
-  if (model.canSave) {
-    // Every term the component charges for a trailing button, in its order:
-    // the label at the style Screen::header substitutes (bodyText), its 20px of
-    // padding, the icon and its 4, and the 8 of gutter beside the button.
-    const fui::TextStyle& trailing = screen.theme().bodyText;
-    saveWidth =
-        static_cast<int16_t>(screen.target().measureText(trailing.font, saveChipLabel(model.saved), trailing).width +
-                             20 + icon_saved_32.w + 4 + 8);
-  }
-  const int16_t room = static_cast<int16_t>(screen.device().width - 2 * toybox::kMargin - labelWidth - saveWidth);
-  const std::string headline = fitLines(screen.target(), model.title, room, 1, bandTitle);
-  chrome(screen, headline.c_str(), model.pageLabel, &bandTitle, model.canSave, model.saved);
+  chrome(screen, model.title, model.pageLabel, &bandTitle, model.canSave, model.saved);
 
   const fui::DeviceContext& device = screen.device();
 
@@ -379,6 +364,30 @@ uint32_t buildReader(toybox::Screen& screen, const ReaderModel& model, ReaderBod
   // whole thread -- twice per paint, counting the measure above.
   if (body.wrap == nullptr) return 0;
   body.wrap->draw(screen.target(), readerBody(device), body.text, body.style, model.topLine);
+  // A save the card refused says so HERE, over the page, instead of throwing
+  // the reader out to a full-screen notice that lost the reader's place (card
+  // #40). A black card, centred on the text, drawn last so it sits on top of
+  // the article -- and cleared the moment the reader is touched again, so it is
+  // a transient acknowledgement, not a wall. A white hairline keeps it from
+  // reading as a second header band.
+  if (model.saveNotice != nullptr && model.saveNotice[0] != '\0') {
+    fui::StyleSet noticeStyles = toybox::invertedStyles();
+    noticeStyles.normal.border = fui::Paint::solid(fui::Color::White);
+    noticeStyles.normal.borderWidth = toybox::kHairline;
+    noticeStyles.selected = noticeStyles.focused = noticeStyles.active = noticeStyles.disabled = noticeStyles.normal;
+    fui::ToastProps toast;
+    toast.message = model.saveNotice;
+    toast.styles = noticeStyles;
+    // The reading cut, not the bold headline one: the bold cut is wide enough
+    // that "Not saved: the card is full." clipped to "Not saved: t..." inside
+    // the panel, which is the very failure a toast exists to avoid. maxLines 2
+    // wraps a longer reason rather than truncating it.
+    toast.text = screen.theme().bodyText;
+    toast.text.color = fui::Color::White;  // on a black panel
+    toast.text.maxLines = 2;
+    toast.anchor = fui::ToastAnchor::Center;
+    fui::toast(screen.frame(), readerBody(device), toast);
+  }
   // Asked AFTER the drawing, and cheap because the wrap has just answered it.
   return body.wrap->lineCount(screen.target(), readerBody(device).width, body.text, body.style);
 }

--- a/src/apps_local/hackernews/HackerNewsScreens.h
+++ b/src/apps_local/hackernews/HackerNewsScreens.h
@@ -163,6 +163,11 @@ struct ReaderModel {
   // with the most reason to be.
   bool canSave = false;
   bool saved = false;
+  // A one-line reason the last save was refused (a full card). When set, the
+  // reader draws it as a transient toast over the page rather than the Activity
+  // throwing you out to a full-screen notice (card #40). Null on every ordinary
+  // paint; cleared by the Activity the moment the reader takes another input.
+  const char* saveNotice = nullptr;
 };
 
 // The body is a required argument for the same reason as Instapaper's: a

--- a/src/apps_local/ui/ToyboxTheme.h
+++ b/src/apps_local/ui/ToyboxTheme.h
@@ -63,9 +63,16 @@ inline Faces readingChromeFaces() { return Faces{kButtonFontId, kReadingFontId, 
 
 // And for a screen whose header band carries a story's title rather than the
 // app's name: the title slot takes the bold reading cut so a whole headline
-// fits and still reads as a headline. The app's own name stays in the display
-// cut on the screen where it *is* the title, which is the front page.
-inline Faces readerFaces() { return Faces{kButtonFontId, kReadingFontId, kReadingBoldFontId}; }
+// fits and still reads as a headline, and the SMALL slot takes the small
+// reading cut so a headline too long for the bold cut steps DOWN through real
+// reading faces (bold 16 -> 14 -> 11) rather than falling straight to an
+// ellipsis. The step used to be the Jersey tile cut (kButtonFontId), which is
+// a pixel display face with no business setting prose -- so a long headline was
+// either cut at reading_serif_14 or shrunk into a 21px Jersey line box, and the
+// fork's own shrink rule had nothing worth stepping down to (card #268). The
+// app's own name stays in the display cut on the screen where it *is* the
+// title, which is the front page.
+inline Faces readerFaces() { return Faces{kReadingSmallFontId, kReadingFontId, kReadingBoldFontId}; }
 
 // A screen whose content is ONE WORD, sized to be read across a room. All three
 // slots carry a different size of the same face, largest in the title slot,


### PR DESCRIPTION
Two Hacker News reader-band cards, one tree.

## #40 - "NOT SAVED (card full)" no longer throws you out of the article

When a save failed (a full card), `saveCurrentArticle()` called `showNotice()`,
which switched the Activity to its full-screen **Notice** phase and replaced the
reader with a message, losing the reading position. That is the one failure that
leaves what you were reading perfectly intact, so ejecting was the wrong move.

Now the reader **stays put** and draws the refusal as a transient toast over the
page (SDK `toast` overlay, a black card centred on the text). The Activity keeps
`phase_ = Reading` and sets `ReaderModel::saveNotice`; the toast clears on the
reader's next input (a page turn, an unsave, or leaving). The toast text is the
reading cut, not the bold headline cut - at the bold cut `"Not saved: the card
is full."` clipped to `"Not saved: t..."` inside the panel, which the simulator
render caught.

## #268 - the reader band now has a real cut to step down to

The band fitted its headline with `fitLines` at a single fixed cut
(`reading_serif_14`), so it could only **ellipsise** - it never stepped down.
The reader now binds `readerFaces` (small slot = `reading_serif_11`), and
`buildReader` hands the **whole** title to `headerBand`, whose `fittedTitle`
walks the real reading ladder **bold_16 -> 14 -> 11** against the room the SAVE
control and page label actually leave (removing an old double-fit that once cut
a headline twice).

`host-tests/fittedtitle` walks 30 captured front-page headlines through
`buildReader` in three save-control states (90 combinations): **avoidable cuts
drop from 10 to 0**. The residual (a whole sentence on a one-line band) is
reported, not gated, exactly as it is for the xkcd bar - a one-line band cannot
hold a full HN sentence at any cut, so most headlines still end in a marked
ellipsis, now showing more of themselves at `reading_serif_11` than they did at
`reading_serif_14`. A two-line band is the separate, larger change that would
show them whole; out of scope here.

## Tests

- `host-tests/fittedtitle`: re-pinned at **0 avoidable** (was 10), bound to
  `readerFaces`. Reverting the routing fix -> 4 avoidable (red); restored -> green.
- `host-tests/ui`: adds `testHnReaderSaveFailedToastStaysOnTheReader` (the toast
  is drawn over an intact reader). Reverting the toast draw -> red; restored -> green.

## Verified in the simulator (no hardware)

Seeded saved articles (`fs_agent`, offline SAVED shelf):

- reader band steps to `reading_serif_11` with a marked ellipsis;
- the full-store toast reads `"Not saved: the card is full."` whole, wrapped in a
  black card over an intact reader (header, body, footer all still present).

Not verified: on-device rendering and an on-device full card (the store's
"full" is a real SD write failure, forced for the render).

## Gate note

`check.sh --committed` is green on every suite touched by this change (fittedtitle,
ui, hackernews) and both device envs compile (`gh_release_x4pro`/`sticky`). Its
one red suite is `release` - `docs/release-notes.md has no entry for tagged
release 1.12.27` - which is unrelated repo state (I never touch that file; it
fails identically on `origin/xteink`) and is not one of CI's gates.
