### PR TITLE
board: a card addressed to Mario is an inbox item by construction

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -60,6 +60,25 @@ against the mirror alone (what the tests do). `board sync` copies the file
 store into Supabase once, ids kept, for the migration that already happened
 on 2026-09-03.
 
+## A card addressed to Mario is an inbox item
+
+The inbox is the open `mario` blockers and nothing else, and a card is not a
+blocker. So a card filed on app `mario` -- which by convention already means
+"only Mario can decide this" -- reached him only if somebody also remembered
+to block on it, and twice nobody did: cards 75 and 84 were his decisions and
+aged a day in `reported` while his inbox said nothing needs you. That is a
+dropped message, not a delay.
+
+Since card #209 it is not something to remember. Filing a card on app `mario`
+(`board new "..." --from mario`) or moving one there (`board app <id> mario`)
+opens a `mario` blocker asking the card's title, and one only: a card that
+already has an open one never gets a second, however many times it is moved.
+`--default` says what happens if he never answers; without one the blocker
+says `nothing happens until he answers`, which is honest and lets him ignore
+it safely. Both the CLI and a trigger on `cards` enforce this, because the CLI
+is not the only writer -- the site's report function, the inbox page and a
+hand-typed `UPDATE` all reach the table directly.
+
 ## When the guard itself breaks
 
 It fails open, on purpose. Anything unexpected inside `guard.py` exits 0

--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -75,9 +75,16 @@ opens a `mario` blocker asking the card's title, and one only: a card that
 already has an open one never gets a second, however many times it is moved.
 `--default` says what happens if he never answers; without one the blocker
 says `nothing happens until he answers`, which is honest and lets him ignore
-it safely. Both the CLI and a trigger on `cards` enforce this, because the CLI
-is not the only writer -- the site's report function, the inbox page and a
-hand-typed `UPDATE` all reach the table directly.
+it safely. A card already `done`, `released` or `parked` is left alone: a
+decision taken is not one to ask again.
+
+Two enforcers, because the CLI is not the only writer -- the site's report
+function, the inbox page and a hand-typed `UPDATE` all reach `cards` directly.
+**Only the CLI half is live.** `20260905000300_mario_inbox.sql` adds the
+triggers and backfills the cards dropped before the rule existed, and it is
+written but **not yet applied**; until `server/board/migrate.sh` has run it,
+a card that reaches `cards` by any route other than `board` gets no blocker.
+`server/board/migrate.sh --list` says whether it is still pending.
 
 ## When the guard itself breaks
 

--- a/docs/workflow/orchestrator.md
+++ b/docs/workflow/orchestrator.md
@@ -31,6 +31,13 @@ answers>'`. Never forward a worker's wording; write the three lines
      asks again.
    - `mario`: it is already in his inbox. Do nothing until `board answer`
      lands, then unblock the worker with the answer.
+   - A whole card that is his decision goes on app `mario`, and lands in his
+     inbox by itself: `board new "<the decision>" --from mario --default
+'<what happens if he never answers>'`, or `board app <id> mario` for one
+     already filed. It opens the blocker for you, asking the card's title, so
+     write the title as the question. Give it a `--default`; the fallback is
+     honest but generic, and an inbox of questions with no stated cost of
+     silence is one he stops reading.
 3. **Infrastructure.** A red gate, a full disk, a lock, a merge conflict:
    yours. Fix it or diagnose it and hand the diagnosis to the worker. Never
    edit app code yourself; whose file is that.

--- a/docs/workflow/worker-contract.md
+++ b/docs/workflow/worker-contract.md
@@ -15,7 +15,9 @@ are enforced by hooks and will refuse rather than remind.
 - **You never talk to Mario.** If only he can move you, record it on the card:
   `board block <id> --session <your id> --need mario --ask '<one line>'
 --default '<what happens if nobody answers>'`. The orchestrator decides
-  whether it reaches him.
+  whether it reaches him. A card is not a blocker, so a decision filed as a
+  card only reaches him on app `mario`, where filing it opens the blocker by
+  itself; still your card's blocker that unblocks you, not a message to him.
 - **A turn does not end on a question or a list of next steps.** It ends with
   the next step taken, or with a blocker recorded and one line saying so.
   The Stop hook refuses anything else.

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -226,6 +226,51 @@ board integrator --session "$WORKER" >/dev/null 2>&1 && bad "a second integrator
 board integrator --session "$WORKER" --release >/dev/null 2>&1 && bad "a stranger released the claim" || ok "only the holder releases the claim"
 board integrator --session "$INTEG" --release >/dev/null && ok "the holder releases the claim" || bad "holder cannot release"
 
