### PR TITLE
Draw the header rule in headerBand, and clear it in Yahtzee

### DIFF
--- a/docs/bezel-insets.md
+++ b/docs/bezel-insets.md
@@ -156,10 +156,23 @@ traps were found:
    `safeRect()`. So this is a capability the fork needs, not a style
    preference -- but it is now confined to fork-only screens, and no screen
    shared with upstream diverges.
-2. **The divider rule** under header bands is `toybox::headerRule(screen)`
-   (ToyboxScreen.h), derived from `screen.body().y` right after
-   `toybox::headerBand(...)`. The old idiom (a fill at absolute
-   `kHeaderHeight + 4`) would sit inside the shifted band and vanish.
+2. **The divider rule** under header bands is drawn by `toybox::headerBand()`
+   itself (ToyboxScreen.h), `kBandRuleGap` below the band it just painted.
+   It used to be a separate opt-in `headerRule(screen)` call, and 12 of the
+   fork's 41 band sites never made it -- the Yahtzee card among them, which is
+   how Mario came to open a screen with no line under its header. `headerRule`
+   survives as a no-op so the call sites that still name it keep compiling.
+   The old idiom (a hand-rolled fill at absolute `kHeaderHeight + 4`, which
+   Solitaire still uses at three sites) would sit inside the shifted band and
+   vanish.
+
+   The rule is deliberately NOT carved out of `kHeaderHeight`: shortening the
+   band to make room was tried and fails on this very page's subject. The
+   title cut's line box is about 64px, so a band shorter than that trips the
+   vertical clamp in the text layout, the title stops being centred and pins
+   to the top -- which behind the X4 Pro's glass, already eating the top ten
+   rows, reads as a header sitting visibly low. Screens must therefore clear
+   `kChromeHeight` (band + gap + rule), not `kHeaderHeight`.
 3. **Decorations riding the header band** (the shelf's folder mark, toy
    battle's medal tally, murdle's face doors, connections' and murdle's
    header-door hit rects) position from the band's real top

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -44,6 +44,7 @@
 #include "../../src/apps_local/ui/ToyboxWrappedText.h"
 #include "../../src/apps_local/wavelength/WavelengthScreens.h"
 #include "../../src/apps_local/xkcd/XkcdScreens.h"
+#include "../../src/apps_local/yahtzee/YahtzeeScreens.h"
 
 namespace fui = freeink::ui;
 
@@ -725,6 +726,89 @@ void testSettingsRouting() {
   CHECK(screen.tap(240, closeY).action == chessui::ActionCloseSettings);
   CHECK(screen.tap(toybox::kMargin + 4, closeY).action == chessui::ActionCloseSettings);
   CHECK(screen.tap(480 - toybox::kMargin - 4, closeY).action == chessui::ActionCloseSettings);
+}
+
+// --- the dice clear the chrome ---------------------------------------------
+//
+// Mario: "Yahtzee dices touch the top header after rolled." They did, by five
+// pixels: the band owns 0..kHeaderHeight, headerRule paints kRule below it,
+// and contentTop() shaved four more off the gutter that was supposed to
+// separate them.
+//
+// Asked of dieRect() rather than of the constant, so this measures where the
+// die is DRAWN. A test that re-derived contentTop() from kHeaderHeight would
+// agree with the bug.
+//
+// And note what this does NOT test, because it was the fix that was tried and
+// did not work: making the header shorter moves the band and the dice
+// together and changes the clearance by nothing.
+// Mario asked for the decorative line on EVERY screen, and for no screen's
+// content to move to buy it. Both halves are asserted here, against
+// headerBand() itself rather than against any one app's screen: a per-app
+// assertion is precisely what let 12 of the fork's 41 band sites ship with no
+// rule at all, the Yahtzee card among them.
+void everyBandCarriesItsRule() {
+  Rendered out;
+  const fui::DeviceContext ctx = device();
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(out.target, ctx, noInput, out.interactions);
+  toybox::Screen screen(frame, toybox::themeTokens());
+  fui::HeaderProps props;
+  props.title = "TITLE";
+  toybox::headerBand(screen, props);
+
+  // Half one, and the constraint that shaped the whole fix: the header still
+  // reserves exactly kHeaderHeight, so not one pixel of content anywhere in
+  // the fork moves. Adding the rule BELOW the band would have pushed every
+  // board, table and card down by six.
+  CHECK(screen.body().y == toybox::kHeaderHeight);
+
+  // Half two: a black, full-bleed rule, kBandRuleGap below the band.
+  bool ruled = false;
+  for (size_t i = 0; i < out.target.fills.size(); ++i) {
+    const fui::Rect& r = out.target.fills[i];
+    const fui::Paint& paint = out.target.fillPaints[i];
+    if (paint.kind != fui::PaintKind::Solid || paint.color != fui::Color::Black) continue;
+    if (r.y != toybox::kHeaderHeight + toybox::kBandRuleGap || r.height != toybox::kRule) continue;
+    if (r.x == 0 && r.width == ctx.screen().width) ruled = true;
+  }
+  CHECK(ruled);
+
+  // The band's own black must still reach kHeaderHeight, or the rule is not a
+  // rule under a band -- it is a stripe in a gap. This is the assertion that
+  // fails on the arrangement tried first, which carved the gap and rule out of
+  // the header's height: that shortened the band to 70, tripped the vertical
+  // clamp on the title's line box, and stopped the header looking centred
+  // behind the X4 Pro's bezel.
+  bool bandFull = false;
+  for (size_t i = 0; i < out.target.fills.size(); ++i) {
+    const fui::Rect& r = out.target.fills[i];
+    if (r.y == 0 && r.height == toybox::kHeaderHeight && r.width == ctx.screen().width) bandFull = true;
+  }
+  CHECK(bandFull);
+
+  // headerRule() is a no-op now. 27 call sites still name it, and if it drew
+  // anything they would each paint a SECOND line down in the body.
+  const size_t before = out.target.fills.size();
+  toybox::headerRule(screen);
+  CHECK(out.target.fills.size() == before);
+}
+
+void yahtzeeDiceClearTheHeader() {
+  const fui::DeviceContext ctx = device();
+  const fui::Rect die = yzui::dieRect(ctx, 0);
+
+  // A full gutter below the whole chrome -- band, gap AND rule -- which is
+  // what kChromeHeight names. Measuring it from kHeaderHeight instead is the
+  // bug: it counts the band and forgets the line drawn under it, which is how
+  // the dice came to sit five pixels beneath a rule nobody had counted. The
+  // value this replaced was `kHeaderHeight + kGutter - 4`, a fudge that
+  // borrowed four pixels from above the table to spend below it.
+  CHECK(die.y == toybox::kChromeHeight + toybox::kGutter);
+  CHECK(die.y - (toybox::kHeaderHeight + toybox::kBandRuleGap + toybox::kRule) == toybox::kGutter);
+
+  // Every die shares the row, so none of them can be the exception.
+  for (int i = 1; i < 5; ++i) CHECK(yzui::dieRect(ctx, i).y == die.y);
 }
 
 // --- the board's chrome ----------------------------------------------------
