### PR TITLE
fix(instapaper): bound the two wire tokens where the index row is written

### DIFF
--- a/docs/apps/instapaper.md
+++ b/docs/apps/instapaper.md
@@ -111,3 +111,23 @@ the account was reconnected. Press SYNC and pair again.
   online, tells the service to forget this reader too.
 - The service: `server/read-bridge/` in this repo, and its design in
   [instapaper-plan.md](instapaper-plan.md).
+
+### The two token columns are the bridge's rule, not the device's
+
+`index.tsv` has two columns that are neither numbers nor free text: `hash` (
+Instapaper's own, relayed verbatim by the bridge) and `sha` (the bridge's
+`sha256(text).hexdigest()[:16]`). Both are **alphanumerics only, 32 at most**,
+and that bound is set on the service side: `UserStore.article_path` in
+`server/read-bridge/bridge/store.py` files every article under
+`"".join(c for c in hash if c.isalnum())[:32] + ".txt"`, so 32 alphanumerics
+is the key the bridge itself holds. Anything longer names no file at either
+end.
+
+The device applies that rule with `instapaper::sanitizeToken`, and applies it
+at **every write** -- the index row, and the `/api/article/<id>/<hash>` path
+the downloader builds -- rather than once where the sync response is parsed.
+The reason is what the old code did: the writer inherited the bound from the
+reader, put both raw strings through one `char[160]`, and a hash with a tab in
+it shifted every column after it. A short row is a corrupted row here, because
+this index *is* the sync protocol. If a column is ever added, bound it where
+it is written.

--- a/host-tests/instapaper/test_index.cpp
+++ b/host-tests/instapaper/test_index.cpp
@@ -179,6 +179,155 @@ void testProgressBounds() {
   CHECK(out[2].progress == 0.0f);
 }
 