+# Mario reads his inbox and nothing else, the inbox is the open `mario`
+# blockers and nothing else, and a card is not a blocker. So a card filed on
+# app `mario` -- the app that by convention already means "only Mario can
+# decide this" -- reached him only if somebody also remembered to block on it.
+# Twice nobody did: cards 75 and 84 were his decisions and aged a day in
+# `reported` while his inbox said nothing needs you. Card #209 made the rule
+# physical, and this is where it is watched holding.
+echo "a card addressed to Mario is an inbox item by construction"
+MID=$(board new "Retire Main and open a fresh orchestrator" --from mario | sed 's/^#\([0-9]*\).*/\1/')
+board inbox | grep -q "Need from you: Retire Main and open a fresh orchestrator" \
+  && ok "a card filed on app mario reaches the inbox, asking its title" || bad "a card filed on app mario never reached the inbox"
+board inbox | grep -q "If you do nothing: nothing happens until he answers" \
+  && ok "the blocker it opens says what happens if he never answers" || bad "the auto blocker states no default"
+board new "Archive the four dead apps" --from mario --default "they stay on the shelf" >/dev/null
+board inbox | grep -q "If you do nothing: they stay on the shelf" \
+  && ok "a filer-supplied default wins over the honest fallback" || bad "the filer's default was dropped"
+OID=$(board new "Sudoku keeps its own puzzle" --from sudoku | sed 's/^#\([0-9]*\).*/\1/')
+board show "$OID" | grep -q "BLOCKED(mario)" && bad "a card on another app opened a mario blocker" || ok "only app mario opens one"
+
+# Moved there, not only filed there: the orchestrator retargets cards, and a
+# decision that becomes Mario's on Tuesday is as invisible as one that was his
+# on Monday.
+board app "$OID" mario --default "the puzzle stays where it is" >/dev/null
+board inbox | grep -q "Need from you: Sudoku keeps its own puzzle" \
+  && ok "moving a card to app mario reaches the inbox" || bad "a move to app mario never reached the inbox"
+board show "$OID" | grep -q "moved to app mario" && ok "the move is on the card" || bad "the move left no history"
+board app "$OID" mario >/dev/null
+board app "$OID" mario >/dev/null
+[ "$(board show "$OID" | grep -c '^  blocker ')" = 1 ] \
+  && ok "moving it there again files no second blocker" || bad "repeated moves multiplied the blocker"
+board inbox | grep -q "If you do nothing: the puzzle stays where it is" \
+  && ok "a repeat move keeps the default the filer gave" || bad "a repeat move overwrote the default"
+board app "$OID" sudoku >/dev/null
+board app "$OID" mario >/dev/null
+[ "$(board show "$OID" | grep -c '^  blocker ')" = 1 ] \
+  && ok "a round trip through another app files no second blocker" || bad "a round trip multiplied the blocker"
+board answer "$MID" "retire it" >/dev/null
+board show "$MID" | grep -q "closed: retire it" && ok "he answers the auto blocker like any other" || bad "the auto blocker cannot be answered"
+
+# Filing on app mario is not the orchestrator-only `board ask`: a worker
+# already records `--need mario` blockers on its own card by the contract, so
+# the same worker may file the decision as a card. The gate that stays shut is
+# `board ask`, asserted above.
+expect "a worker may file a card on app mario" 0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"board new 'Which layout ships' --from mario\"}}"
+
 echo "emulator staleness, one answer for check.sh and CI"
 STALE="$HERE/../../scripts_local/emulator-stale.sh"
 E="$WORK/emu"; mkdir -p "$E/src" "$E/site/emulator"; ( cd "$E" && git init -q -b xteink && git config user.email t@t && git config user.name t \

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -265,6 +265,65 @@ board app "$OID" mario >/dev/null
 board answer "$MID" "retire it" >/dev/null
 board show "$MID" | grep -q "closed: retire it" && ok "he answers the auto blocker like any other" || bad "the auto blocker cannot be answered"
 
+# A decision already taken is not one to ask again. The rule and the backfill
+# in the migration have to agree about this, or a board restored by INSERTing
+# a dump opens one blocker per settled decision it ever held.
+DID=$(board new "A decision he already took" --from tooling | sed 's/^#\([0-9]*\).*/\1/')
+board state "$DID" done >/dev/null
+board app "$DID" mario >/dev/null
+board show "$DID" | grep -q "BLOCKED(mario)" && bad "a done card was put back in the inbox" || ok "a settled card moved to app mario opens nothing"
+board new "A decision long since parked" --from mario >/dev/null
+SID2=$(board list | grep "A decision long since parked" | sed 's/^#\([0-9]*\).*/\1/')
+board state "$SID2" parked >/dev/null
+
+# The words the filer typed must not vanish in silence. This is the one case
+# where they cannot be used: the card is already asking him something else, and
+# overwriting THAT blocker's default would be worse than not applying these.
+EID=$(board new "Archive the empty duplicate" --from tooling | sed 's/^#\([0-9]*\).*/\1/')
+board block "$EID" --session "$WORKER" --need mario --ask "Archive it or keep it?" --default "it stays" >/dev/null
+board app "$EID" mario --default "THESE WORDS SHOULD MATTER" 2>&1 | grep -q -- "--default not applied" \
+  && ok "a --default that cannot be used says so out loud" || bad "a --default was dropped in silence"
+board show "$EID" | grep -q "if nothing: it stays" \
+  && ok "and the blocker already there keeps its own words" || bad "the existing blocker's default was overwritten"
+
+# Two open mario blockers on one card. Rare before this rule; routine once
+# every card on app mario carries one of its own. The inbox prints two lines,
+# and an answer typed against one of them must not land on the other -- which
+# is what `board answer` did, silently, by keeping the last match.
+FID=$(board new "Wavelength retail deck" --from mario --default "the deck ships" | sed 's/^#\([0-9]*\).*/\1/')
+board block "$FID" --session "$WORKER" --need mario --ask "Do we have permission for the retail deck?" --default "we assume not" >/dev/null
+board inbox | grep -q -- "board answer $FID '<choice>' --n 2" \
+  && ok "the inbox names the blocker in the command it prints" || bad "the inbox prints an ambiguous answer command"
+# Into a file, not a pipe: an ambiguous answer is REFUSED, so `board` exits 1,
+# and under `set -o pipefail` that non-zero status is the pipeline's however
+# well grep matched. A refusal read as a missing message is the one shape this
+# assertion must not have.
+board answer "$FID" "yes" > "$WORK/amb" 2>&1
+grep -q "say which with --n" "$WORK/amb" \
+  && ok "an ambiguous answer is refused rather than guessed" || bad "an ambiguous answer picked one silently: $(head -c 120 "$WORK/amb")"
+board answer "$FID" "we have it" --n 2 >/dev/null
+board show "$FID" | grep -q "blocker 2 \[mario, closed: we have it\]" \
+  && ok "--n answers the blocker it names" || bad "--n answered the wrong blocker"
+board show "$FID" | grep -q "blocker 1 \[mario, open\]" \
+  && ok "and leaves the other one open" || bad "--n closed a blocker it did not name"
+
+# Moving a card off his desk does not withdraw what he was asked: taking an
+# item out of his inbox with no answer is the dropped message this whole rule
+# is about. It is said out loud and left for a person.
+board app "$FID" tooling 2>&1 | grep -q "still in Mario.s inbox" \
+  && ok "moving a card off app mario says what it leaves in his inbox" || bad "a card left the app and its inbox item went unmentioned"
+board inbox | grep -q "Need from you: Wavelength retail deck" \
+  && ok "and does not silently withdraw it" || bad "the move withdrew an unanswered question"
+
+# Filed by heading, and by the GitHub sweep: same rule, same wording.
+printf '## mario: Which of the three layouts ships\nbody\n' > "$WORK/import3.md"
+board import "$WORK/import3.md" >/dev/null
+board inbox | grep -q "Need from you: Which of the three layouts ships" \
+  && ok "an imported card on app mario reaches the inbox" || bad "import skipped the rule"
+board new "Capital App" --from MARIO >/dev/null
+board list | grep -q "^#[0-9]* *reported *mario *Capital App" \
+  && ok "the app name is lowercased on the way in" || bad "board new stored a mixed-case app the SQL trigger would miss"
+
 # Filing on app mario is not the orchestrator-only `board ask`: a worker
 # already records `--need mario` blockers on its own card by the contract, so
 # the same worker may file the decision as a card. The gate that stays shut is

--- a/host-tests/relwatch/checks.sql
+++ b/host-tests/relwatch/checks.sql
@@ -381,3 +381,72 @@ select t('collect on an unanswered young request posts nothing',
          (select count(*)::text from events), '0');
 select t('and does not move the last-seen clock',
          (select last_ok_at::text from release_state), '2026-09-04 17:00:00+00');
+
+-- 15. A card addressed to Mario is an item in his inbox, by construction
+-- (card #209). The inbox view is the open `mario` blockers and nothing else,
+-- and a card is not a blocker, so a card filed on app `mario` -- the app that
+-- already means "only Mario can decide this" -- used to reach him only if
+-- somebody also remembered to block on it. Cards 75 and 84 aged a day in
+-- `reported` because nobody did. The rule is here as well as in the board CLI
+-- because the CLI is not the only writer: the site's report function, the
+-- inbox page and a hand-typed UPDATE all reach `cards` directly.
+insert into cards (title, app, kind, state) values
+  ('Retire Main and open a fresh orchestrator', 'mario', 'task', 'reported'),
+  ('Sudoku keeps its own puzzle', 'sudoku', 'bug', 'reported');
+select t('a card filed on app mario opens a mario blocker asking its title',
+         (select b.ask from blockers b join cards c on c.id = b.card_id
+          where c.title = 'Retire Main and open a fresh orchestrator' and b.open and b.need = 'mario'),
+         'Retire Main and open a fresh orchestrator');
+select t('and it says what happens if he never answers',
+         (select b."default" from blockers b join cards c on c.id = b.card_id
+          where c.title = 'Retire Main and open a fresh orchestrator' and b.open and b.need = 'mario'),
+         'nothing happens until he answers');
+select t('so it is in the inbox view, which is the only thing he reads',
+         (select count(*)::text from inbox where title = 'Retire Main and open a fresh orchestrator'), '1');
+select t('and the card says it was blocked',
+         (select count(*)::text from history h join cards c on c.id = h.card_id
+          where c.title = 'Retire Main and open a fresh orchestrator'
+            and h.what = 'blocked (mario): Retire Main and open a fresh orchestrator'), '1');
+select t('a card on any other app opens nothing',
+         (select count(*)::text from blockers b join cards c on c.id = b.card_id
+          where c.title = 'Sudoku keeps its own puzzle'), '0');
+
+-- Moved there, not only filed there: a decision that becomes his on Tuesday is
+-- as invisible as one that was his on Monday.
+update cards set app = 'mario' where title = 'Sudoku keeps its own puzzle';
+select t('moving a card to app mario opens one too',
+         (select count(*)::text from inbox where title = 'Sudoku keeps its own puzzle'), '1');
+update cards set app = 'mario' where title = 'Sudoku keeps its own puzzle';
+update cards set state = 'triaged' where title = 'Sudoku keeps its own puzzle';
+update cards set title = 'Sudoku keeps its own puzzle' where title = 'Sudoku keeps its own puzzle';
+select t('moving it there again, or editing it in place, opens no second one',
+         (select count(*)::text from blockers b join cards c on c.id = b.card_id
+          where c.title = 'Sudoku keeps its own puzzle' and b.need = 'mario'), '1');
+update cards set app = 'sudoku' where title = 'Sudoku keeps its own puzzle';
+update cards set app = 'mario' where title = 'Sudoku keeps its own puzzle';
+select t('a round trip through another app while the blocker is open opens no second one',
+         (select count(*)::text from blockers b join cards c on c.id = b.card_id
+          where c.title = 'Sudoku keeps its own puzzle' and b.need = 'mario'), '1');
+
+-- Answered and moved back is a new question, not the old one: the numbering
+-- has to survive it, because (card_id, n) is unique.
+update blockers set open = false, answer_choice = 'keep it', answered_at = now()
+  where need = 'mario' and card_id = (select id from cards where title = 'Sudoku keeps its own puzzle');
+update cards set app = 'sudoku' where title = 'Sudoku keeps its own puzzle';
+update cards set app = 'mario' where title = 'Sudoku keeps its own puzzle';
+select t('once answered, moving it back asks again',
+         (select count(*)::text from blockers b join cards c on c.id = b.card_id
+          where c.title = 'Sudoku keeps its own puzzle' and b.need = 'mario'), '2');
+select t('and the second blocker took the next number',
+         (select string_agg(b.n::text, ',' order by b.n) from blockers b join cards c on c.id = b.card_id
+          where c.title = 'Sudoku keeps its own puzzle'), '1,2');
+
+-- The other half of that migration: the cards already dropped before the rule
+-- existed. Seeded behind the trigger's back, because the point is a card that
+-- never met it; run.sh re-applies the migration file after this, and the two
+-- checks it runs are the ones that see the repair.
+alter table cards disable trigger cards_mario_inbox_ins;
+insert into cards (title, app, kind, state) values
+  ('A decision that aged in reported', 'mario', 'task', 'reported'),
+  ('A decision he already took', 'mario', 'task', 'done');
+alter table cards enable trigger cards_mario_inbox_ins;

--- a/host-tests/relwatch/checks.sql
+++ b/host-tests/relwatch/checks.sql
@@ -411,6 +411,20 @@ select t('a card on any other app opens nothing',
          (select count(*)::text from blockers b join cards c on c.id = b.card_id
           where c.title = 'Sudoku keeps its own puzzle'), '0');
 
+-- A decision already taken is not one to ask again, and the trigger has to
+-- agree with the backfill in the same file about that: a board restored by
+-- INSERTing a dump would otherwise open one blocker per settled decision.
+insert into cards (title, app, kind, state) values
+  ('A decision taken long ago', 'mario', 'task', 'done'),
+  ('A decision parked on purpose', 'mario', 'task', 'parked');
+select t('a settled card filed on app mario opens nothing',
+         (select count(*)::text from blockers b join cards c on c.id = b.card_id
+          where c.title in ('A decision taken long ago', 'A decision parked on purpose')), '0');
+update cards set app = 'sudoku' where title = 'A decision taken long ago';
+update cards set app = 'mario' where title = 'A decision taken long ago';
+select t('and moving a settled card there opens nothing either',
+         (select count(*)::text from inbox where title = 'A decision taken long ago'), '0');
+
 -- Moved there, not only filed there: a decision that becomes his on Tuesday is
 -- as invisible as one that was his on Monday.
 update cards set app = 'mario' where title = 'Sudoku keeps its own puzzle';

--- a/host-tests/relwatch/run.sh
+++ b/host-tests/relwatch/run.sh
@@ -121,15 +121,26 @@ fi
 # apply before anything here inserts a card), so the half of that file which
 # repairs cards dropped before the rule existed would never have been executed
 # by anything. checks.sql leaves two behind the trigger's back; re-applying the
-# file runs the backfill over them, which it can do because the file is
-# re-runnable by construction (create or replace, drop trigger if exists).
+# file runs the backfill over them. The file's definitions are re-runnable
+# (create or replace, drop trigger if exists); the backfill itself is a plain
+# INSERT and production applies it exactly once, through board_migrations.
 if ! psql < "$MIG/20260905000300_mario_inbox.sql" > "$WORK/backfill.out" 2>&1; then
   echo "FAIL relwatch  the mario-inbox migration is not re-runnable"; tail -20 "$WORK/backfill.out"; exit 1
 fi
-psql -c "select t('the backfill files the open card that was dropped',
-                  (select count(*)::text from inbox where title = 'A decision that aged in reported'), '1')" >/dev/null
-psql -c "select t('and leaves the one he has already answered alone',
-                  (select count(*)::text from inbox where title = 'A decision he already took'), '0')" >/dev/null
+# `if ! ... exit 1`, like every other psql in this file. Under `set -uo pipefail`
+# with no -e, a bare `psql -c ... >/dev/null` that errored would simply not
+# insert its row, and the report below counts only what landed: the suite would
+# print "N passed, 0 failed" for a check that never ran.
+for q in \
+  "select t('the backfill files the open card that was dropped',
+            (select count(*)::text from inbox where title = 'A decision that aged in reported'), '1')" \
+  "select t('and leaves the settled one out of his inbox',
+            (select count(*)::text from inbox where title = 'A decision he already took'), '0')"
+do
+  if ! psql -c "$q" >/dev/null 2>"$WORK/backfill.out"; then
+    echo "FAIL relwatch  a backfill check did not run:"; sed 's/^/  /' "$WORK/backfill.out"; exit 1
+  fi
+done
 
 # The keys under test contain '|', which is psql's own column separator, so the
 # report is formatted in SQL and read back as whole lines.

