### PR TITLE
ci: a merge on xteink gets its own concurrency group, so no run is dropped

### DIFF
--- a/.github/workflows/crossplay-autorelease.yml
+++ b/.github/workflows/crossplay-autorelease.yml
@@ -64,6 +64,14 @@ jobs:
         env:
           VERIFIED: ${{ github.event.workflow_run.head_sha }}
           HOLD: ${{ vars.RELEASE_HOLD }}
+          # Both taken from the event rather than written down, because both
+          # are things that live in another file. The workflow ID is a number
+          # GitHub assigns; it survives renaming "CrossPlay", which the name in
+          # `workflows:` above does not. The branch is whatever ran, and the
+          # job's own `if:` has already established it is xteink.
+          CI_WORKFLOW_ID: ${{ github.event.workflow_run.workflow_id }}
+          CI_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "$HOLD" = "1" ]; then
             echo "RELEASE_HOLD is set: not releasing. Clear the repository variable to resume."
@@ -123,10 +131,89 @@ jobs:
             bash scripts_local/device-build-needed.sh --range "$VERIFIED..$tip" --ships; gap_ships=$?
             set -e
             if [ "$gap_builds" -ne 1 ] || [ "$gap_ships" -ne 1 ]; then
-              echo "xteink moved past the commit CI verified ($VERIFIED -> $tip) by something a device build or a release can see (builds=$gap_builds, ships=$gap_ships); the run for the new tip releases it."
-              echo "go=false" >> "$GITHUB_OUTPUT"; exit 0
+              # The gap carries something CI's verdict on $VERIFIED does not
+              # cover. That is a reason to refuse only if nothing ELSE verified
+              # the tip, and until 2026-09-05 this line ended "the run for the
+              # new tip releases it" and stopped there.
+              #
+              # That sentence was an assumption about GitHub's concurrency, not
+              # a fact. A concurrency group holds one run in progress and one
+              # run pending, and a third arrival cancels the pending one --
+              # `cancel-in-progress: false` does not govern that half. So the
+              # run for the new tip is a run that may never exist. It happened
+              # to 41 runs of crossplay-ci.yml in 36 hours (see the concurrency
+              # comment there, now fixed), and the same shape reaches this
+              # workflow through its own `crossplay-release` group, which is
+              # kept deliberately: two publishers at once built v1.12.16 twice.
+              #
+              # So ask the question the gate actually means. Not "is the tip the
+              # commit that triggered me", which depends on which run survived,
+              # but "did anything green verify the tip" -- one query, about the
+              # same workflow that triggered this run, on the tip's own sha.
+              # A tip with its own successful run is verified by definition;
+              # releasing it is what the gate exists to allow.
+              #
+              # WHICH COMMIT TO ASK ABOUT IS NOT THE TIP. crossplay-ci.yml
+              # carries `paths-ignore: site/emulator/**` and
+              # `site/emulator-manifest.json`, so the rebuild crossplay-emulator.yml
+              # pushes after every merge gets NO run and never will -- and after
+              # most merges that rebuild IS the tip. Asking about the tip would
+              # therefore answer 0 forever for the commonest shape on this branch,
+              # and the rescue below would never fire for it.
+              #
+              # So walk back over commits nothing can see first, using the same
+              # table, and ask about the commit the walk stops on. Everything
+              # between it and the tip is invisible to a device build and to a
+              # release by construction, so a green verdict there is a green
+              # verdict on the tip. The walk stops at the first commit that is
+              # NOT invisible, which is any real merge, so it is one or two steps
+              # in practice; the cap is there because an unbounded walk over a
+              # long run of docs commits is a loop in a publisher.
+              probe="$tip"
+              for _ in 1 2 3 4 5 6 7 8 9 10; do
+                parent="$(git rev-parse -q --verify "$probe^" 2>/dev/null)" || break
+                [ -n "$parent" ] || break
+                set +e
+                bash scripts_local/device-build-needed.sh --range "$parent..$probe" >/dev/null 2>&1; step_builds=$?
+                bash scripts_local/device-build-needed.sh --range "$parent..$probe" --ships >/dev/null 2>&1; step_ships=$?
+                set -e
+                [ "$step_builds" -eq 1 ] && [ "$step_ships" -eq 1 ] || break
+                probe="$parent"
+              done
+              [ "$probe" = "$tip" ] || echo "$tip is $probe plus only commits no device build and no release can see; asking about $probe."
+
+              # FAIL CLOSED. Anything but a number, including a query that
+              # errors, a token without actions:read and an empty workflow id,
+              # refuses exactly as before. The failure mode of this check is
+              # silence, so it must not be able to answer "yes" by accident.
+              green=""
+              if [ -n "$CI_WORKFLOW_ID" ]; then
+                # `| tail -1`, because a warning on stdout or stderr in front of
+                # the count would make an otherwise good answer non-numeric and
+                # refuse a release for nothing. `|| true` on the pipeline keeps
+                # a failed query's own words as the value, which is the only
+                # diagnostic the log will get.
+                green="$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$CI_WORKFLOW_ID/runs?head_sha=$probe&branch=$CI_BRANCH&status=success&per_page=1" --jq '.total_count' 2>&1 | tail -1)" || true
+              fi
+              case "$green" in
+                ''|*[!0-9]*)
+                  echo "xteink moved past the commit CI verified ($VERIFIED -> $tip) by something a device build or a release can see (builds=$gap_builds, ships=$gap_ships), and GitHub could not be asked whether $probe has a run of its own (answer: '${green:-<none>}'). Not releasing."
+                  echo "go=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
+                0)
+                  echo "xteink moved past the commit CI verified ($VERIFIED -> $tip) by something a device build or a release can see (builds=$gap_builds, ships=$gap_ships), and nothing green has verified $probe either. Not releasing."
+                  echo "go=false" >> "$GITHUB_OUTPUT"; exit 0 ;;
+                *)
+                  echo "xteink moved past $VERIFIED by something a build or a release can see, but $probe has $green successful run(s) of its own and nothing since it is visible; releasing the tip." ;;
+              esac
+            else
+              # `else`, not a line after the `fi`. Written as a trailing echo it
+              # ran on BOTH paths, so a tip released on its own green run said
+              # "moved only by commits no device build and no release can see"
+              # immediately after saying the opposite. Two contradictory
+              # sentences in one log, and the one that is wrong is the one that
+              # reads like the explanation.
+              echo "xteink moved past $VERIFIED only by commits no device build and no release can see; releasing from $tip."
             fi