+// ------------------------------------------- the two columns off the wire
+//
+// `hash` is Instapaper's and reaches this device verbatim through the bridge
+// (bridge/engine.py: str(e.get("hash") or "")); nothing between the two ends
+// caps its length or its characters. `sha` is the bridge's own
+// sha256(...).hexdigest()[:16]. The bound both are written under is not a
+// guess about what a well-behaved service sends: the bridge stores every
+// article at "".join(c for c in hash if c.isalnum())[:32] + ".txt"
+// (bridge/store.py), so 32 alphanumerics IS the key on the other side.
+//
+// These build their Articles by hand rather than through a sync, on purpose.
+// The point of the fix is that the row format is enforced by the function
+// that WRITES the row, not by whoever filled the struct in.
+
+// The failure a reader would actually meet. serializeIndex used to put the
+// whole row -- both tokens and every number -- through one char[160], and
+// snprintf truncates rather than overflows, so a long hash cut the row off
+// mid-column and the domain and title were appended onto the stump. What
+// came back was not "an article with a shortened hash". It was an article
+// that had lost its title, its reading position, and the ARCHIVE the reader
+// had already pressed: the row reappears in the queue, and nothing on screen
+// explains why.
+void testALongHashDoesNotUnarchiveAnArticle() {
+  instapaper::Article a = make(101, "A headline the reader would recognise");
+  a.hash = std::string(200, 'a');
+  a.progress = 0.5f;
+  a.progressAt = 1756100000;
+  a.archivePending = true;
+  a.renderable = false;
+
+  std::vector<instapaper::Article> read;
+  CHECK(instapaper::parseIndex(instapaper::serializeIndex({a}), read));
+  CHECK(read.size() == 1);
+  CHECK(read[0].id == 101);
+  CHECK_EQ(read[0].title, "A headline the reader would recognise");
+  CHECK_EQ(read[0].domain, "example.com");
+  CHECK(read[0].savedAt == 1000);
+  CHECK(read[0].words == 900 && read[0].minutes == 4);
+  CHECK(read[0].progressAt == 1756100000);
+  CHECK(read[0].progress > 0.499f && read[0].progress < 0.501f);
+  CHECK(read[0].archivePending);
+  CHECK(!read[0].renderable);
+  // And the one thing that IS lost is only the sync key, cut to exactly the
+  // form the bridge files the article under -- so the download URL built from
+  // it still names the bridge's own file.
+  CHECK(read[0].hash.size() == instapaper::kTokenLimit);
+  CHECK_EQ(read[0].hash, std::string(instapaper::kTokenLimit, 'a'));
+}
+
+// The sharper half, and not a length problem at all: a tab inside a token
+// spells a column boundary. One arriving in Instapaper's hash used to shift
+// every column after it by one, which parseIndex has no way to notice --
+// sanitising on the READ side cannot put back a separator the WRITE side
+// already emitted.
+void testASeparatorInsideATokenCannotShiftTheColumns() {
+  instapaper::Article a = make(102, "Still the right title");
+  a.hash = "aa\tbb";
+  a.sha = "cc\ndd\re";
+  a.savedAt = 4242;
+  a.progressAt = 99;
+
+  std::vector<instapaper::Article> read;
+  CHECK(instapaper::parseIndex(instapaper::serializeIndex({a}), read));
+  CHECK(read.size() == 1);
+  CHECK_EQ(read[0].hash, "aabb");
+  CHECK_EQ(read[0].sha, "ccdde");
+  CHECK(read[0].savedAt == 4242);
+  CHECK(read[0].words == 900 && read[0].minutes == 4);
+  CHECK(read[0].progressAt == 99);
+  CHECK_EQ(read[0].title, "Still the right title");
+  CHECK_EQ(read[0].domain, "example.com");
+}
+
+// A traversal in the hash never reaches the file, because the file never
+// holds it. The existing round-trip check passed while the raw "../../" sat
+// on the card and in the URL the downloader built from the in-memory copy;
+// this one reads the bytes.
+void testTheWrittenRowHoldsNoTraversal() {
+  instapaper::Article a = make(103, "x");
+  a.hash = "../../etc/passwd";
+  a.sha = "ab/cd";
+  const std::string text = instapaper::serializeIndex({a});
+  CHECK(text.find("..") == std::string::npos);
+  CHECK(text.find("/etc/") == std::string::npos);
+  CHECK(text.find("\t103\t") == std::string::npos);  // and the id column did not move
+  CHECK(text.find("\netcpasswd\t") == std::string::npos);
+}
+
+// The float column, which is bounded by the same rule the reader applies.
+// "%.4f" of an unclamped wire value spells forty characters, which is how a
+// progress of 1e30 could cut a row short all by itself.
+void testTheProgressColumnIsBoundedWhereItIsWritten() {
+  instapaper::Article big = make(104, "x");
+  big.progress = 1e30f;
+  instapaper::Article negative = make(105, "x");
+  negative.progress = -4.0f;
+  const std::string text = instapaper::serializeIndex({big, negative});
+  CHECK(text.find("\t1.0000\t") != std::string::npos);
+  CHECK(text.find("\t0.0000\t") != std::string::npos);
+  CHECK(text.find("e+") == std::string::npos);
+
+  std::vector<instapaper::Article> read;
+  CHECK(instapaper::parseIndex(text, read));
+  CHECK(read.size() == 2);
+  CHECK(read[0].progress == 1.0f);
+  CHECK(read[1].progress == 0.0f);
+}
+
+// The property that says writer and reader agree, and the cheapest guard
+// against the two drifting apart again: writing an index, reading it and
+// writing it again must produce the same bytes. It did not, and could not,
+// while the writer emitted a 200-character hash the reader cut to 32.
+void testWritingAnIndexTwiceProducesTheSameFile() {
+  instapaper::Article a = make(106, "Fixed point");
+  a.hash = std::string(90, 'Z');
+  a.sha = "sha-256-ish";
+  a.progress = 12345.0f;
+  a.progressDirty = true;
+  instapaper::Article b = make(107, "Second\trow", 7);
+  b.hash = "ok";
+  b.domain = "caf\xc3\xa9.example.com";
+
+  const std::string once = instapaper::serializeIndex({a, b});
+  std::vector<instapaper::Article> read;
+  CHECK(instapaper::parseIndex(once, read));
+  CHECK_EQ(instapaper::serializeIndex(read), once);
+}
+
+// What truncation must NOT reach. The title is the one column a reader looks
+// at, and it is free-form and last precisely so a fixed budget never has to
+// cut it. Sizing a buffer instead of bounding the tokens would have looked
+// like a fix and quietly capped headlines with no ellipsis to show for it --
+// the failure this fork has filed a shelf of cards about. So: the only
+// truncation in this file is the two protocol tokens, and it stops there.
+void testNoReadableColumnIsEverCut() {
+  const std::string longTitle(4000, 'w');
+  const std::string longDomain(600, 'd');
+  instapaper::Article a = make(108, longTitle.c_str());
+  a.domain = longDomain;
+  a.hash = std::string(64, 'f');
+
+  std::vector<instapaper::Article> read;
+  CHECK(instapaper::parseIndex(instapaper::serializeIndex({a}), read));
+  CHECK(read.size() == 1);
+  CHECK_EQ(read[0].title, longTitle);
+  CHECK_EQ(read[0].domain, longDomain);
+  CHECK(read[0].hash.size() == instapaper::kTokenLimit);
+}
+
 // ---------------------------------------------------------------- the merge
 void testMergeNewAndChanged() {
   std::vector<instapaper::Article> local = {make(101, "Known"), make(102, "Also known")};
@@ -417,6 +566,12 @@ int main() {
   testDamage();
   testSanitising();
   testProgressBounds();
+  testALongHashDoesNotUnarchiveAnArticle();
+  testASeparatorInsideATokenCannotShiftTheColumns();
+  testTheWrittenRowHoldsNoTraversal();
+  testTheProgressColumnIsBoundedWhereItIsWritten();
+  testWritingAnIndexTwiceProducesTheSameFile();
+  testNoReadableColumnIsEverCut();
   testMergeNewAndChanged();
   testMergeMetadataOnlyChangeDoesNotDownload();
   testMergeMissingFileIsDownloaded();

--- a/src/apps_local/instapaper/InstapaperIndex.cpp
+++ b/src/apps_local/instapaper/InstapaperIndex.cpp
@@ -34,25 +34,31 @@ uint32_t toUint(const std::string& text) { return static_cast<uint32_t>(std::str
 
 int64_t toInt64(const std::string& text) { return static_cast<int64_t>(std::strtoll(text.c_str(), nullptr, 10)); }
 
+// The one definition of what this column may hold. serializeIndex clamps with
+// it too, so a wire value of 1e30 is written as "1.0000" rather than as the
+// forty characters "%.4f" would otherwise spell -- and so serialising an
+// article, parsing it and serialising it again cannot change the file.
+float clampProgress(const float value) {
+  if (!(value > 0.0f)) return 0.0f;  // also catches NaN, which would poison every later comparison
+  return value > 1.0f ? 1.0f : value;
+}
+
 float toFloat(const std::string& text) {
   const double value = std::strtod(text.c_str(), nullptr);
-  if (!(value > 0.0)) return 0.0f;  // also catches NaN, which would poison every later comparison
+  if (!(value > 0.0)) return 0.0f;
   return value > 1.0 ? 1.0f : static_cast<float>(value);
 }
 
-// Hex only, and bounded. Both fields come off the wire and both end up in a
-// filename or a URL path, so a stray slash or dot is worth refusing here
-// rather than trusting three layers down.
-std::string sanitizeToken(std::string_view text, size_t limit) {
+}  // namespace
+
+std::string sanitizeToken(const std::string_view text) {
   std::string out;
   for (const char c : text) {
-    if (out.size() >= limit) break;
+    if (out.size() >= kTokenLimit) break;
     if ((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) out.push_back(c);
   }
   return out;
 }
-
-}  // namespace
 
 std::string sanitizeField(const std::string_view text) {
   std::string out;
@@ -86,11 +92,40 @@ std::string serializeIndex(const std::vector<Article>& articles) {
     if (a.renderable) flags |= kFlagRenderable;
     if (a.progressDirty) flags |= kFlagProgressDirty;
     if (a.archivePending) flags |= kFlagArchivePending;
-    char numbers[160];
-    std::snprintf(numbers, sizeof(numbers), "%lld\t%s\t%s\t%u\t%u\t%u\t%.4f\t%u\t%u\t", static_cast<long long>(a.id),
-                  a.hash.c_str(), a.sha.c_str(), a.savedAt, a.words, static_cast<unsigned>(a.minutes),
-                  static_cast<double>(a.progress), a.progressAt, flags);
-    out += numbers;
+    // No shared buffer for the row. It used to be one char[160] holding every
+    // numeric column AND both tokens, and snprintf does not overflow -- it
+    // truncates, which here is worse. A long `hash` did not corrupt memory; it
+    // cut the row off mid-number, so the tail (domain, title) was appended
+    // straight onto a half-written column and the next parse read the title
+    // out of the sha column, lost savedAt, progress and the flags, and with
+    // them the archive intent the reader had already pressed. A short row is a
+    // corrupted row because this index IS the sync protocol.
+    //
+    // Every column below is bounded where it is written: the integers by
+    // std::to_string, the float by clampProgress, the two tokens by
+    // sanitizeToken. Nothing here can be made too long by anything the service
+    // sends.
+    char progressText[16];
+    std::snprintf(progressText, sizeof(progressText), "%.4f", static_cast<double>(clampProgress(a.progress)));
+
+    out += std::to_string(static_cast<long long>(a.id));
+    out += '\t';
+    out += sanitizeToken(a.hash);
+    out += '\t';
+    out += sanitizeToken(a.sha);
+    out += '\t';
+    out += std::to_string(a.savedAt);
+    out += '\t';
+    out += std::to_string(a.words);
+    out += '\t';
+    out += std::to_string(static_cast<unsigned>(a.minutes));
+    out += '\t';
+    out += progressText;
+    out += '\t';
+    out += std::to_string(a.progressAt);
+    out += '\t';
+    out += std::to_string(flags);
+    out += '\t';
     out += sanitizeField(a.domain);
     out += '\t';
     // Title last: the only free-form column, so damage stops at the newline.
@@ -123,8 +158,8 @@ bool parseIndex(const std::string_view text, std::vector<Article>& out) {
     size_t cursor = 0;
     Article a;
     a.id = toInt64(field(row, cursor));
-    a.hash = sanitizeToken(field(row, cursor), 32);
-    a.sha = sanitizeToken(field(row, cursor), 32);
+    a.hash = sanitizeToken(field(row, cursor));
+    a.sha = sanitizeToken(field(row, cursor));
     a.savedAt = toUint(field(row, cursor));
     a.words = toUint(field(row, cursor));
     a.minutes = static_cast<uint16_t>(toUint(field(row, cursor)));

--- a/src/apps_local/instapaper/InstapaperIndex.h
+++ b/src/apps_local/instapaper/InstapaperIndex.h
@@ -102,6 +102,27 @@ bool parseIndex(std::string_view text, std::vector<Article>& out);
 // Strip anything that would break the row format, and collapse whitespace.
 std::string sanitizeField(std::string_view text);
 
+// The bound the two token columns are written under, and it is not a guess
+// about what Instapaper sends. The bridge stores every article at
+//   "".join(c for c in hash if c.isalnum())[:32] + ".txt"
+// (server/read-bridge/bridge/store.py, UserStore.article_path), so 32
+// alphanumerics IS the hash the service keeps; anything past that names no
+// file on either side of the link. `sha` is the bridge's own
+// sha256(...).hexdigest()[:16] and sits well inside it.
+inline constexpr size_t kTokenLimit = 32;
+
+// Instapaper's `hash` and the bridge's `sha`, cut to the form above.
+//
+// Called at every WRITE -- the index row here, the download URL in
+// InstapaperSync -- and not once at the point the Article was filled in.
+// Both strings arrive verbatim from a third party's JSON, and a guarantee
+// that lives in the function that RECEIVED them is a guarantee the next
+// caller of serializeIndex does not have. The writer is where the row format
+// is decided, so the writer is where the two free-form columns stop being
+// free-form. parseIndex applies it again on the way back for the index a
+// build without this rule already wrote.
+std::string sanitizeToken(std::string_view text);
+
 // "a1234.txt". The only place the filename is spelled.
 std::string articleFileName(int64_t id);
 

--- a/src/apps_local/instapaper/InstapaperSync.cpp
+++ b/src/apps_local/instapaper/InstapaperSync.cpp
@@ -4,8 +4,6 @@
 #include <Logging.h>
 #include <Utf8.h>
 
-#include <cstdio>
-
 #include "../bridge/BridgeHttp.h"
 
 namespace instapaper {
@@ -163,8 +161,26 @@ std::string Sync::syncStatus(const BridgeState& state, const std::string& jobId,
     Article& a = delivery.article;
     a.id = item["id"] | static_cast<int64_t>(0);
     if (a.id == 0) continue;
-    a.hash = item["hash"] | "";
-    a.sha = item["sha"] | "";
+    // Normalised here as well as at every write, and for a reason the write
+    // alone does not cover: the index on the card holds the sanitised form,
+    // so an Article kept raw in RAM would compare unequal to its own saved
+    // row and mergeSummary would queue a download for it on every single
+    // sync, forever, with nothing on screen to say why. Same rule, one
+    // definition -- InstapaperIndex.h.
+    const std::string rawHash = item["hash"] | "";
+    const std::string rawSha = item["sha"] | "";
+    a.hash = sanitizeToken(rawHash);
+    a.sha = sanitizeToken(rawSha);
+    if (a.hash != rawHash || a.sha != rawSha) {
+      // Not a crash and not a refusal: the article still syncs and still
+      // reads. But the bridge and this reader now disagree about its key, so
+      // it will be re-delivered every time, and that is the kind of slow
+      // waste nobody finds without a line saying it happened.
+      // ERR rather than INF because it is the only level that survives every
+      // LOG_LEVEL, and this one has to be findable a month later.
+      LOG_ERR("INSTASYNC", "article %lld sent a hash/sha this format cannot hold; cut to %u chars",
+              static_cast<long long>(a.id), static_cast<unsigned>(kTokenLimit));
+    }
     // Somebody else's headline, from somebody else's page: curly quotes, em
     // dashes and ellipses, none of which the reading cut can draw.
     a.title = utf8FoldTypography(item["title"] | "");
@@ -216,8 +232,14 @@ bool Sync::downloadToPart(const BridgeState& state, const Article& article, cons
     message = "The service did not say how big that article is.";
     return false;
   }
-  char path[96];
-  std::snprintf(path, sizeof(path), "/api/article/%lld/%s", static_cast<long long>(article.id), article.hash.c_str());
+  // The index writer's twin: this used to be a char[96] fed article.hash
+  // straight, so the same unbounded wire string that could cut a row short
+  // could also cut this path short and fetch a different article -- or spell
+  // "/api/article/7/../../etc/passwd", which only the bridge's own resolve
+  // check was stopping. Sanitised here rather than trusted from the Article,
+  // and built as a string so no length can be got wrong again.
+  const std::string path =
+      "/api/article/" + std::to_string(static_cast<long long>(article.id)) + "/" + sanitizeToken(article.hash);
   return bridge::streamToFile(kEndpoint, path, state.token, partPath, expectedBytes,
                               "An article did not arrive whole. Try syncing again.", cancel, message);
 }


### PR DESCRIPTION
Card #271.

## What was wrong

`serializeIndex` put `a.hash` and `a.sha` through one `char numbers[160]` along with every numeric column. Both come straight off a third party's JSON and neither is capped anywhere between Instapaper and that line.

**It was never memory corruption.** `snprintf` is bounded; it truncates. Here truncation is worse than a crash: the row was cut off mid-column and the domain and title were then appended onto the stump, so the next parse read the title out of the `sha` column and lost `savedAt`, `progress` and the flags. With the flags went the ARCHIVE the reader had already pressed. The row reappears in the queue and nothing on screen says why. This index *is* the sync protocol, so a short row is a corrupted row.

The sharper half is not about length at all: a tab inside `hash` spells a column boundary. One arriving from the service shifted every column after it, and sanitising on the read side cannot put back a separator the write side already emitted.

## The actual bound, from the service side

Not a guess about what a well-behaved Instapaper sends. `UserStore.article_path` (`server/read-bridge/bridge/store.py:71`) files every article under

```python
"".join(c for c in bookmark_hash if c.isalnum())[:32] + ".txt"
```

so **32 alphanumerics is the key the bridge itself holds**. Anything longer names no file at either end. `sha` is the bridge's own `sha256(text).hexdigest()[:16]` and sits well inside. The reader's cap of 32 was right all along; the writer was the only place in the chain not applying it.

## The fix

- `sanitizeToken` leaves the anonymous namespace and takes a named `kTokenLimit`, so writer and reader share one definition of the column instead of the writer inheriting one.
- `serializeIndex` drops the shared buffer entirely. Every column is bounded **where it is written**: integers by `std::to_string`, the float by `clampProgress`, the two tokens by `sanitizeToken`. Re-sizing the buffer would not have been the fix.
- `progress` was a second, independent way to blow the same row. `item["progress"] | 0.0f` is unclamped on ingest, and `%.4f` of `1e30` spells forty characters. Clamped at the write with the same rule `parseIndex` applies, which also makes serialise -> parse -> serialise produce identical bytes. It did not before.
- **The twin in the same app**: `Sync::downloadToPart` built `/api/article/%lld/%s` in a `char[96]` from the same raw hash. Only the bridge's own `is_relative_to` check stood between that and `/api/article/7/../../etc/passwd`. Sanitised at the write, built as a string.
- `Sync::syncStatus` normalises on ingest too. Not belt-and-braces: the card holds the sanitised form, so an Article kept raw in RAM compares unequal to its own saved row and `mergeSummary` queues a download for it on *every* sync, forever. Logs at ERR when it happens, since that waste is otherwise invisible.

## Tests

Six new, in `host-tests/instapaper/test_index.cpp`. Five go red with the writer reverted, 19 checks in total:

| test | what it catches |
|---|---|
| `testALongHashDoesNotUnarchiveAnArticle` | the user-facing failure: title, progress and the archive intent all lost |
| `testASeparatorInsideATokenCannotShiftTheColumns` | a tab in `hash` moving every column |
| `testTheWrittenRowHoldsNoTraversal` | reads the bytes on the card, not the round trip |
| `testTheProgressColumnIsBoundedWhereItIsWritten` | `1e30` blowing the row on its own |
| `testWritingAnIndexTwiceProducesTheSameFile` | writer and reader agreeing, as a property |

The sixth, `testNoReadableColumnIsEverCut`, is **green today on purpose**. A bounds guard fails silently, and the plausible wrong fix here is a bigger fixed buffer, which would have started cutting headlines with no ellipsis. That test fails against the wrong fix rather than against the old code, and a 4000-character title round-trips whole to prove truncation is confined to the two protocol tokens.

The pre-existing `testSanitising` passed the whole time with `../../etc/passwd` sitting raw on the card, because it asserted the round trip rather than the file.

## What I did NOT verify

- **No device, no hardware run.** Host suites only.
- **`Sync::syncStatus` and `downloadToPart` are not covered by any host test.** `InstapaperSync.cpp` needs ArduinoJson and the network stack, so it is outside the freestanding `host-tests/instapaper` build. The ingest normalisation, the ERR log and the rebuilt download URL are compile-checked by the device build and read by eye, nothing more. The index writer, which is the card, is fully covered.
- **Not reproduced against a real Instapaper account.** Real hashes are ~11 characters, so this stays latent in normal use; every test drives `serializeIndex` directly with a hand-built `Article`, which is the point (the guarantee must not depend on who filled the struct in).
- **The `%.4f` clamp changes what gets written for an out-of-range progress.** Existing indices are unaffected (the reader already clamped), but I have not diffed a real `index.tsv` before and after.
- The stale-browser-artifact warning from `check.sh` is pre-existing on this branch and unrelated.

## Twin check

A repo-wide sweep for the same shape (fixed buffer fed a string the app does not control). **Not fixed here** - reported so it can be triaged:

**Closest analogues, in the study bridge family as cards #112/#219 predicted:**
- `StudySync.cpp:286/299` - `char deckDirs[N][48]` takes the server's deck slug and is the *key* of the persisted `/study/.bridge` store. A slug >= 48 bytes truncates, every later `strcmp` misses, `setAck` appends a new slot each sync until it silently drops acks. Reviews re-sent forever. `StudySync.h:60` even records that the buffer was widened 32 -> 48 the last time this bit, which is the pattern this PR reverses.
- `StudySync.cpp:316` - `char lastBuilds[N][20]` takes the server's `buildId` and is compared full-string at `StudyActivity.cpp:2146`. Truncation means every deck re-downloads; a 19-char prefix collision means a stale deck reads as current.
- `StudyActivity.cpp:2138` - server slug into `char dir[96]`, which becomes `mkdir` and the parent of every downloaded file, while `setBuild` records the untruncated slug. The two disagree permanently.

Those three are bounded today only by `decks.py:36-40` (`slug <= 42`) and a 10-digit `build_id` - a server-side convention the firmware does not enforce. Exactly the shape fixed here.

**Elsewhere:**
- `SettingsList.h:89` - an SD font folder name >31 chars truncates into `sdFontFamilyName[32]`, the read at `:73` is a full-equality compare, so it never matches and the user's chosen font silently reverts on the next boot. Reachable with nothing but a long folder name.
- `SettingsList.h:162/174` - the same asymmetry as this card, resolved the *wrong* way: the write truncates the dictionary name to 31 and the read was capped to a 31-byte prefix compare to match. Two dictionaries sharing a 31-char prefix are now indistinguishable and `Dictionary::open` takes whichever sorts first. Its neighbour `sdFontFamilyName` has the identical buffer and fails closed instead.
- `OpdsServerListActivity.cpp:187` - `normalizeFolder` prepends `/`, so a 63-char entry becomes 64 and loses its last character in a `char[64]`.
- `CrossPointWebServer.cpp:1377` - HTTP POST body into the SETTINGS struct, truncated then persisted. LAN + dev mode only.
- Display-only, damage stops at the screen: `InstapaperActivity.cpp:904` (`char subtitle[64]` fed the wire `domain` - a long hostname cuts mid-word with no ellipsis), `KOReaderSyncActivity.cpp:471`, `StudyActivity.cpp:2442/2445`, `ParsedText.cpp:1574`.

Checked and **clean by construction**: `HackerNewsSaved.cpp` `serializeSavedIndex` (pure `std::string` append - already the shape this PR moves Instapaper to), `RecentBooksStore`, `OpdsServerStore`, `WifiCredentialStore`, the trivia and connections network apps (every fixed buffer takes integers and literals; `ConnectionsImport` drops an oversized puzzle rather than truncating it), `ProgressMapper.cpp:177` and `Dictionary::buildPath` (both *reject* rather than truncate, which is the right shape), `ShelfState`, `LinkSession`, `ScreenshotUtil`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)