--- a/host-tests/relwatch/run.sh
+++ b/host-tests/relwatch/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-# The release watcher, on a real postgres running the board's real migrations.
+# The board's SQL, on a real postgres running the board's real migrations:
+# the release watcher it was built for, and since card #209 the rule that a
+# card addressed to Mario is an item in his inbox.
 #
 # On 2026-09-04 two releases failed, four workflow runs over five hours, and
 # every visible signal said healthy: the autorelease reported success, tags
@@ -114,6 +116,20 @@ if ! psql < "$HERE/checks.sql" > "$WORK/checks.out" 2>&1; then
   tail -30 "$WORK/checks.out"
   exit 1
 fi
+
+# The backfill in 20260905000300 ran against an empty board (the migrations
+# apply before anything here inserts a card), so the half of that file which
+# repairs cards dropped before the rule existed would never have been executed
+# by anything. checks.sql leaves two behind the trigger's back; re-applying the
+# file runs the backfill over them, which it can do because the file is
+# re-runnable by construction (create or replace, drop trigger if exists).
+if ! psql < "$MIG/20260905000300_mario_inbox.sql" > "$WORK/backfill.out" 2>&1; then
+  echo "FAIL relwatch  the mario-inbox migration is not re-runnable"; tail -20 "$WORK/backfill.out"; exit 1
+fi
+psql -c "select t('the backfill files the open card that was dropped',
+                  (select count(*)::text from inbox where title = 'A decision that aged in reported'), '1')" >/dev/null
+psql -c "select t('and leaves the one he has already answered alone',
+                  (select count(*)::text from inbox where title = 'A decision he already took'), '0')" >/dev/null
 
 # The keys under test contain '|', which is psql's own column separator, so the
 # report is formatted in SQL and read back as whole lines.