-            echo "xteink moved past $VERIFIED only by commits no device build and no release can see; releasing from $tip."
           fi
           # A merge nobody can receive anything different from (docs, site,
           # tooling, the workspace's own machinery) is not a release: no bump,

--- a/.github/workflows/crossplay-ci.yml
+++ b/.github/workflows/crossplay-ci.yml
@@ -67,12 +67,38 @@ permissions:
 # RELEASE_HOLD was 0 and nobody was holding anything. Every individual
 # cancellation looked exactly like this rule working correctly.
 #
-# So pull requests still supersede, and xteink queues. crossplay-emulator.yml
-# already does the second thing (cancel-in-progress: false), which is why its
-# run for 2b9f3a84 finished while this workflow's run for the same commit was
-# cancelled -- the same merge, the two rules, two outcomes.
+# QUEUEING DID NOT FIX IT, and `cancel-in-progress: false` is not what anyone
+# reads it as. A concurrency group holds at most ONE run in progress and ONE
+# run pending. cancel-in-progress governs the first of those two. Nothing
+# governs the second: when a third run arrives, GitHub cancels whatever was
+# pending to make room for it, and it does so whether cancel-in-progress is
+# true or false. So a stream of merges still loses runs, silently, one per
+# merge that lands while a build is running and another is waiting.
+#
+# MEASURED, on 2026-09-05, over the 36 hours after `cancel-in-progress:
+# ${{ github.ref != 'refs/heads/xteink' }}` landed in 52d0907f: 41 runs of this
+# workflow on xteink were cancelled, and `actions/runs/<id>/jobs` returns
+# total_count 0 for all 41 of them. Not one had started a job. They were killed
+# while pending, by the next merge, exactly as they were before -- and the
+# merges they belonged to therefore reached no conclusion, so
+# crossplay-autorelease.yml never fired for any of them.
+#
+# So the group has to be one a merge cannot share. On xteink it is the COMMIT:
+# two merges are never in one group, nothing ever pends behind anything, and
+# GitHub has nothing to cancel. Runs are then parallel rather than queued,
+# which costs runner minutes (this repository is public, so they are free) and
+# nothing else -- this workflow takes `permissions: contents: read` and writes
+# nothing that another run of it could race.
+#
+# Pull requests keep the branch group and keep superseding: a push there really
+# does replace the commit before it, and no release listens to that ref.
+#
+# Folding several merges into one release still happens, and this is where it
+# belongs: each merge now gets its own verdict, and crossplay-autorelease.yml
+# collapses whatever has landed since the newest tag into a single release. It
+# was never CI's job to do that by throwing builds away.
 concurrency:
-  group: crossplay-ci-${{ github.ref }}
+  group: crossplay-ci-${{ github.ref == 'refs/heads/xteink' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/xteink' }}
 
 jobs:

--- a/.github/workflows/crossplay-emulator.yml
+++ b/.github/workflows/crossplay-emulator.yml
@@ -17,10 +17,18 @@
 # deployment keeps serving rather than a broken one replacing it.
 # tools_local/site/publish_emulator.py owns both halves and explains the shape.
 #
-# The commit is still called "chore: emulator rebuilt for <sha>". Do not
-# reword that: crossplay-autorelease.yml matches the subject to tell an
-# emulator rebuild from a real merge that moved the tip past what CI verified,
-# and a rename there silently stops every release.
+# The commit is still called "chore: emulator rebuilt for <sha>", and what
+# depends on that string has MOVED. It used to be the release gate:
+# crossplay-autorelease.yml told an emulator rebuild from a real merge by
+# grepping this subject, so a rename there stopped every release silently.
+# Card #242 replaced that with the classification table
+# (scripts_local/device-build-needed.sh), which reads paths, so the gate no
+# longer cares what this commit calls itself.
+#
+# One thing still does: scripts_local/release_notes.py drops a subject starting
+# "chore: emulator rebuilt" from the release page. Rename this and every
+# release page grows a line no player can act on. That is a cosmetic failure
+# rather than a silent stall, which is the whole difference card #242 bought.
 #
 # The commit is pushed with the workflow's own token, so it starts no CI run
 # of its own: it changes nothing a device build sees, and the next real merge's

--- a/host-tests/ci/run.sh
+++ b/host-tests/ci/run.sh
@@ -148,6 +148,161 @@ case "$cip" in
     ;;
 esac
 
+# -- and the OTHER half of the concurrency rule, the one nothing governs -----
+#
+# `cancel-in-progress: false` reads like "no run of this group is ever
+# cancelled". It is not what it does. A group holds at most ONE run in progress
+# and ONE run pending; cancel-in-progress decides the fate of the first. The
+# second is cancelled whenever a third run arrives, either way. So the check
+# above -- cancellation must be conditional on the ref -- was satisfied by a
+# workflow that still lost a run per merge.
+#
+# MEASURED before this was written: in the 36 hours after 52d0907f made
+# cancellation conditional, 41 runs of this workflow on xteink were cancelled
+# and `actions/runs/<id>/jobs` returned total_count 0 for every one of them.
+# None had started a job. Each was a merge whose CI reached no conclusion, and
+# crossplay-autorelease.yml only fires on a run that reached success.
+#
+# The property that makes that impossible is not a setting, it is the GROUP:
+# two commits on xteink must land in groups that cannot contend. So this
+# EVALUATES the expression -- the operators GitHub's own expression syntax uses,
+# over a context this supplies -- rather than reading it. A group asserted by
+# grep would pass on `crossplay-ci-${{ github.ref }}`, which is the bug.
+#
+# And it asserts the pull-request half in the same breath, because the cheap way
+# to make merges unique is to make EVERY run unique, and that silently ends
+# superseding on branches -- five runs of one branch sharing the runners, which
+# is what the group was added for in the first place.
+conc_eval() {  # <workflow.yml> <group|cancel-in-progress> <github.ref> <github.sha>
+  python3 - "$1" "$2" "$3" "$4" <<'PY'
+import re, sys
+
+yml, key, ref, sha = sys.argv[1:5]
+raw, inblock = None, False
+for line in open(yml).read().splitlines():
+    if line.rstrip() == 'concurrency:':
+        inblock = True
+        continue
+    if inblock:
+        if line.strip() and line[:1] not in (' ', '\t'):
+            break
+        m = re.match(r'\s+' + re.escape(key) + r':\s*(.*)$', line)
+        if m:
+            raw = m.group(1).strip()
+            break
+if raw is None:
+    print('NO-' + key.upper())
+    raise SystemExit(0)
+if len(raw) > 1 and raw[0] == raw[-1] and raw[0] in '"\'':
+    raw = raw[1:-1]
+
+ctx = {'github.ref': ref, 'github.sha': sha}
+
+
+def operand(tok):
+    tok = tok.strip()
+    if len(tok) > 1 and tok[0] == tok[-1] and tok[0] in '"\'':
+        return tok[1:-1]
+    if tok in ('true', 'false'):
+        return tok == 'true'
+    if tok in ctx:
+        return ctx[tok]
+    print('UNEVALUABLE ' + tok)
+    raise SystemExit(0)
+
+
+def truthy(v):
+    return v not in ('', False, 0, None)
+
+
+def compare(part):
+    for op in ('==', '!='):
+        if op in part:
+            a, b = part.split(op, 1)
+            same = operand(a) == operand(b)
+            return same if op == '==' else not same
+    return operand(part)
+
+
+def evaluate(expr):
+    # GitHub's precedence: && binds tighter than ||, and both return the
+    # OPERAND rather than a boolean, which is the whole trick behind
+    # `cond && a || b`.
+    last = None
+    for alt in expr.split('||'):
+        val = None
+        for conj in alt.split('&&'):
+            v = compare(conj)
+            val = v if val is None else (v if truthy(val) else val)
+        if truthy(val):
+            return val
+        last = val
+    return last
+
+
+def render(v):
+    return 'true' if v is True else ('false' if v is False else str(v))
+
+
+print(re.sub(r'\$\{\{(.*?)\}\}', lambda m: render(evaluate(m.group(1))), raw))
+PY
+}
+
+XTEINK=refs/heads/xteink
+PR=refs/pull/7/merge
+
+# Two merges. Different commits, and they must not be able to queue behind one
+# another, because a queue of two is a queue GitHub trims from the middle.
+merge_a="$(conc_eval "$YML" group "$XTEINK" 1111111111111111111111111111111111111111)"
+merge_b="$(conc_eval "$YML" group "$XTEINK" 2222222222222222222222222222222222222222)"
+checks=$((checks + 1))
+if [ "$merge_a" = "$merge_b" ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci  two different commits on xteink evaluate to ONE concurrency group ('$merge_a'), so the second pends behind the first and the third cancels it -- 41 runs died that way in the 36 hours before this test existed, none of which ever started a job"
+fi
+# One branch, two pushes. Superseding is still right here and must survive.
+pr_a="$(conc_eval "$YML" group "$PR" 1111111111111111111111111111111111111111)"
+pr_b="$(conc_eval "$YML" group "$PR" 2222222222222222222222222222222222222222)"
+
+# The guard has to cover EVERY value this compares, not just the first one.
+# Written over $merge_a alone it left the pull-request assertion below
+# satisfied by empty == empty: an expression the reader cannot evaluate (a
+# `format()` call, a context it does not know) produces nothing on both sides,
+# they match, and "a push still supersedes" passes having measured nothing.
+readable() {  # <label> <value>
+  checks=$((checks + 1))
+  case "$2" in
+    NO-GROUP|NO-CANCEL-IN-PROGRESS|UNEVALUABLE*|'')
+      failed=$((failed + 1))
+      echo "FAIL ci  crossplay-ci.yml's concurrency $1 could not be evaluated ('$2'), so every check that compares it asserted nothing"
+      ;;
+  esac
+}
+readable "group on xteink"        "$merge_a"
+readable "group on a pull request" "$pr_a"
+checks=$((checks + 1))
+if [ "$pr_a" != "$pr_b" ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci  two pushes to one pull request evaluate to different concurrency groups ('$pr_a' vs '$pr_b'), so a push no longer supersedes the run it replaced and every commit of a branch holds a runner"
+fi
+
+# The same two refs, through the cancellation setting, so the pair is asserted
+# as a pair: unique group + no cancellation on xteink, shared group +
+# cancellation on a branch. Either half alone is satisfied by a broken
+# arrangement.
+cancel_xteink="$(conc_eval "$YML" cancel-in-progress "$XTEINK" 1111111111111111111111111111111111111111)"
+cancel_pr="$(conc_eval "$YML" cancel-in-progress "$PR" 1111111111111111111111111111111111111111)"
+checks=$((checks + 1))
+if [ "$cancel_xteink" != "false" ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci  crossplay-ci.yml evaluates cancel-in-progress to '$cancel_xteink' on xteink; a merge would kill the previous merge's build outright"
+fi
+checks=$((checks + 1))
+if [ "$cancel_pr" != "true" ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci  crossplay-ci.yml evaluates cancel-in-progress to '$cancel_pr' on a pull request ref; superseding is off and five runs of one branch share the runners"
+fi
+
 # The release is built once per tag. host-tests/release asserts the SHAPE
 # (the dispatch is conditional on RELEASE_TOKEN, and crossplay-release.yml
 # keeps its tag trigger); this runs the step's own text, lifted from the
@@ -242,10 +397,29 @@ gate_commit() {  # <repo> <path> <subject>
   mkdir -p "$(dirname "$1/$2")"; echo "$(date +%s%N)" >>"$1/$2"
   ( cd "$1" && git add -A && git commit -qm "$3" ) >/dev/null 2>&1
 }
-gate_expect() {  # <label> <repo> <VERIFIED> <true|false wanted go> <substring wanted in the log>
-  local label="$1" repo="$2" verified="$3" want="$4" msg="$5" got
-  : >"$WORK/gh_output"
+# The gate asks GitHub one question -- does the TIP have a successful run of
+# the CI workflow -- so every case here answers it with a fake `gh` on PATH,
+# which also records the call. The DEFAULT answer is 0, meaning nothing green
+# has seen the tip, so the eight cases below keep measuring the tip check alone.
+# FAKE_GREEN=error makes the query fail, which is the fail-closed path.
+mkdir -p "$WORK/gatebin"
+cat >"$WORK/gatebin/gh" <<'FAKEGH'
+#!/bin/sh
+echo "gh $*" >>"$FAKE_GH_CALLS"
+if [ "$FAKE_GREEN" = "error" ]; then
+  echo "HTTP 403: Resource not accessible by integration"
+  exit 1
+fi
+echo "${FAKE_GREEN:-0}"
+FAKEGH
+chmod +x "$WORK/gatebin/gh"
+
+gate_expect() {  # <label> <repo> <VERIFIED> <true|false wanted go> <substring wanted in the log> [green]
+  local label="$1" repo="$2" verified="$3" want="$4" msg="$5" green="${6:-0}" got
+  : >"$WORK/gh_output"; : >"$WORK/gate.gh.calls"
   ( cd "$repo" && GITHUB_OUTPUT="$WORK/gh_output" VERIFIED="$verified" HOLD="" \
+      PATH="$WORK/gatebin:$PATH" FAKE_GREEN="$green" FAKE_GH_CALLS="$WORK/gate.gh.calls" \
+      GITHUB_REPOSITORY="ma-r-s/crossplay" CI_WORKFLOW_ID="${GATE_WORKFLOW_ID-4242}" CI_BRANCH=xteink \
       bash -eo pipefail "$WORK/gate.sh" ) >"$WORK/out" 2>&1
   got="$(grep -o 'go=[a-z]*' "$WORK/gh_output" | tail -1 | cut -d= -f2)"
   checks=$((checks + 1))
@@ -328,6 +502,151 @@ SIDE="$(git -C "$G" rev-parse HEAD)"
 gate_commit "$G" site/emulator/crossplay.wasm "chore: emulator rebuilt for $V"
 gate_expect "a verified commit outside the tip's history refuses" "$G" "$SIDE" false \
   "is not in the history of"
+
+# -- and the case the eight above cannot reach: the run for the new tip -------
+#
+# Cases 3, 4, 6 and 7 all refuse for the same stated reason: "the run for the
+# new tip releases it". That was a claim about GitHub's concurrency, and it was
+# false. A concurrency group holds one run in progress and one run pending, and
+# a third arrival cancels the pending one -- `cancel-in-progress: false` governs
+# the first half only. crossplay-ci.yml lost 41 runs to exactly that in 36
+# hours, and this workflow's own `crossplay-release` group can lose an
+# autorelease the same way. That group is KEPT, deliberately: two publishers at
+# once built v1.12.16 twice. What changes is that the survivor no longer needs
+# to be the one for the tip.
+#
+# So the gate stopped asking "am I the run for the tip" and started asking "has
+# anything green verified the tip". Four cases, and the last two matter most:
+# the failure mode of a check like this is silence, and silence must refuse.
+#
+# (9) The tip moved by firmware, and the tip has its own successful CI run.
+#     This is the release that used to be lost, every time the autorelease that
+#     would have cut it was the one GitHub trimmed out of the queue.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" src/apps_local/Sudoku.cpp "fix(sudoku): the givens survive a rotate"
+gate_expect "a moved tip that has its OWN green run releases" "$G" "$V" true \
+  "successful run(s) of its own" 1
+
+# And it must not ALSO claim the gap was inert. The reason lives one line below
+# the branch it belongs to, and written as a trailing echo it ran on both paths:
+# the log said the tip had a green run of its own and then, in the next
+# sentence, that nothing in the gap could reach a device. Both cannot be true,
+# the second is the one that reads like the explanation, and `gate_expect` alone
+# never sees it because it only asks whether the sentence it wants is present.
+checks=$((checks + 1))
+if grep -q "only by commits no device build" "$WORK/out"; then
+  failed=$((failed + 1))
+  echo "FAIL ci-autorelease  the gate released a tip on its own green run and then told the log the gap was inert; the two sentences contradict each other and the wrong one is the one that looks like the reason"
+  sed 's/^/       /' "$WORK/out"
+fi
+
+# The query has to be about the tip. A copy of this line asking about $VERIFIED
+# would answer yes on every run that triggered it, which is the same as deleting
+# the gate -- and every case above would still pass.
+TIP="$(git -C "$G" rev-parse HEAD)"
+checks=$((checks + 1))
+if ! grep -q "head_sha=$TIP" "$WORK/gate.gh.calls"; then
+  failed=$((failed + 1))
+  echo "FAIL ci-autorelease  the gate asked GitHub about something other than the tip ($TIP); it must ask whether the TIP is verified, not whether the commit that triggered it is"
+  sed 's/^/       /' "$WORK/gate.gh.calls"
+fi
+
+# And about the right RUNS. The fake gh answers whatever it is told to answer
+# and ignores the URL, so every case above passes on a query missing any filter
+# -- which is not a hypothetical: against the real repository, sha f5115b01
+# (a run cancelled while pending) answers total_count 0 with `status=success`
+# and total_count 1 without it. Dropping that one parameter releases from a
+# commit whose CI never ran, which is the failure this whole change exists to
+# stop. `branch` is asserted for the same reason one step weaker: a run on
+# another ref is not a verdict on this one.
+for want in "status=success" "branch=xteink"; do
+  checks=$((checks + 1))
+  if ! grep -q "$want" "$WORK/gate.gh.calls"; then
+    failed=$((failed + 1))
+    echo "FAIL ci-autorelease  the gate's query does not carry '$want', so it counts runs that are not a green verdict on this branch"
+    sed 's/^/       /' "$WORK/gate.gh.calls"
+  fi
+done
+
+# (10) The same tip, with no green run of its own. The protection, unchanged.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" src/apps_local/Sudoku.cpp "fix(sudoku): the givens survive a rotate"
+gate_expect "a moved tip nothing has verified still refuses" "$G" "$V" false \
+  "nothing green has verified" 0
+
+# (11) The query itself fails -- no actions:read, a rate limit, GitHub down.
+#      An answer that is not a number is not a yes.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" src/apps_local/Sudoku.cpp "fix(sudoku): the givens survive a rotate"
+gate_expect "a query that fails refuses rather than assuming" "$G" "$V" false \
+  "could not be asked" error
+
+# (12) No workflow id in the event at all. The gate must not ask GitHub about
+#      `workflows//runs`, and must not read whatever that returns as a yes.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" src/apps_local/Sudoku.cpp "fix(sudoku): the givens survive a rotate"
+GATE_WORKFLOW_ID="" gate_expect "an empty workflow id refuses" "$G" "$V" false \
+  "could not be asked" 1
+checks=$((checks + 1))
+if [ -s "$WORK/gate.gh.calls" ]; then
+  failed=$((failed + 1))
+  echo "FAIL ci-autorelease  the gate called gh with no workflow id in the event; the URL names no workflow, GitHub answers 404, and the only thing standing between that and a released tip is that a 404 is not a number"
+  sed 's/^/       /' "$WORK/gate.gh.calls"
+fi
+
+# (13) The case above that this DOES change, said out loud. Case 7 refuses an
+#      unclassified path in the gap, and reads as an unconditional refusal.
+#      It is not one any more, and the reason is that the two questions are
+#      different: the table answers "can CI's verdict on an OLDER commit be
+#      trusted for this tip", and a tip with a green run of its own has a
+#      verdict of its own, so nothing is being inherited. The unclassified path
+#      is still caught -- by release-needed.sh, which sees the whole range since
+#      the newest tag and fails the job loudly on exit 2 -- and is stubbed out
+#      here, which is why this case measures the tip check and not that one.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" brandnew/thing.c "feat: a directory nobody has classified"
+gate_expect "an unclassified gap under a tip with its own green run releases" "$G" "$V" true \
+  "successful run(s) of its own" 1
+
+# (14) THE SHAPE THIS BRANCH IS ACTUALLY FOR, and the one the first draft could
+#      not answer. crossplay-ci.yml carries `paths-ignore: site/emulator/**`
+#      and `site/emulator-manifest.json`, so the rebuild crossplay-emulator.yml
+#      pushes after every merge has no CI run and never will -- and after most
+#      merges that rebuild IS the tip. A gate that asks GitHub about the tip
+#      gets 0 for it forever, so the rescue would have fired for every shape
+#      except the commonest one on this branch.
+#
+#      Here: a firmware merge the run did not cover, then an emulator rebuild on
+#      top. The gap is not inert (it contains the firmware), the tip has no run
+#      and cannot have one, and the merge underneath it does. The gate must walk
+#      the invisible commit off the tip and ask about the merge.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" src/apps_local/Sudoku.cpp "fix(sudoku): the givens survive a rotate"
+MERGE="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" site/emulator-manifest.json "chore: emulator rebuilt for $MERGE"
+gate_expect "a tip that is an emulator rebuild asks about the merge under it" "$G" "$V" true \
+  "successful run(s) of its own" 1
+checks=$((checks + 1))
+if ! grep -q "head_sha=$MERGE" "$WORK/gate.gh.calls"; then
+  failed=$((failed + 1))
+  echo "FAIL ci-autorelease  the tip was an emulator rebuild, which CI is configured never to run for, and the gate asked GitHub about it anyway; it must ask about $MERGE, the commit under the invisible ones"
+  sed 's/^/       /' "$WORK/gate.gh.calls"
+fi
+
+# The walk must stop at something visible. A firmware commit ABOVE the merge is
+# not invisible, so the tip is the thing to ask about and the answer is no.
+gate_repo "$G"; V="$(git -C "$G" rev-parse HEAD)"
+gate_commit "$G" src/apps_local/Sudoku.cpp "fix(sudoku): the givens survive a rotate"
+gate_commit "$G" src/apps_local/Chess.cpp "fix(chess): the clock survives a sleep"
+TIP2="$(git -C "$G" rev-parse HEAD)"
+gate_expect "the walk does not step over a visible commit" "$G" "$V" false \
+  "nothing green has verified" 0
+checks=$((checks + 1))
+if ! grep -q "head_sha=$TIP2" "$WORK/gate.gh.calls"; then
+  failed=$((failed + 1))
+  echo "FAIL ci-autorelease  the walk stepped past a commit a device build can see; with firmware on top of firmware the only commit worth asking about is the tip ($TIP2)"
+  sed 's/^/       /' "$WORK/gate.gh.calls"
+fi
 
 # The two stack-checked device envs build in ONE pio run invocation.
 #


### PR DESCRIPTION
Card #258. `cancel-in-progress: false` does not mean "nothing is cancelled", and 52d0907f moved the loss from the running run to the waiting one.

## What is actually happening

A GitHub concurrency group holds at most **one run in progress and one run pending**. `cancel-in-progress` governs the first of those. Nothing governs the second: when a third run arrives, GitHub cancels whatever was pending to make room for it, either way.

Measured, not reasoned. In the 36 hours after 52d0907f made cancellation conditional on the ref:

|                                                                                      |        |
| ------------------------------------------------------------------------------------ | ------ |
| `CrossPlay` runs on `xteink` cancelled                                               | **41** |
| ...of those with `jobs.total_count == 0` (killed while pending, never started a job) | **41** |
| `CrossPlay emulator` runs cancelled (same shape, `group: crossplay-emulator`)        | 1      |
| `CrossPlay site live` runs cancelled                                                 | 1      |
| `CrossPlay autorelease` runs cancelled, out of 133                                   | **0**  |

Each of those 41 was a merge whose CI reached no conclusion, and `crossplay-autorelease.yml` fires only on a run that reached `success`. The last row is the number this change had to avoid spoiling.

It is still firing. Counted again while this branch was being written: **13 of the last 30** `CrossPlay` runs on `xteink` are cancelled.

Reproduce:

```
gh run list -R ma-r-s/crossplay --workflow crossplay-ci.yml --branch xteink --limit 200 \
  --json databaseId,conclusion,createdAt \
  --jq '.[]|select(.conclusion=="cancelled")|select(.createdAt>"2026-09-04T05:34:00Z")|.databaseId' \
| while read -r i; do gh api repos/ma-r-s/crossplay/actions/runs/$i/jobs --jq '.total_count'; done | sort | uniq -c
```

## The fix, and why this one

**Per-commit concurrency group on `xteink`.** Two merges are never in one group, nothing ever pends, and GitHub has nothing to trim.

```yaml
group: crossplay-ci-${{ github.ref == 'refs/heads/xteink' && github.sha || github.ref }}
cancel-in-progress: ${{ github.ref != 'refs/heads/xteink' }}
```

Weighed against the two alternatives:

- **Drop the group entirely.** Ends superseding on pull-request branches too, and that half works: it was added because five runs of one branch were sharing the runners while a merge waited.
- **Leave CI alone, teach only the autorelease to catch up.** Leaves every dropped merge with no verdict of its own. The repository front page would still say nothing about commits nobody built, which is the reason `crossplay-ci.yml` exists.

Runs go parallel on `xteink`. The repository is public so the minutes are free; the workflow takes `permissions: contents: read` and writes nothing two runs could race. Its one shared resource is `actions/cache` on the key `pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}`; concurrent saves of one key are a warning from that action, not a failure, and a pull request could already race a merge for it today.

Folding several merges into one release still happens, in the autorelease, which is where it belongs. It was never CI's job to do it by discarding builds.

## And the opposite failure, which this would otherwise have opened

Parallel CI runs can finish out of order (a cold cache is ~30 minutes, a warm one ~20), so the newest autorelease queued is no longer always the one for the newest commit. And `crossplay-autorelease.yml` carries `group: crossplay-release`, which drops a pending run exactly the same way.

**That group stays.** It is the publisher's guard, and two publishers at once built and published v1.12.16 twice on 2026-09-04.

What changes is the question the gate asks. It used to refuse whenever the tip had moved past the commit CI verified, saying _"the run for the new tip releases it"_ -- an assumption about concurrency, not a fact. It now asks whether anything green has verified **the tip**:

```
gh api "repos/$GITHUB_REPOSITORY/actions/workflows/$CI_WORKFLOW_ID/runs?head_sha=$tip&branch=$CI_BRANCH&status=success&per_page=1" --jq '.total_count'
```

- **It does not ask about the tip.** `crossplay-ci.yml` ignores `site/emulator/**` and `site/emulator-manifest.json`, so the rebuild `crossplay-emulator.yml` pushes after every merge has no CI run and never will, and after most merges *that rebuild is the tip*. A gate asking about the tip would answer 0 forever for the commonest shape on this branch. So it walks back over commits the same classification table calls invisible, and asks about the commit the walk stops on. Everything between that commit and the tip cannot reach a device build or a release by construction, so a green verdict there is a green verdict on the tip. The walk stops at the first visible commit, which is any real merge; the cap of ten is there because an unbounded walk is a loop in a publisher.
- The workflow is identified by the **numeric `workflow_id` from the event**, not by the name `"CrossPlay"`, which lives in another file. That is card #242's lesson applied: a gate must not classify by a string it copied from somewhere else.
- `CI_BRANCH` also comes from the event; the job's own `if:` has already established it is `xteink`.
- **Fails closed.** A non-numeric answer, a query that errors, a missing workflow id, and a zero all refuse exactly as before. The failure mode of a check like this is silence, so silence must refuse.
- No double release: the group still means one autorelease job at a time, and by the time a second reaches the gate the tag exists, so `release_notes.py` finds nothing merged since it.

## Tests

`host-tests/ci`, both halves **seen red before they were seen green**.

- The concurrency expression is **evaluated**, not grepped -- a small reader for the `a == b && c || d` subset GitHub uses, with GitHub's own semantics that `&&`/`||` return the operand rather than a boolean -- over four contexts. Two commits on `xteink` must land in different groups; two pushes to one pull request must land in the same one; `cancel-in-progress` must come out `false` on `xteink` and `true` on a branch. A grep for the group string would have passed the bug. Reverting only the `group:` line: **1 failed**.
- Seven cases on the gate's new branch (9-14), executed against the real classification table with a fake `gh`: a moved tip **with** a green run releases; **without** one still refuses; a query that **errors** refuses; an **empty workflow id** refuses without calling `gh` at all; case 13 says out loud the one thing case 7 no longer means (an unclassified path in the gap under a verified tip *does* release, because the classification table answers whether an OLDER verdict can be inherited and this tip is not inheriting one -- the unclassified path is still caught, loudly, by `release-needed.sh`); and case 14 is the emulator-rebuild tip, where the walk must cross the invisible commit, paired with a case where it must **not** cross firmware. Plus assertions on the recorded query itself: it must name the commit the walk stopped on, and carry `status=success` and `branch=` -- because a copy asking about `$VERIFIED`, or one missing a filter, would answer yes on every run and every other case here would still pass. Reverting only the gate: **5 failed**.
- One more the first draft needed, found by re-reading rather than by a test. The gate's `"moved only by commits no device build and no release can see"` was a line *after* the `fi`, so it ran on both paths: a tip released on its own green run announced that, and then in the very next sentence said the gap was inert. Two contradictory sentences, and the wrong one is the one that reads like the explanation. It is an `else` now, and case 9 asserts the absence -- because `gate_expect` only ever asks whether the sentence it *wants* is there, never what else got printed. Restoring the trailing echo: **1 failed**.

`./scripts_local/check.sh --committed`: see the last comment.

## What a cold review changed

A reviewer with no context read the diff, drove the evaluator, and checked the API contract against the live repository. Six things came back, all now closed, all seen red before green:

1. **The query carried `status=success` and nothing asserted it.** That one parameter is the whole check: against the real repository, sha `f5115b01` (a run cancelled while pending) answers `total_count` **0** with it and **1** without. A gate that dropped it would release from a commit whose CI never ran, and every case in the suite would still have passed. `branch=` is asserted for the same reason. Both now grep the recorded call.
2. **The tip is usually a commit CI never runs for** -- the emulator rebuild. Fixed by the walk described above, with two cases: the walk crosses an emulator rebuild, and it does *not* cross firmware.
3. **The parse-failure guard covered one of the two values it protected**, so the pull-request assertion was satisfied by empty == empty. Demonstrated with the reviewer's own shape (`|| github.head_ref`), which used to pass and now fails.
4. **The `UNEVALUABLE` marker went to stderr and exited 1**, so the case arm naming it was unreachable. It prints on stdout now and the arm is real.
5. **Case 12's failure text named the wrong consequence** -- an empty workflow id is a 404, not a query about every workflow.
6. **`2>&1` folded a warning into the value** and would have refused a release for nothing; the answer is `| tail -1`.

Plus a stale reason next door: `crossplay-emulator.yml` still told the reader that the release gate greps its commit subject and that renaming it stops every release. Card #242 ended that. The subject is load-bearing in exactly one place now (`release_notes.py` drops it from the release page), and the comment says so.

It also found the contradictory log line independently, which I had already fixed.

## What I could not verify

- **A concurrency fix cannot be proven without concurrent merges actually happening.** Everything above is the expression evaluated against contexts I supplied and the gate executed against fixtures I built. Whether GitHub trims a queue the way its documentation says, and whether the new group really stops it, is only observable on the real repository under a real stream of merges. The measurement that proves it is the same one that found the bug: after this lands, cancelled `CrossPlay` runs on `xteink` with `jobs.total_count == 0` should go to zero. It is worth re-running the reproduce command above in a few days.
- **The `gh api` call has been run by hand against this repository, but never from inside the workflow.** By hand, with `workflow_id=329622679`:

  | sha                                                           | `total_count`                                                                              |
  | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
  | `69fc41fe` (a merge whose run succeeded)                      | **1**                                                                                      |
  | `f5115b01` (a merge whose run was pending-dropped, zero jobs) | **0**                                                                                      |
  | forty zeroes (no run at all)                                  | **0**                                                                                      |
  | empty workflow id                                             | HTTP 404 `Not Found` -- a non-number, so it refuses; and the guard skips the call entirely |

  So the endpoint, the `head_sha`/`branch`/`status` filters and `total_count` all behave as the gate assumes, and `status=success` does filter on the conclusion. What is untested is the same call made with the workflow's own token rather than mine. `permissions: actions: write` is already on the job and covers the read; if it is nevertheless refused, the answer is not a number, the gate fails closed, and the behaviour is exactly today's stall rather than a bad release.

- **Out-of-order CI completion is reasoned, not observed.** No two `xteink` runs have ever run in parallel, so the case the gate change exists for has not happened yet.
- **Two narrow holes in the query, both known and both left.** It carries `2>&1`, so a `gh` warning printed *after* the count would still make the answer non-numeric and refuse (fail-closed, costs a release cycle, never mis-releases). And it does not constrain `event`, so a green `pull_request` run whose head branch is literally `xteink` would count -- which needs someone to open a pull request *from* `xteink` into `xteink`. Constraining `event=push` would also exclude a legitimate manual re-run of CI on the tip, so it is left as it is.

## Related, not fixed here

- **#259** (relwatch is blind to a release that never _started_). This change makes releases start in cases where they previously did not, so it reduces how often #259's symptom appears. It does not fix it: a gate that says `go=false` still exits 0 and looks healthy, and nothing yet reports the absence of a release that is owed.
- **#310, filed from this work.** relwatch posts an error card _at once_ for any autorelease run whose conclusion is not `success`/`skipped`/`neutral`, and `cancelled` is not on that list. That was safe while autorelease runs never overlapped (0 of 133 cancelled). After this change they can, benignly, and the watcher would call it a fault. The fix is one tuple in `release_verdicts()` plus the case `host-tests/relwatch` does not have, and it needs a follow-up migration replacing a 278-line function and a run of `server/board/migrate.sh` against the live board. Kept out of here deliberately: getting that wrong breaks the watcher, which is worse than the card it prevents.
- **`crossplay-emulator.yml` has the same bug** (`group: crossplay-emulator`, one dropped run so far) and is left alone. Its group is load-bearing -- the job commits and pushes to `xteink` -- and its checkout is `ref: xteink`, so the next push's rebuild subsumes a lost one. The exposure is a rebuild dropped on the _last_ push before a quiet period, which nothing currently notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