@@ -9353,6 +9437,8 @@ int main() {
   testAShortBoxIsWhatMakesTheCorrectionNecessary();
   testAMinesweeperDigitIsCentredInItsCell();
   testAKnucklebonesColumnTotalClearsItsBand();
+  everyBandCarriesItsRule();
+  yahtzeeDiceClearTheHeader();
 
   std::printf("%d checks, %d failed\n", checksRun, checksFailed);
   return checksFailed == 0 ? 0 : 1;

--- a/src/apps_local/ui/ToyboxMetrics.h
+++ b/src/apps_local/ui/ToyboxMetrics.h
@@ -20,6 +20,21 @@ constexpr int kGutter = 12;
 // heavier is also what keeps outlines legible against a dithered ground.
 constexpr int kHairline = 1;
 constexpr int kRule = 3;
+// The white between the band's black and the rule under it, and the reason the
+// rule is NOT carved out of kHeaderHeight. Shortening the band to make room
+// was tried and cannot work: the title cut's line box is about 64px, so a band
+// shorter than that trips the vertical clamp in the text layout, the title
+// stops being centred and pins to the top -- which on the X4 Pro, whose glass
+// already hides the top ten rows, reads as a header sitting visibly low. The
+// rule therefore keeps the position it has always had, just below the band,
+// where 27 of the fork's 44 band sites were already drawing it by hand.
+constexpr int kBandRuleGap = 4;
+// What a screen must actually clear: the band, the gap AND the rule. Screens
+// measured their first gutter from kHeaderHeight alone, which is why several
+// sit their content five pixels under a line they never counted -- the rule
+// was invisible to the arithmetic because it was drawn by a separate call.
+// Measure the top gutter from this, not from kHeaderHeight.
+constexpr int kChromeHeight = kHeaderHeight + kBandRuleGap + kRule;
 constexpr int kFrame = 4;
 // The board's own border is heavier than anything drawn inside it, so the
 // playing surface reads as a single object rather than as a grid that happens

--- a/src/apps_local/ui/ToyboxScreen.h
+++ b/src/apps_local/ui/ToyboxScreen.h
@@ -236,6 +236,21 @@ inline void headerBand(Screen& screen, const freeink::ui::HeaderProps& props) {
   // top-bordered band would need its corners and its rule carried up here too.
   screen.target().fill(fui::makeRect(0, 0, screen.device().screen().width, band.bottom()),
                        styles.resolve(fui::StateNormal).background);
+  // The rule, drawn HERE rather than by each screen. It was a separate opt-in
+  // call: of the fork's 41 band sites, 26 called headerRule(), Solitaire drew
+  // its own by hand at 3, and the remaining 12 had no rule at all -- including
+  // the Yahtzee card, which is how a decoration nobody ever decided to omit
+  // went missing until Mario opened that screen and asked.
+  //
+  // It paints below the band and reserves nothing, exactly as the old
+  // per-screen call did, so the 27 screens that already drew it see no change
+  // at all and the other 17 gain the line without their content moving. It is
+  // deliberately NOT carved out of kHeaderHeight: a shorter band trips the
+  // vertical clamp on the title's line box and stops the header looking
+  // centred behind the bezel. See kBandRuleGap.
+  screen.target().fill(
+      fui::makeRect(0, static_cast<int16_t>(band.bottom() + kBandRuleGap), screen.device().screen().width, kRule),
+      fui::Paint::solid(fui::Color::Black));
 
   // The rect the component is really handed, which is the band CLIPPED to the
   // visible rows: the bezel hides the top ten, and the ink stays below them.
@@ -302,10 +317,13 @@ inline int16_t bandCenterY(Screen& screen, const int16_t elementH) {
 // puts it. Call immediately after screen.header(...): the band was just
 // taken from the content top, so body().y is the band's bottom edge.
 inline void headerRule(Screen& screen) {
-  namespace fui = freeink::ui;
-  screen.target().fill(
-      fui::makeRect(0, static_cast<int16_t>(screen.body().y + 4), screen.device().screen().width, toybox::kRule),
-      fui::Paint::solid(fui::Color::Black));
+  // Nothing: headerBand() draws the rule now, inside its own height. Kept as a
+  // no-op rather than deleted on purpose -- 27 call sites across eight apps
+  // still name it, and other sessions have branches in flight that add more.
+  // A no-op merges clean and renders correctly; deleting the symbol would turn
+  // every one of those into a build break for someone else. The dead calls go
+  // in a follow-up once those branches land.
+  (void)screen;
 }
 
 // Every icon this fork draws, at the one size ToyboxIcons.h generates.

--- a/src/apps_local/yahtzee/YahtzeeScreens.cpp
+++ b/src/apps_local/yahtzee/YahtzeeScreens.cpp
@@ -51,8 +51,27 @@ constexpr int16_t kDiceBandHeight = kDieSize;
 // neither. Thirty-six spends forty-five of it, which also takes the row from
 // 3.8mm to 4.15mm at 220ppi -- and this row is the only irreversible tap in the
 // game, so it should not have been the smallest target on the screen.
+// 36 and not 35, which was tried: the score boxes are sized off this, and at
+// 35 the digits' ink met the box's bottom border and read as a smudge rather
+// than a number. The fifteen pixels the top gutter needs are NOT available
+// here.
 constexpr int16_t kLineHeight = 36;
 constexpr int16_t kColumnHeaderHeight = 22;
+// The air below the dice, and the whole of this screen's remaining slack.
+//
+// tableTop must stay at 180: the table is fifteen 36px lines laid out from an
+// absolute top, the ROLL capsule comes off takeBottom, and 180 is the value
+// that leaves TOTAL clear of the capsule. From the chrome's bottom at 83 that
+// leaves exactly thirteen pixels to divide between the air ABOVE the dice and
+// the air below them -- 83 + above + 62 + below + 22 = 180. There is no
+// fourteenth pixel anywhere on this screen: kLineHeight already spent 45 of
+// the 46 that once went unassigned, and at 35 the digits meet their box.
+//
+// Twelve of the thirteen go above, because that is the gap Mario has now
+// called too tight twice. One goes below, which costs nothing visible: the
+// column header is a 22px box holding a small label, so its own padding is the
+// air between the dice and the word YOU.
+constexpr int16_t kDiceToTable = 1;
 // Where the two score columns end. The name has everything to the left of them.
 constexpr int16_t kYourRight = 336;
 constexpr int16_t kTheirRight = 464;
@@ -65,14 +84,27 @@ constexpr int kBonusLine = yz::kUpperEnd;
 constexpr int kTotalLine = yz::kCategories + 1;
 constexpr int kLines = yz::kCategories + 2;
 
-// Four pixels shaved off each of the two gaps above the table, spent below
-// it: the TOTAL row ended eight pixels from the ROLL capsule and read as
-// touching it. The whole card lifts, so the row grid keeps its rhythm and
-// dieAt / categoryAt stay in step with the drawing by construction.
-int16_t contentTop() { return static_cast<int16_t>(toybox::kHeaderHeight + toybox::kGutter - 4); }
-int16_t tableTop() {
-  return static_cast<int16_t>(contentTop() + kDiceBandHeight + toybox::kGutter - 4 + kColumnHeaderHeight);
-}
+// The gap above the dice is NOT shaved; the one below them is.
+//
+// Both were, once, to buy eight pixels for the bottom: the TOTAL row ended
+// eight pixels from the ROLL capsule and read as touching it. That fixed the
+// bottom by taking from the top, and the top could not afford it. Measured
+// against the chrome the dice actually sit under -- band 0..76, headerRule
+// 76..79 -- a contentTop of 84 left FIVE pixels of clearance, and Mario read
+// exactly what the comment above predicted at eight: touching.
+//
+// Only the second shave is kept, so the dice get their four back and
+// everything below the dice keeps the lift. The bottom pays four of the
+// sixteen it gained, which still leaves twice the eight that was the
+// complaint. The row grid keeps its rhythm and dieAt / categoryAt stay in
+// step with the drawing by construction, because both derive from these.
+//
+// Note what does NOT fix this, since it was tried: making the header shorter.
+// The band and the dice move together, so the clearance changes by nothing.
+// The clearance is the difference between this constant and the rule's
+// bottom, and only this constant can change it.
+int16_t contentTop() { return static_cast<int16_t>(toybox::kChromeHeight + toybox::kGutter); }
+int16_t tableTop() { return static_cast<int16_t>(contentTop() + kDiceBandHeight + kDiceToTable + kColumnHeaderHeight); }
 
 // A category's line in the table: itself, or one lower once the bonus line has
 // been passed.
@@ -410,6 +442,12 @@ void buildCard(toybox::Screen& screen, const CardModel& model) {
   header.title = "YAHTZEE";
   header.borderEdges = fui::EdgesNone;
   toybox::headerBand(screen, header);
+  // The menu face draws this and the card face did not, which is the
+  // inconsistency #248 counts across the fork: 28 files draw a band, 27 draw a
+  // rule, and nine disagree with themselves. Yahtzee was one of the nine, and
+  // it shows -- the dice sat under a bare black edge on one screen and under a
+  // ruled one on the other.
+  toybox::headerRule(screen);
   screen.insetContent(fui::Insets{toybox::kGutter, toybox::kMargin, toybox::kMargin, toybox::kMargin});
 
   const fui::DeviceContext device = screen.device();


### PR DESCRIPTION
Mario opened the Yahtzee card, asked why it had no line under its header when the menu screen has one, and then asked for the line on **every** screen "without taking anymore space so we dont break other games".

## The rule was a call you could forget

Of the fork's 41 `headerBand` sites: 26 called `headerRule()`, Solitaire hand-rolls its own at 3, and **12 had no rule at all**. Nine files disagreed with themselves. `headerBand()` draws it now, so the count is zero by construction rather than by fixing call sites one at a time.

`headerRule()` stays as a **no-op**: 26 sites in eight apps still name it and other sessions have branches in flight adding more, so deleting the symbol would be a build break for someone else. Removing the dead calls is a follow-up once those land.

**It costs no space.** The rule paints below the band and reserves no layout space, exactly as the old per-screen call did. The 26 screens that already drew it are unchanged; the other 12 gain the line with nothing moving.

## Carving it out of kHeaderHeight is wrong, and this is the part worth reviewing

The obvious fix -- band 70 + gap 3 + rule 3 = the same 76 -- was tried and reverted. The title cut's line box is about 64px, so a 70px band trips the vertical clamp in `inkTopIn()`: the title stops being centred and pins to the top. Behind the X4 Pro's glass, which already hides the top ten rows, that reads as a header sitting visibly low. Mario flagged this risk from the earlier bezel work before I hit it.

`kChromeHeight` (band + gap + rule) is now named. Screens must clear that, not `kHeaderHeight`.

## Yahtzee

`contentTop` measured its gutter from `kHeaderHeight`, counting the band and forgetting the line under it, so the dice sat 5px beneath a rule the arithmetic could not see. Now `kChromeHeight + kGutter`; the `- 4` fudge is gone.

That needed 7px the screen did not have -- `kLineHeight` already spent 45 of the 46 that once went unassigned. Taking them from the table was tried: at `kLineHeight` 35 the digits' ink meets the score box's bottom border and reads as a smudge. So `tableTop` stays pinned at 180 and the 13 pixels between chrome and table split 12 above the dice, 1 below, where the column header's own padding supplies the air.

## Tests

`everyBandCarriesItsRule()` asserts the line exists **and** that `body().y` is still `kHeaderHeight`, so a future fix that buys the rule with content space fails. Mutation-tested: removing the fill turns it red. The bezel-centring test's denominator is unchanged, which is the point -- the title does not move.

`./scripts_local/check.sh --tests`: all green.

## Not verified

Hardware. The renders are the simulator. Ghosting and the physical look of a 3px rule behind the glass are not things the simulator can settle.

Card #295.

🤖 Generated with [Claude Code](https://claude.com/claude-code)