--- a/server/board/supabase/migrations/20260905000300_mario_inbox.sql
+++ b/server/board/supabase/migrations/20260905000300_mario_inbox.sql
@@ -1,0 +1,76 @@
+-- A card addressed to Mario is an item in his inbox, by construction.
+--
+-- The inbox view is the open `mario` blockers and nothing else, and a card is
+-- not a blocker. So a card filed on app `mario` -- the app that by convention
+-- already means "only Mario can decide this" -- reached him only if somebody
+-- also remembered to block on it. Twice nobody did: cards 75 and 84 were his
+-- decisions and aged a day in `reported` while his inbox said nothing needs
+-- you. That is a dropped message, not a delay.
+--
+-- The rule lives here as well as in the CLI because the CLI is not the only
+-- writer: the site's report function, the inbox page and a hand-typed UPDATE
+-- all reach `cards` directly, and a rule that only one writer obeys is prose
+-- with extra steps.
+--
+-- The blocker carries a default. One with no stated "what happens if you
+-- never answer" forces him to engage before he can safely ignore it, which is
+-- exactly how an inbox becomes noise and stops being read. This wording is a
+-- placeholder the filer's own words replace: `board new --default` and
+-- `board app <id> mario --default` overwrite it on the blocker this opens.
+--
+-- Idempotent on the one thing that matters, an open `mario` blocker: a card
+-- that has one gets no second one, so moving a card to `mario` twice files
+-- one blocker in total.
+
+create or replace function cards_mario_inbox() returns trigger
+language plpgsql security definer set search_path = public as $$
+declare
+  next_n integer;
+begin
+  if exists (select 1 from blockers where card_id = new.id and open and need = 'mario') then
+    return null;
+  end if;
+  select coalesce(max(n), 0) + 1 into next_n from blockers where card_id = new.id;
+  insert into blockers (card_id, n, need, ask, "default", by_session)
+    values (new.id, next_n, 'mario', new.title,
+            'nothing happens until he answers', 'board');
+  insert into history (card_id, what)
+    values (new.id, 'blocked (mario): ' || new.title);
+  return null;
+end
+$$;
+
+-- Filed there.
+drop trigger if exists cards_mario_inbox_ins on cards;
+create trigger cards_mario_inbox_ins after insert on cards
+  for each row when (new.app = 'mario')
+  execute function cards_mario_inbox();
+
+-- Moved there. `update of app` plus the distinct-from guard so that editing
+-- the title or state of a card already on his desk is not a second delivery.
+drop trigger if exists cards_mario_inbox_upd on cards;
+create trigger cards_mario_inbox_upd after update of app on cards
+  for each row when (new.app = 'mario' and old.app is distinct from new.app)
+  execute function cards_mario_inbox();
+
+-- The cards that were already dropped. Only the ones still open: a decision
+-- that has since been taken does not need asking again, and an inbox that
+-- opens with a pile of settled questions is one nobody reads. On the board as
+-- it stands every card on app `mario` is `done`, so this backfills nothing
+-- today and is here because the next board restored from a dump will not be.
+with filed as (
+  insert into blockers (card_id, n, need, ask, "default", by_session)
+  select c.id,
+         coalesce((select max(b.n) from blockers b where b.card_id = c.id), 0) + 1,
+         'mario', c.title, 'nothing happens until he answers', 'board'
+  from cards c
+  where c.app = 'mario'
+    and c.state not in ('done', 'released', 'parked')
+    and not exists (
+      select 1 from blockers b where b.card_id = c.id and b.open and b.need = 'mario'
+    )
+  returning card_id
+)
+insert into history (card_id, what)
+select f.card_id, 'blocked (mario): ' || c.title
+from filed f join cards c on c.id = f.card_id;

