### PR TITLE
Make the header band absolute in headerBand, so every screen's is 76

### DIFF
--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -9181,6 +9181,46 @@ void testTheHeaderTitleStaysOutOfTheCoveredRows() {
 // And the third: the band's BOTTOM edge is what every layout below it is tuned
 // against, so widening the paint upward must not move it. Under absolute chrome
 // that edge is kHeaderHeight, with or without the glass.
+// And the band is absolute WITHOUT the screen asking, which is the half that
+// was missing. absoluteChrome() used to be an opt-in call placed before
+// headerBand(), and screens forgot it the same way they forgot the rule:
+// Yahtzee called it on its menu and not on its card, so the card's band began
+// at the bezel's safe top and painted 85 rows where the menu painted 76. Two
+// headers, two heights, in one game. This drives headerBand() directly on a
+// bezelled frame with no absoluteChrome() call of its own, which is exactly
+// what those screens did.
+void testTheBandIsAbsoluteWithoutBeingAsked() {
+  Rendered out;
+  const fui::DeviceContext ctx = bezelDevice();
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(out.target, ctx, noInput, out.interactions);
+  toybox::Screen screen(frame, toybox::themeTokens());
+  fui::HeaderProps props;
+  props.title = "TITLE";
+  toybox::headerBand(screen, props);
+
+  // The bezel must not push the band down. Both numbers matter: a band that
+  // starts at the safe top AND keeps its height ends kHeaderHeight + 10 down
+  // the panel, which is the 85px band Mario saw.
+  CHECK(screen.body().y == toybox::kHeaderHeight);
+
+  bool paintedFromRowZero = false;
+  for (size_t i = 0; i < out.target.fills.size(); ++i) {
+    const fui::Rect& r = out.target.fills[i];
+    if (r.y == 0 && r.height == toybox::kHeaderHeight && r.width == ctx.screen().width) paintedFromRowZero = true;
+  }
+  CHECK(paintedFromRowZero);
+
+  // And the rule tracks it, rather than sitting 10px lower on this screen than
+  // on its sibling.
+  bool ruled = false;
+  for (size_t i = 0; i < out.target.fills.size(); ++i) {
+    const fui::Rect& r = out.target.fills[i];
+    if (r.y == toybox::kHeaderHeight + toybox::kBandRuleGap && r.height == toybox::kRule) ruled = true;
+  }
+  CHECK(ruled);
+}
+
 void testTheHeaderBandBottomIgnoresTheBezel() {
   fui::ListItem items[1] = {};
   items[0].label = "CHESS";
@@ -9244,6 +9284,7 @@ int main() {
   testAHandDrawnRightLabelSitsOnTheTitlesLine();
   testTheHeaderTitleStaysOutOfTheCoveredRows();
   testTheHeaderBandBottomIgnoresTheBezel();
+  testTheBandIsAbsoluteWithoutBeingAsked();
   testTriviaOptionsCarryTheirIndex();
   testTriviaAlwaysOffersAWayOut();
   testTriviaDrawsNoOptionsWithoutAQuestion();

--- a/src/apps_local/ui/ToyboxScreen.h
+++ b/src/apps_local/ui/ToyboxScreen.h
@@ -226,6 +226,18 @@ inline int16_t headerTitleWidth(Screen& screen, const freeink::ui::Rect& band, c
 // twenty-fifth copy will not have.
 inline void headerBand(Screen& screen, const freeink::ui::HeaderProps& props) {
   namespace fui = freeink::ui;
+  // Absolute chrome, done HERE so no screen can forget it. It was an opt-in
+  // call placed before this one, and screens forgot it exactly the way they
+  // forgot the rule: Yahtzee called it on its menu and not on its card or its
+  // result, so the card's band began at the bezel's safe top instead of row 0
+  // and painted 85 rows where the menu painted 76. Mario saw the two screens
+  // side by side and asked why one header was taller, which is the only way
+  // this was ever going to be found -- every band looks right alone.
+  //
+  // Safe to do unconditionally: it is idempotent for the 25 screens that
+  // already call it, and no screen in the fork insets its content before its
+  // band, so there is no inset here to clobber.
+  absoluteChrome(screen);
   const fui::Rect band = screen.takeTop(screen.theme().headerHeight);
   const int16_t safeTop = screen.frame().safeRect().y;
   const int16_t inkTop = band.y > safeTop ? band.y : safeTop;


### PR DESCRIPTION
Mario put the Yahtzee card next to the games list and asked why one header was taller. He was right, and it is measurable:

| | band height |
|---|---|
| Games list | **76 rows** |
| Yahtzee card | **85 rows** |

## Same failure as the rule, one function along

`absoluteChrome()` is an opt-in call placed *before* `headerBand()`, and screens forget it exactly the way they forgot `headerRule()`. Yahtzee calls it on its menu and on neither its card nor its result, so those bands begin at the bezel's safe top instead of row 0. The paint still runs from row 0 (deliberate -- paint may go under the glass), so the band ends up `safeTop + kHeaderHeight` tall: 85 against 76, in one game.

Not only Yahtzee. Band sites vs `absoluteChrome()` calls per file:

```
checkers 3/1   connect four 3/1   knucklebones 3/1   minesweeper 3/1
yahtzee  3/1   hacker news  2/1   trivia       2/1   xkcd         1/0
```

`headerBand()` now does it, so no screen can forget. Unconditional is safe: idempotent for the 25 screens that already call it, and **no screen in the fork insets its content before its band** -- checked, not assumed, because that is the way this would break quietly.

## Verified by pixels, not by reading the diff

Before: games list black to row 75, Yahtzee to row 84. After, both identical -- black `0..24` and `62..76` with the title's white between, rule at `80..82`. Checkers was rendered too, since it is the app that both missed the call *and* lays out against `screen.body()`; its content did not move.

## Tests

`testTheBandIsAbsoluteWithoutBeingAsked()` drives `headerBand()` on a bezelled frame with no `absoluteChrome()` of its own -- exactly what those screens did -- and asserts the band starts at row 0, is `kHeaderHeight` tall, and carries its rule. Mutation-tested: dropping the call turns all three red.

`./scripts_local/check.sh --tests`: all green.

## Not verified

Hardware, and the board screens of the seven other apps that were missing the call. The ui suite covers them; a render does not.

Follow-up to #295 / [#104](https://github.com/ma-r-s/crossplay/pull/104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)