--- a/server/board/supabase/migrations/20260905000300_mario_inbox.sql
+++ b/server/board/supabase/migrations/20260905000300_mario_inbox.sql
@@ -27,6 +27,13 @@ language plpgsql security definer set search_path = public as $$
 declare
   next_n integer;
 begin
+  -- A decision already taken is not one to ask again. Without this the two
+  -- halves of this file disagree: the backfill below skips settled cards, but
+  -- a board restored by INSERTing a dump would fire this trigger for every
+  -- settled decision it ever held, which is the flood the backfill avoids.
+  if new.state in ('done', 'released', 'parked') then
+    return null;
+  end if;
   if exists (select 1 from blockers where card_id = new.id and open and need = 'mario') then
     return null;
   end if;

--- a/tools_local/board/board.py
+++ b/tools_local/board/board.py
@@ -20,7 +20,8 @@ file store so the hooks never need the network.
     board dispatcher --name Dispatch --session <id>   the session Mario talks to; may message anyone
     board pulse [add <host> <GET|POST> <url> <alive> <app> | remove <host>]   what the board probes every 30 min
     board release                                     is the release watcher awake, and what is it owed
-    board new "<title>" --from <app> [--kind bug|feature|task] [--body "..."] [--parent <id>]
+    board new "<title>" --from <app> [--kind bug|feature|task] [--body "..."] [--parent <id>] [--default "..."]
+    board app <id> <app> [--default "..."]             move a card to another app
     board parent <id> --of <parent>                    put a card under another (subtasks)
     board bind <id> --session <sid> [--tree wt/x] [--branch app/x]
     board block <id> --session <sid> --need desk|design|info|mario --ask "..." --default "..."
@@ -37,6 +38,11 @@ file store so the hooks never need the network.
 Session ids are the ones the SessionStart hook prints; nothing else identifies
 a session from inside Bash, which is why every write that belongs to a session
 takes --session explicitly.
+
+A card on app `mario` is an inbox item by construction: filing one there, or
+moving one there, opens a `mario` blocker asking the card's title, because the
+inbox lists open `mario` blockers and Mario reads nothing else. --default says
+what happens if he never answers; without one it says so honestly.
 """
 
 import argparse
@@ -63,6 +69,13 @@ STATES = [
     "parked",
 ]
 NEEDS = ["desk", "design", "info", "mario", "device", "other"]
+
+# The app whose cards are Mario's own decisions, and what an auto-opened
+# blocker says happens when he never answers one. The wording is the honest
+# one on purpose: a blocker with no stated default forces him to engage before
+# he can safely ignore it, which is how an inbox turns into noise.
+MARIO_APP = "mario"
+MARIO_DEFAULT = "nothing happens until he answers"
 
 
 def now():
@@ -182,6 +195,13 @@ class FileStore:
     def save_card(self, c):
         c["updated"] = now()
         self._write(self.cards / f"{c['id']}.json", c)
+
+    def set_blocker_default(self, cid, n, default):
+        c = self.get_card(cid)
+        for b in c["blockers"]:
+            if b["n"] == n:
+                b["default"] = default
+        self.save_card(c)
 
     def list_cards(self):
         out = []
@@ -449,6 +469,14 @@ class SupaStore:
             prefer="return=minimal",
         )
 
+    def set_blocker_default(self, cid, n, default):
+        self._req(
+            "PATCH",
+            f"blockers?card_id=eq.{cid}&n=eq.{n}",
+            {"default": default},
+            prefer="return=minimal",
+        )
+
     def list_cards(self):
         rows = self._req("GET", f"cards?select={self.SELECT}&order=id.asc") or []
         return [self._to_card(r) for r in rows]
@@ -704,7 +732,8 @@ def cmd_new(st, a):
                 "history": [{"at": now(), "what": "created"}],
             }
         )
-    print(f"#{c['id']} {c['title']}")
+        inbox = ensure_inbox(st, c["id"], a.default, "board", adopt=True)
+    print(f"#{c['id']} {c['title']}" + ("  (in Mario's inbox)" if inbox else ""))
 
 
 def cmd_bind(st, a):
@@ -753,6 +782,50 @@ def _block(st, cid, need, ask, default, by, steps=None):
         hist(c, f"blocked ({need}): {ask}")
         st.save_card(c)
     return c, n
+
+
+def ensure_inbox(st, cid, default=None, by="board", adopt=False):
+    """A card on app `mario` is an item in Mario's inbox, by construction.
+
+    The inbox is the open `mario` blockers and nothing else, so a card filed on
+    the app that already means "only Mario decides this" was invisible to him
+    until someone remembered to block on it. Twice nobody did (cards 75 and 84
+    aged a day in `reported`), which is a dropped message, not a delay.
+
+    Idempotent on the only thing that matters -- whether an open `mario`
+    blocker is already there -- so re-running it, or moving a card to `mario`
+    twice, never files a second one.
+    """
+    c = st.get_card(cid)
+    if str(c.get("from", "")).lower() != MARIO_APP:
+        return False
+    want = (default or "").strip() or MARIO_DEFAULT
+    already = [b for b in c["blockers"] if b["open"] and b["need"] == "mario"]
+    if already:
+        # On the Supabase store the trigger opens this blocker inside the
+        # card's own INSERT or UPDATE, so the CLI arrives to find the work
+        # done and its --default dropped on the floor. `adopt` is the caller
+        # saying it knows none was open before it wrote, so the blocker it
+        # found is that one and the words it was given belong on it.
+        if adopt and (default or "").strip():
+            st.set_blocker_default(cid, already[-1]["n"], want)
+        return False
+    _block(st, cid, "mario", c["title"], want, by)
+    return True
+
+
+def cmd_app(st, a):
+    """Move a card to another app, and into Mario's inbox when the app is his."""
+    app = a.app.lower()
+    with st.lock():
+        c = st.get_card(a.id)
+        had = any(b["open"] and b["need"] == "mario" for b in c["blockers"])
+        if str(c.get("from", "")).lower() != app:
+            c["from"] = app
+            card_history(st, c, f"moved to app {app}")
+            st.save_card(c)
+        opened = ensure_inbox(st, c["id"], a.default, "board", adopt=not had)
+    print(f"#{c['id']} -> {app}" + ("  (in Mario's inbox)" if opened else ""))
 
 
 def cmd_block(st, a):
@@ -1039,6 +1112,7 @@ def cmd_import(st, a):
                     ],
                 }
             )
+            ensure_inbox(st, c["id"])
             made += 1
             print(f"#{c['id']} {c['title']}")
     print(f"board: imported {made} cards")
@@ -1118,6 +1192,7 @@ def cmd_issues(st, a):
                     ],
                 }
             )
+            ensure_inbox(st, c["id"])
             made += 1
             print(f"#{c['id']} <- issue #{i['number']} {c['title']}")
     closed = 0
@@ -1243,7 +1318,19 @@ def main(argv=None):
     s.add_argument("--from", dest="from_app", required=True)
     s.add_argument("--kind", choices=["bug", "feature", "task"], default="task")
     s.add_argument("--body")
+    s.add_argument(
+        "--default",
+        help="on app mario: what happens if he never answers (a card filed there opens a mario blocker by itself)",
+    )
     s.set_defaults(fn=cmd_new)
+    s = sub.add_parser("app", help="move a card to another app")
+    s.add_argument("id", type=int)
+    s.add_argument("app")
+    s.add_argument(
+        "--default",
+        help="on app mario: what happens if he never answers",
+    )
+    s.set_defaults(fn=cmd_app)
     s = sub.add_parser("bind")
     s.add_argument("id", type=int)
     s.add_argument("--session", required=True)

--- a/tools_local/board/board.py
+++ b/tools_local/board/board.py
@@ -76,6 +76,11 @@ NEEDS = ["desk", "design", "info", "mario", "device", "other"]
 # he can safely ignore it, which is how an inbox turns into noise.
 MARIO_APP = "mario"
 MARIO_DEFAULT = "nothing happens until he answers"
+# A decision already taken is not one to ask again. The rule and the backfill
+# in 20260905000300 both skip these, and they have to agree: a board restored
+# by INSERTing a dump would otherwise flood the inbox with every settled
+# decision it ever held, which is the flood the backfill was written to avoid.
+SETTLED = ("done", "released", "parked")
 
 
 def now():
@@ -384,9 +389,13 @@ class SupaStore:
                 prefer="return=minimal",
             )
         for b in fields.get("blockers", []):
+            # on_conflict + merge-duplicates, because on a card whose app is
+            # `mario` the insert trigger has already written blocker n=1 by the
+            # time this runs, and a plain POST is then a unique violation that
+            # aborts `board sync` mid-run. The caller's blocker wins.
             self._req(
                 "POST",
-                "blockers",
+                "blockers?on_conflict=card_id,n",
                 {
                     "card_id": c["id"],
                     "n": b["n"],
@@ -401,7 +410,7 @@ class SupaStore:
                     "answer_note": (b.get("answer") or {}).get("note"),
                     "answered_at": (b.get("answer") or {}).get("at"),
                 },
-                prefer="return=minimal",
+                prefer="resolution=merge-duplicates,return=minimal",
             )
         return self.get_card(c["id"])
 
@@ -725,14 +734,19 @@ def cmd_new(st, a):
         c = st.create_card(
             {
                 "title": a.title,
-                "from": a.from_app,
+                "from": a.from_app.lower(),
                 "kind": a.kind,
                 "body": a.body or "",
                 "parent": a.parent,
                 "history": [{"at": now(), "what": "created"}],
             }
         )
-        inbox = ensure_inbox(st, c["id"], a.default, "board", adopt=True)
+        ensure_inbox(st, c["id"], a.default, "board", adopt=True)
+        c = st.get_card(c["id"])
+    # The card's own state, not whether this call did the filing: on the
+    # Supabase store the trigger files inside the INSERT, and a marker keyed on
+    # "did I file it" would go silent exactly where the SQL enforcer works.
+    inbox = any(b["open"] and b["need"] == "mario" for b in c["blockers"])
     print(f"#{c['id']} {c['title']}" + ("  (in Mario's inbox)" if inbox else ""))
 
 
@@ -797,7 +811,7 @@ def ensure_inbox(st, cid, default=None, by="board", adopt=False):
     twice, never files a second one.
     """
     c = st.get_card(cid)
-    if str(c.get("from", "")).lower() != MARIO_APP:
+    if str(c.get("from", "")).lower() != MARIO_APP or c["state"] in SETTLED:
         return False
     want = (default or "").strip() or MARIO_DEFAULT
     already = [b for b in c["blockers"] if b["open"] and b["need"] == "mario"]
@@ -809,6 +823,7 @@ def ensure_inbox(st, cid, default=None, by="board", adopt=False):
         # found is that one and the words it was given belong on it.
         if adopt and (default or "").strip():
             st.set_blocker_default(cid, already[-1]["n"], want)
+            return True
         return False
     _block(st, cid, "mario", c["title"], want, by)
     return True
@@ -819,13 +834,42 @@ def cmd_app(st, a):
     app = a.app.lower()
     with st.lock():
         c = st.get_card(a.id)
+        was = str(c.get("from", "")).lower()
         had = any(b["open"] and b["need"] == "mario" for b in c["blockers"])
-        if str(c.get("from", "")).lower() != app:
+        moved = was != app
+        if moved:
             c["from"] = app
             card_history(st, c, f"moved to app {app}")
             st.save_card(c)
-        opened = ensure_inbox(st, c["id"], a.default, "board", adopt=not had)
-    print(f"#{c['id']} -> {app}" + ("  (in Mario's inbox)" if opened else ""))
+        # Only an actual move files, because only an actual move is something
+        # the SQL trigger can see (`old.app is distinct from new.app`). A CLI
+        # that also re-asked on a no-op would be a rule with two answers.
+        took = (
+            ensure_inbox(st, c["id"], a.default, "board", adopt=not had)
+            if moved
+            else False
+        )
+        c = st.get_card(c["id"])
+    ob = [b for b in c["blockers"] if b["open"] and b["need"] == "mario"]
+    print(f"#{c['id']} -> {app}" + ("  (in Mario's inbox)" if ob else ""))
+    # Say when the words the filer typed went nowhere. A --default silently
+    # dropped is the failure the default exists to prevent.
+    if (a.default or "").strip() and not took:
+        why = (
+            f"it already had an open mario blocker (#{ob[0]['n']})"
+            if ob and had
+            else f"it is {c['state']} on app {app}, so nothing was filed"
+        )
+        print(f"board: --default not applied to #{c['id']}: {why}")
+    # Moving a card off his desk does not withdraw what he was asked. Removing
+    # an item from his inbox without an answer is the dropped message this rule
+    # exists to prevent, so it is said out loud and left for a person.
+    if was == MARIO_APP and app != MARIO_APP and ob:
+        for b in ob:
+            print(
+                f"board: #{c['id']} is still in Mario's inbox on blocker #{b['n']}"
+                f" ({b['ask']}); answer it or: board unblock {c['id']} --n {b['n']}"
+            )
 
 
 def cmd_block(st, a):
@@ -860,9 +904,25 @@ def cmd_answer(st, a):
     with st.lock():
         c = st.get_card(a.id)
         target = None
-        for b in c["blockers"]:
-            if b["open"] and b["need"] == "mario":
-                target = b
+        if a.n is not None:
+            for b in c["blockers"]:
+                if b["open"] and b["n"] == a.n:
+                    target = b
+            if target is None:
+                sys.exit(f"board: #{c['id']} has no open blocker #{a.n}")
+        else:
+            # More than one open `mario` blocker used to answer the LAST one
+            # silently, so an answer typed against the first line of the inbox
+            # landed on a different question. Rare before this rule; routine
+            # once every card on app mario carries one of its own.
+            asks = [b for b in c["blockers"] if b["open"] and b["need"] == "mario"]
+            if len(asks) > 1:
+                sys.exit(
+                    f"board: #{c['id']} has {len(asks)} open blockers that need Mario; "
+                    "say which with --n: "
+                    + ", ".join(f"#{b['n']} {b['ask']}" for b in asks)
+                )
+            target = asks[0] if asks else None
         if target is None:
             for b in c["blockers"]:
                 if b["open"]:
@@ -1078,7 +1138,7 @@ def cmd_inbox(st, a):
                     for line in str(b["steps"]).splitlines():
                         if line.strip():
                             print(f"  How: {line.strip()}")
-                print(f"  Answer: board answer {c['id']} '<choice>'")
+                print(f"  Answer: board answer {c['id']} '<choice>' --n {b['n']}")
                 print()
     if not n:
         print("Nothing needs you.")
@@ -1362,6 +1422,9 @@ def main(argv=None):
     s = sub.add_parser("answer")
     s.add_argument("id", type=int)
     s.add_argument("choice")
+    s.add_argument(
+        "--n", type=int, help="which blocker; required when more than one needs Mario"
+    )
     s.add_argument("--note")
     s.set_defaults(fn=cmd_answer)
     s = sub.add_parser("state")


### PR DESCRIPTION
Card #209. Mario delegated the decision to the orchestrator, which approved it with one addition (the default); both are recorded as the answer on that card.

## The problem

Mario reads his inbox and nothing else. The inbox is the open `mario` blockers and nothing else, and **a card is not a blocker**. So a card filed on app `mario` -- which by convention already means "only Mario can decide this" -- reached him only if somebody also remembered to block on it. Twice nobody did: cards 75 and 84 were his decisions and aged a day in `reported` while his inbox said *nothing needs you*. That is a dropped message, not a delay.

## What this does

Filing a card on app `mario`, or moving one there, opens a `mario` blocker asking the card's title.

- **Idempotent** on the only thing that matters, an open `mario` blocker. A card that has one never gets a second, however many times it is moved or the rule re-runs.
- **It carries a default.** The orchestrator's addition: a blocker with no stated "what happens if you never answer" forces him to engage before he can safely ignore it, which is how an inbox becomes noise and stops being read. `board new --default '...'` and `board app <id> mario --default '...'` supply the real words; without them it says `nothing happens until he answers`, which is honest.
- **A settled card is left alone.** `done`, `released` and `parked` are decisions already taken, and asking again is how an inbox fills with noise.

Two enforcers, because the CLI is not the only writer of `cards` (the site's report function, the inbox page and a hand-typed `UPDATE` all reach the table directly):

| Where | What |
| --- | --- |
| `tools_local/board/board.py` | `ensure_inbox()` on every path that makes a card (`new`, `import`, the GitHub issue sweep) and on the new `board app <id> <app>` command, which is also the first way to retarget a card from the CLI at all. |
| `server/board/supabase/migrations/20260905000300_mario_inbox.sql` | after-insert and after-update-of-app triggers on `cards`, plus a backfill for cards dropped before the rule existed. |

## MIGRATION PENDING -- NOT APPLIED

`20260905000300_mario_inbox.sql` is written and tested but **not applied to the live board**. Another session is bulk-moving card states there, so applying it waits on the orchestrator. Until then the CLI enforces the rule on its own and no other writer does; `server/board/migrate.sh --list` says whether it is still pending, and `docs/workflow/README.md` says so too.

Its backfill is restricted to cards in open states. On the board as it stands **all 17 cards on app `mario` are `done`, so the backfill files nothing today**; it is there for a board restored from a dump.

## Watched red, both ways

- `host-tests/bugflow`: 9 of the first 11 checks fail with `board.py` reverted, and 9 more fail with the second commit's fixes reverted (including the smoking gun, `an ambiguous answer picked one silently: #16 answered: yes`).
- `host-tests/relwatch`: with the migration file removed the suite stops on the missing trigger by name; with only the settled-state guard removed, the two state checks go red.

## Second commit: what a cold review found

A critic briefed only on the spec and the diff, with no memory of writing it, found seven real bugs:

1. **`board sync` would have aborted mid-run the moment the migration landed.** It POSTs a card, then that card's own blockers with their stored numbers; on app `mario` the insert trigger has already written blocker `n=1`, and `unique (card_id, n)` made the second write a 23505 that `sys.exit`s. The blockers POST is now an upsert on `(card_id, n)`; the caller's blocker wins.
2. **A settled card was asked again.** The rule filed regardless of state while the backfill in the same file skipped `done/released/parked`. The two halves of one file disagreed, and a board restored by INSERTing a dump would have opened one blocker per settled decision it ever held. Both halves now skip settled cards.
3. **`--default` could vanish in silence** on a card already carrying a hand-written `mario` blocker. Overwriting that blocker's default would be worse, so it is not applied and the command says so.
4. **The `(in Mario's inbox)` marker never printed on the real board.** It was keyed on "did this call file it", and on Supabase the trigger files inside the INSERT, so the one visible sign the rule fired went silent exactly where the SQL enforcer does the work. It now reports the card's own state.
5. **`board answer` answered the wrong question.** With two open `mario` blockers it kept the last match, so an answer typed against the first inbox line landed on the other. Rare before this rule and routine after it, since every card on app `mario` now carries one of its own. `board answer` takes `--n`, refuses an ambiguous answer rather than guessing, and the inbox prints the `--n` in the command it hands him.
6. **`board new --from MARIO` stored a mixed-case app** that the case-sensitive SQL trigger would have missed, and that `triage_backlog.for_mario` and `board route` would both have read as a different app. Lowercased, as `board app` and `board import` already did.
7. **The two enforcers disagreed on a no-op.** `board app <id> mario` on a card already there re-asked an answered question; the trigger cannot, since it fires on `old.app is distinct from new.app`. Only an actual move files now.

Plus a test fix that matters more than it looks: two relwatch checks ran as bare `psql -c ... >/dev/null` under `set -uo pipefail` with no `-e`. An error there inserts no row, and the report counts only rows that landed, so a check that had stopped running would have printed "N passed, 0 failed" forever.

## Two things deliberately NOT done

- **Moving a card off app `mario` does not withdraw the blocker.** Taking an item out of his inbox with no answer is the dropped message this whole rule is about, and the auto blocker is indistinguishable in kind from one a person wrote. The move says what it leaves behind, names the blocker and prints the `board unblock` for it. A person decides.
- **The auto blocker records `by=board`, not a session.** `board app` has no `--session` and `board new` never had one, so the orchestrator cannot tell from the blocker which session needs the answer. Adding session plumbing to both is wider than this card.

## Tests

- **`host-tests/bugflow`** (the CLI, file store), 127 checks: filed there, moved there, moved there twice, a round trip through another app, a settled card opening nothing, a card on another app opening nothing, the filer's default winning, a `--default` that cannot be used saying so, two open `mario` blockers and `--n`, a move off `mario` naming what it leaves, `board import` on a `mario:` heading, and the lowercasing. Plus one pin: a worker may file on app `mario`. That is deliberate -- a worker already records `--need mario` blockers on its own card by the contract; the gate that stays shut is `board ask`, asserted a few lines above.
- **`host-tests/relwatch`** (the trigger, real postgres, real migrations), 78 checks: the same rules in SQL, that an *answered* card moved back asks again and the second blocker takes the next `n`, and the settled-state guard. The backfill is exercised by seeding two cards behind the trigger's back and re-applying the file.

## What I did NOT verify

- **The trigger has never run on the live board.** Everything SQL-side is proved on `postgres:16-alpine` against the real migrations, not against Supabase. RLS is not exercised (the suite connects as the owner, as the service key does), and neither is PostgREST's view of the new blocker rows.
- **No `SupaStore` path was exercised against a real Supabase.** `set_blocker_default()` is a one-line PATCH, and the blockers upsert (`on_conflict=card_id,n` with `resolution=merge-duplicates`) has no test that talks to PostgREST. The `adopt` handover between the CLI and the trigger is tested in each half separately, never end to end. So `board new --from mario --default '...'` on the live board is the least-verified path here, and `board sync` after the migration lands is the second.
- **`adopt` is not race-safe against a non-CLI writer.** `cmd_app` reads whether a `mario` blocker was open, then `ensure_inbox` adopts the one it finds. `st.lock()` on the Supabase store is the *local mirror* lock and does not serialise the site's writers, so a blocker opened by the inbox page inside that window would have its default overwritten. Low probability, unfixed.
- **The inbox page** (`site/inbox/`) was not opened. The `inbox` view is asserted in SQL; how the page renders a blocker whose `ask` is a card title, and whether its "Take the default" button reads well against `nothing happens until he answers`, is untested.
- **The device builds** are whatever CI says; nothing here can reach firmware.

---
Closes card #209 on the board.

Generated with [Claude Code](https://claude.com/claude-code)
