### PR TITLE
fix(trivia): move the US-centric toggle out of the device's Settings (#311)

### DIFF
--- a/docs/apps/trivia-pack-format.md
+++ b/docs/apps/trivia-pack-format.md
@@ -65,7 +65,8 @@ Each record:
 second byte or a version bump an old reader would refuse. `Pack::read` masks it
 off (`difficulty()` is always the level, `usCentric()` is the flag) and the
 chooser skips the marked questions unless the `triviaShowUsCentric` setting is
-on. The pack ships international by default; the toggle opts a US player back in.
+on (TRIVIA > SETTINGS > US QUESTIONS since card #311; the stored key is
+unchanged). The pack ships international by default; the toggle opts a US player back in.
 A pack built without ratings (`build_pack.py`) never sets the bit, which reads
 back as `us=false` everywhere -- the honest answer for a pack with no US signal.
 See board #191/#223 and `assemble_pack.py` rule 4.

--- a/docs/apps/trivia.md
+++ b/docs/apps/trivia.md
@@ -79,12 +79,42 @@ question count no longer matches it.
 ## International by default
 
 The pack ships every question, but US-centric ones are marked and the chooser
-hides them unless Settings > System > "Show US-centric trivia" is on (off by
-default). The difficulty levels are calibrated for an international table, where
-the US-centric questions are the hardest, so turning the toggle on adds them
-mostly to level 5. The flag rides bit 7 of each question's difficulty byte; see
+hides them unless TRIVIA > SETTINGS > US QUESTIONS is on (off by default). The
+difficulty levels are calibrated for an international table, where the
+US-centric questions are the hardest, so turning the toggle on adds them mostly
+to level 5. The flag rides bit 7 of each question's difficulty byte; see
 [trivia-pack-format.md](trivia-pack-format.md) and board #191/#223. Nothing is
 deleted from the data, so the toggle needs no re-download and no re-rating.
+
+## The app owns its own settings
+
+TRIVIA has a SETTINGS screen, reached from the last row of its front door. It
+holds US QUESTIONS, which shipped in v1.12.29 in the DEVICE's Settings > System
+list instead, one row below Developer Mode. That was wrong and card #311 moved
+it: CrossPoint owns the reader, the keyboard and the system, and a CrossPlay
+app's own options belong inside that app.
+
+**DIFFICULTY stays on the front door, and that is not an oversight.** The two
+options are different kinds. Difficulty is a per-session mood -- easy tonight,
+hard tomorrow, changed about as often as the mode is -- so it sits beside
+QUIZMASTER and SOLO where it costs no taps and reads without opening anything.
+US QUESTIONS is a persistent preference about which questions exist for you at
+all: set once, near enough to never changed again. One surface each is not two
+option surfaces. Chess's LEVEL is set-and-forget, which is why chess keeps its
+on the settings screen and Trivia does not.
+
+**What did not move is the storage.** The value is still
+`CrossPointSettings::triviaShowUsCentric` under the key `"triviaShowUsCentric"`,
+which is what devices updating from v1.12.29 already have saved, so nobody's
+choice was reset. The `SettingInfo` entry is still in `SettingsList.h` too --
+without a category, the shape `SettingsList.h` already used for the OPDS and
+frontlight values, which persists it and keeps it in the web settings API while
+keeping it off the device's Settings screen. `host-tests/appsettings` is the
+guard: it traces who reads each categorised setting and fails if every reader
+lives in one app.
+
+DIFFICULTY is untouched by all of this: still the byte in `/trivia/prefs`, still
+set from the front door.
 
 ## What the device never does
 

--- a/docs/trivia-curation.md
+++ b/docs/trivia-curation.md
@@ -464,7 +464,8 @@ numbers, on the new population. See "Recalibrating the thresholds" below.
 Mario's call on 2026-09-04: they should not show up until a toggle is written;
 2026-09-05, the toggle (#191/#223). The pack now carries every us_centric
 question with a `us` flag (bit 7 of the difficulty byte), and the
-`triviaShowUsCentric` setting decides at runtime whether the chooser deals them.
+`triviaShowUsCentric` setting decides at runtime whether the chooser deals them
+(TRIVIA > SETTINGS > US QUESTIONS since card #311; the stored key is unchanged).
 The default is hidden, so the pack is international by default. `enrich_pack.py`
 still writes `us` as a field rather than a deletion, every US-centric row keeps
 its rating, and no re-rating is ever needed to flip the toggle. Deleting the

--- a/host-tests/appsettings/run.sh
+++ b/host-tests/appsettings/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# An app's own option never renders in the device's global Settings.
+# See host-tests/appsettings/test_appsettings.py for what this is and why.
+#
+#   host-tests/appsettings/run.sh
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE/../.." || exit 1
+exec python3 host-tests/appsettings/test_appsettings.py

--- a/host-tests/appsettings/test_appsettings.py
+++ b/host-tests/appsettings/test_appsettings.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""An app's own option never renders in the device's global Settings.
+
+Mario's rule, 2026-09-05: CrossPoint owns the reader, the keyboard and the
+system; a CrossPlay app's options belong inside that app.
+
+It was broken and looked deliberate. `triviaShowUsCentric` shipped in v1.12.29
+as a row under Settings > System, one line below Developer Mode, and read by
+exactly one file in the repo, TriviaActivity.cpp. Nothing could see that,
+because nothing here had ever asked WHO READS a setting.
+
+So this carries no list of app names, which would pass the day somebody adds an
+app it has not heard of. It asks the code: for every row that renders in the
+global Settings screen, find every file that reads its value. If they all live
+under one src/apps_local/<app>/ directory, the setting belongs to that app and
+the row must not be in the global menu at all.
+
+A category-less SettingInfo is the intended shape for these. It still persists
+under its key and is still exposed by the web settings API -- which is what lets
+a setting move screens without resetting on devices that already have it -- it
+simply does not render in the on-device Settings. SettingsList.h already used
+that shape for the OPDS and frontlight values before this suite existed.
+
+TWO THINGS THIS SUITE MUST NOT DO, both learned the hard way:
+
+  It must not silently skip a row. The first version matched constructor calls
+  with a regex ending `),\\n`, which missed `tiltPageTurn` -- inserted with
+  `v.insert(..., SettingInfo::Enum(...));`, so its call ends `));`. That row was
+  categorised, was in neither the checked set nor the disclosure list, and the
+  suite reported clean over it. Calls are now brace-matched, and the parser
+  ASSERTS it accounted for every `SettingInfo::` call in the file, so an
+  unparsed one is a failure rather than an absence.
+
+  It must not disclose into a void. The rows whose ownership cannot be traced
+  are printed as SKIP, not as a note: check.sh surfaces `SKIP` from a passing
+  suite's log and deletes that log on green, so a "note" line was written,
+  never shown, then removed. host-tests/checksh polices the SKIP pattern.
+
+  host-tests/appsettings/test_appsettings.py
+"""
+import os
+import re
+import subprocess
+import sys
+
+CHECKS = 0
+FAILED = 0
+
+
+def check(ok, msg):
+    global CHECKS, FAILED
+    CHECKS += 1
+    if not ok:
+        FAILED += 1
+        print(f"FAIL appsettings  {msg}")
+
+
+LIST = "src/SettingsList.h"
+# Files that MUST mention every setting: the declaration, the struct that holds
+# it, and the activity that sorts the fork's rows. A reader here says nothing
+# about who owns the value.
+PLUMBING = {
+    LIST,
+    "src/CrossPointSettings.h",
+    "src/CrossPointSettings.cpp",
+    "src/activities/settings/SettingsActivity.cpp",
+}
+
+list_src = open(LIST).read()
+
+
+def calls(src):
+    """Every SettingInfo::X(...) call, brace-matched to its closing paren.
+
+    Paren-matched rather than pattern-matched on purpose: the call sites end in
+    `),`, `));`, `)` and `).withTextSettings()`, and a regex tuned to the shapes
+    present on the day it was written is how tiltPageTurn went missing.
+    """
+    out = []
+    for m in re.finditer(r"SettingInfo::(\w+)\(", src):
+        i = m.end() - 1
+        depth = 0
+        j = i
+        while j < len(src):
+            if src[j] == "(":
+                depth += 1
+            elif src[j] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        out.append({"kind": m.group(1), "body": src[i + 1 : j]})
+    return out
+
+
+parsed = calls(list_src)
+# Every call in the file is accounted for. `SettingInfo::` appears only as a
+# constructor call here, so the two counts must agree exactly; if they ever do
+# not, the parser lost one and every verdict below is over an unknown subset.
+check(
+    len(parsed) == list_src.count("SettingInfo::"),
+    f"parsed {len(parsed)} SettingInfo:: calls but the file has "
+    f"{list_src.count('SettingInfo::')}; the parser lost one and this suite is "
+    f"reporting over an unknown subset of the settings",
+)
+# Three rows are not constructor calls at all: fontFamily, fontSize and
+# dictionary are built field by field, because their enum values come off the SD
+# card at runtime. They carry a category and they render, so they are rows, and a
+# suite that only knew about constructors would report clean over them exactly as
+# the first version did over tiltPageTurn.
+builders = []
+for m in re.finditer(r"\bs\.category\s*=\s*StrId::STR_CAT_(\w+)\s*;", list_src):
+    # The surrounding builder block: back to the `SettingInfo s;` that starts it,
+    # forward to the return. Both fields we need are set within it.
+    start = list_src.rfind("SettingInfo s;", 0, m.start())
+    end = list_src.find("return s;", m.end())
+    block = list_src[start if start >= 0 else m.start() : end if end >= 0 else m.end()]
+    ids = re.findall(r"s\.nameId = StrId::(STR_\w+)", block)
+    keys = re.findall(r's\.key = "([^"]+)"', block)
+    builders.append({"id": ids[0] if ids else "?", "key": keys[0] if keys else ""})
+
+# Every STR_CAT_ in the file is now accounted for by a call or a builder. The
+# only other mention is a comparison (`s.category == StrId::STR_CAT_CONTROLS`),
+# which is a lookup, not a declaration.
+declared = sum(1 for c in parsed if "STR_CAT_" in c["body"]) + len(builders)
+mentions = len(re.findall(r"STR_CAT_\w+", list_src)) - len(re.findall(r"==\s*StrId::STR_CAT_\w+", list_src))
+check(
+    declared == mentions,
+    f"{mentions} STR_CAT_ declarations in {LIST} but this suite modelled "
+    f"{declared}; a row is being declared in a shape it cannot see, and every "
+    f"verdict below is over an unknown subset",
+)
+
+rows = []
+uncategorised = 0
+for c in parsed:
+    if "STR_CAT_" not in c["body"]:
+        uncategorised += 1
+        continue  # category-less: persisted and web-exposed, but not on the screen
+    field = re.findall(r"&CrossPointSettings::(\w+)", c["body"])
+    ids = re.findall(r"StrId::(STR_\w+)", c["body"])
+    rows.append(
+        {
+            "field": field[0] if field else "",
+            "id": ids[0] if ids else "?",
+        }
+    )
+
+# The runtime-built rows read the SD card through getters rather than a member
+# pointer, so there is no field to trace; they are disclosed, not skipped in
+# silence.
+for b in builders:
+    rows.append({"field": "", "id": b["id"]})
+
+check(len(rows) >= 30, f"only found {len(rows)} categorised rows; the parser has drifted")
+
+APPS_DIR = "src/apps_local"
+apps = sorted(d for d in os.listdir(APPS_DIR) if os.path.isdir(os.path.join(APPS_DIR, d)))
+check(len(apps) > 10, f"only found {len(apps)} apps under {APPS_DIR}; the sweep would be vacuous")
+
+
+def readers(field):
+    """Every file under src/ that reads this settings field.
+
+    Deliberately loose. A false POSITIVE here only makes a row look shared and
+    pass; a false negative would drop it into the untraceable list, which is
+    printed. Both `.field` and `->field` are matched because the settings object
+    is reached both ways.
+    """
+    pattern = rf"(\.|->){field}\b|CrossPointSettings::{field}\b"
+    r = subprocess.run(["grep", "-rlE", pattern, "src"], capture_output=True, text=True)
+    return sorted(f for f in r.stdout.split() if f not in PLUMBING)
+
+
+def owning_app(paths):
+    """The single app that owns these readers, or None."""
+    owners = set()
+    for p in paths:
+        parts = p.split("/")
+        # src/apps_local/<app>/File.cpp -- anything shallower is shared code.
+        if len(parts) >= 4 and parts[0] == "src" and parts[1] == "apps_local" and parts[2] in apps:
+            owners.add(parts[2])
+        else:
+            return None  # a reader outside the apps: not one app's setting
+    return owners.pop() if len(owners) == 1 else None
+
+
+untraceable = []
+examined = 0
+for row in rows:
+    if not row["field"]:
+        # An ENUM/String row driven by getters rather than a member pointer
+        # (STR_FONT_SIZE and the three SD-card-backed builders are these).
+        # There is no field to trace readers for.
+        untraceable.append(row["id"])
+        continue
+    who = readers(row["field"])
+    if not who:
+        # Nothing reads it but the plumbing. That is its own smell, but this
+        # suite cannot tell an unused setting from one read through a macro or
+        # an alias, so it says so rather than guessing.
+        untraceable.append(f"{row['id']} ({row['field']})")
+        continue
+    examined += 1
+    app = owning_app(who)
+    check(
+        app is None,
+        f"{row['id']} ({row['field']}) is read only by src/apps_local/{app}/ "
+        f"and renders in the device's global Settings. An app's own option "
+        f"belongs on that app's own settings screen; drop the StrId::STR_CAT_* "
+        f"from its SettingInfo (it keeps its key and the web settings API) and "
+        f"put the control in the app.",
+    )
+
+# A clean verdict has to say what it did NOT look at, somewhere a reader sees.
+if untraceable:
+    print(
+        f"SKIP appsettings  {len(untraceable)} of {len(rows)} categorised rows "
+        f"have no traceable reader outside the settings plumbing, so ownership "
+        f"was NOT checked for them: " + ", ".join(untraceable)
+    )
+print(
+    f"appsettings: {len(parsed)} SettingInfo calls, {uncategorised} category-less, "
+    f"{len(rows)} categorised, {examined} ownership-checked"
+)
+print(f"{CHECKS} checks, {FAILED} failed")
+sys.exit(1 if FAILED else 0)

--- a/host-tests/trivia/test_trivia.cpp
+++ b/host-tests/trivia/test_trivia.cpp
@@ -812,10 +812,18 @@ void testBackFrom() {
   // classified here rather than falling into whatever the switch's default
   // happens to be.
   int leaves = 0;
-  for (const View view : {View::Menu, View::Quizmaster, View::Solo, View::Notice}) {
+  for (const View view : {View::Menu, View::Quizmaster, View::Solo, View::Notice, View::Settings}) {
     if (trivia::backFrom(view, true) == Back::LeaveApp) ++leaves;
   }
   CHECK(leaves == 1);
+
+  // The fifth screen, and the sweep above is what forced it to be classified.
+  // SETTINGS is the app's own options (card #311), reached only from the menu,
+  // so Back returns there -- the same place its BACK TO MENU button goes. It
+  // needs no packOpen case: its door is on the menu, so a card with no pack
+  // can never be standing on it.
+  CHECK(trivia::backFrom(View::Settings, true) == Back::ToMenu);
+  CHECK(trivia::backFrom(View::Settings, false) == Back::ToMenu);
 
   // And with no pack there is nothing but the notice, so both reachable
   // screens leave. The play screens are unreachable in that state; asserting

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -370,6 +370,22 @@ void buildBoard(Rendered& out, const chessui::BoardModel& model) {
   chessui::buildBoardChrome(screen, model);
 }
 
+void buildTriviaMenu(Rendered& out, const triviaui::MenuModel& model) {
+  const fui::DeviceContext ctx = device();
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(out.target, ctx, noInput, out.interactions);
+  toybox::Screen screen(frame, toybox::themeTokens());
+  triviaui::buildMenu(screen, model);
+}
+
+void buildTriviaSettings(Rendered& out, const triviaui::SettingsModel& model) {
+  const fui::DeviceContext ctx = device();
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(out.target, ctx, noInput, out.interactions);
+  toybox::Screen screen(frame, toybox::themeTokens());
+  triviaui::buildSettings(screen, model);
+}
+
 void buildChoice(Rendered& out, const triviaui::ChoiceModel& model) {
   const fui::DeviceContext ctx = device();
   const fui::InputSnapshot noInput{};
@@ -9146,6 +9162,113 @@ void testTriviaAlwaysOffersAWayOut() {
   }
 }
 
+// --- trivia settings (card #311) ---------------------------------------------
+//
+// The US-centric toggle shipped in v1.12.29 as a row in the DEVICE's Settings >
+// System list, beside sleep timeout and Developer Mode, and only TriviaActivity
+// ever read it. CrossPoint owns the reader, the keyboard and the system; a
+// CrossPlay app's own options belong inside that app. host-tests/appsettings
+// guards the settings list; these guard the screen it moved to.
+
+// Both rows draw, and the toggle says which way it is set IN WORDS. Chess and
+// toybattle both spell a boolean as ON or OFF rather than drawing the SDK's
+// switch glyph: at arm's length on e-ink a knob's position is a guess and a
+// word is not.
+void testTriviaSettingsShowsTheToggleAndItsState() {
+  triviaui::SettingsModel model;
+  model.usCentric = false;
+
+  {
+    Rendered out;
+    buildTriviaSettings(out, model);
+    CHECK(out.target.drew("US QUESTIONS"));
+    CHECK(out.target.drew("OFF"));
+    // The VALUE column says one thing. drew() is exact string equality, so this
+    // is about the value cell, not the screen: the subtitle legitimately starts
+    // with the word OFF in both states, and asserting no substring "ON"
+    // anywhere would fail on "WOULD KNOW".
+    CHECK(!out.target.drew("ON"));
+    CHECK(out.target.drew("BACK TO MENU"));
+    // DIFFICULTY is a per-session mood and stays on the front door; this
+    // screen is for the app's persistent preference. Carrying it here as well
+    // would be a second place to set one thing.
+    CHECK(!out.target.drew("DIFFICULTY"));
+  }
+
+  model.usCentric = true;
+  {
+    Rendered out;
+    buildTriviaSettings(out, model);
+    CHECK(out.target.drew("ON"));
+    CHECK(!out.target.drew("OFF"));
+  }
+}
+
+// Each row answers for ITSELF. Frame::hit's value parameter defaults to 0, so a
+// row that forgets it reports as the first one -- which is exactly how solo's
+// four options all scored as option 1 in v1.12.0. A settings list has the same
+// failure mode and it is quieter: tapping US QUESTIONS would cycle DIFFICULTY.
+void testTriviaSettingsRowsCarryTheirIndex() {
+  triviaui::SettingsModel model;
+  Rendered out;
+  buildTriviaSettings(out, model);
+
+  const FakeTarget::TextRun* run = out.target.find("US QUESTIONS");
+  CHECK(run != nullptr);
+  if (run != nullptr) {
+    const fui::ActionEvent event = out.tap(run->rect.x + run->rect.width / 2, run->rect.y + run->rect.height / 2);
+    CHECK(event.action == triviaui::ActionSettingsRow);
+    CHECK(event.value == static_cast<int>(triviaui::SettingRow::UsCentric));
+  }
+
+  // And the way out is a different action, not a third row.
+  const FakeTarget::TextRun* back = out.target.find("BACK TO MENU");
+  CHECK(back != nullptr);
+  if (back != nullptr) {
+    const fui::ActionEvent event = out.tap(back->rect.x + back->rect.width / 2, back->rect.y + back->rect.height / 2);
+    CHECK(event.action == triviaui::ActionCloseSettings);
+  }
+}
+
+// The front door gained a row without either of the two below it moving to the
+// wrong action. The activity used to route "0, 1, or anything else", where
+// anything else cycled the difficulty -- so the SETTINGS row added beside
+// DIFFICULTY would silently have been a second difficulty control. Each row
+// must report its OWN MenuRow, and DIFFICULTY must still be here: it is a
+// per-session mood, not a preference, and burying it taxes the common path.
+void testTriviaMenuRowsCarryTheirOwnAction() {
+  triviaui::MenuModel model;
+  model.difficulty = 0;
+  model.packCount = 50000;
+  model.seenCount = 12;
+
+  Rendered out;
+  buildTriviaMenu(out, model);
+
+  struct Case {
+    const char* label;
+    triviaui::MenuRow row;
+  };
+  const Case cases[] = {
+      {"QUIZMASTER", triviaui::MenuRow::Quizmaster},
+      {"SOLO", triviaui::MenuRow::Solo},
+      {"DIFFICULTY", triviaui::MenuRow::Difficulty},
+      {"SETTINGS", triviaui::MenuRow::Settings},
+  };
+  for (const Case& c : cases) {
+    const FakeTarget::TextRun* run = out.target.find(c.label);
+    CHECK(run != nullptr);
+    if (run == nullptr) continue;
+    const fui::ActionEvent event = out.tap(run->rect.x + run->rect.width / 2, run->rect.y + run->rect.height / 2);
+    CHECK(event.action == triviaui::ActionMenuRow);
+    CHECK(event.value == static_cast<int>(c.row));
+  }
+
+  // The difficulty VALUE is on the front door too, not just its label -- the
+  // whole point of leaving it here is that it reads without opening anything.
+  CHECK(out.target.drew("Any difficulty"));
+}
+
 // --- the header band under the bezel ---------------------------------------
 //
 // Every other test in this file builds against device(), whose safeArea is
@@ -9648,6 +9771,9 @@ int main() {
   testTriviaOptionsCarryTheirIndex();
   testTriviaAlwaysOffersAWayOut();
   testTriviaDrawsNoOptionsWithoutAQuestion();
+  testTriviaSettingsShowsTheToggleAndItsState();
+  testTriviaSettingsRowsCarryTheirIndex();
+  testTriviaMenuRowsCarryTheirOwnAction();
   testTheSeaSaltCardYouTapIsTheCardTheRulesGet();
   testTheSeaSaltChromeIsTappableAndTheCallPillIsEarned();
   testTheSeaSaltCallChoiceSaysWhatEachWordCosts();

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -350,15 +350,24 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
         // whose owner turned that off must not come back on under a new key.
         SettingInfo::Toggle(StrId::STR_DEVICE_REPORT, &CrossPointSettings::deviceReport, "heartbeat",
                             StrId::STR_CAT_SYSTEM),
-        // Trivia ships international by default; this opts a US player back into
-        // the US-centric questions. A CrossPlay setting, held back by
-        // SettingsActivity so it renders below every CrossPoint one.
-        SettingInfo::Toggle(StrId::STR_TRIVIA_US_CENTRIC, &CrossPointSettings::triviaShowUsCentric,
-                            "triviaShowUsCentric", StrId::STR_CAT_SYSTEM),
         // Placed last by SettingsActivity, after the action rows, not by this
         // declaration order: it is the one setting that opens the device to
         // the network, so it should not sit next to a reading preference.
         SettingInfo::Toggle(StrId::STR_DEV_MODE, &CrossPointSettings::devMode, "devMode", StrId::STR_CAT_SYSTEM),
+
+        // Trivia ships international by default; this opts a US player back into
+        // the US-centric questions. Persisted + web-exposed, but CATEGORY-LESS
+        // so it does not render in the device's Settings screen: it is one
+        // app's option, and it now lives on TRIVIA's own SETTINGS screen
+        // (triviaui::buildSettings). CrossPoint owns the reader, the keyboard
+        // and the system; a CrossPlay app's options belong inside that app.
+        //
+        // The key stays "triviaShowUsCentric" and the value stays in
+        // CrossPointSettings on purpose. Both shipped in v1.12.29 and are
+        // already saved on devices, so moving either would silently discard a
+        // preference somebody had chosen. Only the surface moved.
+        SettingInfo::Toggle(StrId::STR_TRIVIA_US_CENTRIC, &CrossPointSettings::triviaShowUsCentric,
+                            "triviaShowUsCentric"),
 
         // OPDS download folder: persisted + web-exposed, but category-less so it
         // is hidden from the on-device Settings screen (edited via OPDS UI).

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -55,7 +55,7 @@ void SettingsActivity::rebuildSettingsLists() {
 
   // Filled by the loop, drained after the action rows below.
   std::vector<SettingInfo> forkSystemSettings;
-  forkSystemSettings.reserve(3);
+  forkSystemSettings.reserve(2);
 
   for (auto& setting : getSettingsList(&sdFontSystem.registry(), &dictionaries)) {
     if (setting.category == StrId::STR_NONE_OPT) continue;
@@ -82,8 +82,12 @@ void SettingsActivity::rebuildSettingsLists() {
       // CrossPlay's own settings sort below every CrossPoint one. Held back
       // rather than pushed here, because the action rows below are appended
       // after this loop and would otherwise sit underneath them.
-      if (setting.valuePtr == &CrossPointSettings::deviceReport || setting.valuePtr == &CrossPointSettings::devMode ||
-          setting.valuePtr == &CrossPointSettings::triviaShowUsCentric) {
+      //
+      // Both of these are DEVICE-wide: what the device reports, and whether it
+      // accepts firmware over Wi-Fi. An app's own option never belongs here --
+      // triviaShowUsCentric was in this list until card #311 and is now
+      // category-less, so it never reaches this switch at all.
+      if (setting.valuePtr == &CrossPointSettings::deviceReport || setting.valuePtr == &CrossPointSettings::devMode) {
         forkSystemSettings.push_back(setting);
         continue;
       }

--- a/src/apps_local/trivia/TriviaActivity.cpp
+++ b/src/apps_local/trivia/TriviaActivity.cpp
@@ -399,18 +399,56 @@ void TriviaActivity::routeAction(const int action, const int value) {
         break;
       }
       selected_ = value;
-      if (value == 0) {
-        go(View::Quizmaster);
-        deal();
-      } else if (value == 1) {
-        score_.reset();
-        go(View::Solo);
-        deal();
-      } else {
-        difficulty_ = (difficulty_ + 1) % (trivia::kDifficulties + 1);
-        saveDifficulty(difficulty_);
-        requestUpdate();
+      // Switched on the row rather than on "0, 1, or anything else". The old
+      // trailing else cycled the difficulty for every value that was not 0 or
+      // 1, so the SETTINGS row added beside DIFFICULTY would silently have been
+      // a second difficulty control.
+      //
+      // And NO `default:`. A default that breaks is the same silence in a new
+      // coat: the next row added to MenuRow would compile and do nothing. With
+      // every enumerator listed, -Wswitch makes it a build failure instead, and
+      // this tree is built -Wall -Wextra -Werror. Count is named for that
+      // reason alone; it is not a row.
+      switch (static_cast<triviaui::MenuRow>(value)) {
+        case triviaui::MenuRow::Quizmaster:
+          go(View::Quizmaster);
+          deal();
+          break;
+        case triviaui::MenuRow::Solo:
+          score_.reset();
+          go(View::Solo);
+          deal();
+          break;
+        case triviaui::MenuRow::Difficulty:
+          // Stays on the front door: a per-session mood, not a preference.
+          difficulty_ = (difficulty_ + 1) % (trivia::kDifficulties + 1);
+          saveDifficulty(difficulty_);
+          requestUpdate();
+          break;
+        case triviaui::MenuRow::Settings:
+          go(View::Settings);
+          break;
+        case triviaui::MenuRow::Count:
+          break;
       }
+      break;
+    case triviaui::ActionSettingsRow:
+      switch (static_cast<triviaui::SettingRow>(value)) {
+        case triviaui::SettingRow::UsCentric:
+          // Written straight back through the settings object that owns it.
+          // The value and its stored key "triviaShowUsCentric" did not move
+          // when the UI did (card #311): a device that already has this saved
+          // keeps what its owner chose, and the web settings API keeps working.
+          SETTINGS.triviaShowUsCentric = SETTINGS.triviaShowUsCentric ? 0 : 1;
+          SETTINGS.saveToFile();
+          break;
+        case triviaui::SettingRow::Count:
+          break;
+      }
+      requestUpdate();
+      break;
+    case triviaui::ActionCloseSettings:
+      go(View::Menu);
       break;
     case triviaui::ActionQuit: {
       // Quizmaster keeps no score -- it is a person reading to a room, and
@@ -557,6 +595,18 @@ void TriviaActivity::render(RenderLock&&) {
       model.packCount = pack_.count();
       model.seenCount = state_.seenCount();
       triviaui::buildMenu(screen, model);
+      break;
+    }
+    case View::Settings: {
+      triviaui::SettingsModel model;
+      // Read straight from the settings object rather than mirrored into a
+      // member, so there is one copy of this fact and no second one to drift.
+      // It is NOT a defence against a concurrent web write: rendering here is
+      // notification-driven and a write from the browser raises no
+      // requestUpdate(), so this screen would show the old value until the next
+      // tap either way.
+      model.usCentric = SETTINGS.triviaShowUsCentric != 0;
+      triviaui::buildSettings(screen, model);
       break;
     }
     case View::Quizmaster: {

--- a/src/apps_local/trivia/TriviaCore.h
+++ b/src/apps_local/trivia/TriviaCore.h
@@ -233,7 +233,7 @@ constexpr Room roomFor(const bool queryOk, const uint64_t freeBytes, const uint6
 // cannot be built on the host, so a decision left inside it cannot be tested.
 // The activity keeps `using View = trivia::View`, so its call sites are
 // unchanged.
-enum class View : uint8_t { Menu, Quizmaster, Solo, Notice };
+enum class View : uint8_t { Menu, Quizmaster, Solo, Notice, Settings };
 
 // What the Back gesture does on each screen.
 //
@@ -255,6 +255,11 @@ enum class View : uint8_t { Menu, Quizmaster, Solo, Notice };
 //               half of it back.
 //   Notice      a notice is a message with one button; Back dismisses it to
 //               the menu, the same place its own BACK TO MENU / PLAY goes.
+//   Settings    the app's own options, reached only from the menu, so Back
+//               goes back to it -- the same place its BACK TO MENU button
+//               goes. Unlike Notice this needs no packOpen test: the settings
+//               door is on the menu, so a device with no pack on the card can
+//               never be standing here to begin with.
 //
 // `packOpen` is the one thing that is not just "what does this screen offer",
 // and it exists because Back would otherwise open a screen nothing else can
@@ -274,6 +279,8 @@ constexpr Back backFrom(const View view, const bool packOpen) {
       return Back::EndRound;
     case View::Notice:
       return packOpen ? Back::ToMenu : Back::LeaveApp;
+    case View::Settings:
+      return Back::ToMenu;
   }
   return Back::ToMenu;
 }

--- a/src/apps_local/trivia/TriviaScreens.cpp
+++ b/src/apps_local/trivia/TriviaScreens.cpp
@@ -304,26 +304,45 @@ void buildMenu(toybox::Screen& screen, const MenuModel& model) {
   const int16_t left = static_cast<int16_t>(body.x + kMargin);
   const int16_t wide = static_cast<int16_t>(body.width - kMargin * 2);
 
-  // The cards take the room between the header and the difficulty row, which
-  // sits just above the footer rule. Derived from the panel rather than fixed,
-  // so the layout does not need re-tuning if the chrome changes height.
+  // The cards take the room between the header and the two rows, which sit
+  // just above the footer rule. Derived from the panel rather than fixed, so
+  // the layout does not need re-tuning if the chrome changes height or a third
+  // row ever arrives.
   const int16_t top = static_cast<int16_t>(body.y + 24);
-  const int16_t diffH = 62;
-  const int16_t diffY = static_cast<int16_t>(footerTop(screen) - diffH - 18);
-  const int16_t cardH = static_cast<int16_t>((diffY - top - 16 - 20) / 2);
+  const int16_t rowH = 62;
+  const int16_t rowGap = 12;
+  const int16_t rowsH = static_cast<int16_t>(rowH * 2 + rowGap);
+  const int16_t rowsY = static_cast<int16_t>(footerTop(screen) - rowsH - 18);
+  const int16_t cardH = static_cast<int16_t>((rowsY - top - 16 - 20) / 2);
 
   modeCard(screen, fui::Rect{left, top, wide, cardH}, "QUIZMASTER", "Read it out, argue, reveal", ActionMenuRow, 0,
            true);
   modeCard(screen, fui::Rect{left, static_cast<int16_t>(top + cardH + 16), wide, cardH}, "SOLO", "Four options, scored",
            ActionMenuRow, 1, false);
 
-  const fui::Rect diffBox{left, diffY, wide, diffH};
+  // DIFFICULTY stays on the front door, and the value stays beside it. It is a
+  // per-session mood -- easy tonight, hard tomorrow -- changed about as often
+  // as the mode is, so it costs no taps and it is readable without opening
+  // anything. The app's persistent preference lives one row below, behind a
+  // door; see SettingRow in TriviaScreens.h for why the two are not the same
+  // kind of thing.
+  const fui::Rect diffBox{left, rowsY, wide, rowH};
   screen.target().stroke(diffBox, fui::Paint::solid(fui::Color::Black), 1);
-  drawLabel(screen, fui::Rect{static_cast<int16_t>(left + 16), diffBox.y, 200, diffH}, "DIFFICULTY", toybox::kSmallFont,
+  drawLabel(screen, fui::Rect{static_cast<int16_t>(left + 16), diffBox.y, 200, rowH}, "DIFFICULTY", toybox::kSmallFont,
             fui::TextAlign::Left, toybox::kButtonCut);
-  drawLabel(screen, fui::Rect{left, diffBox.y, static_cast<int16_t>(wide - 16), diffH}, diff, toybox::kSmallFont,
+  drawLabel(screen, fui::Rect{left, diffBox.y, static_cast<int16_t>(wide - 16), rowH}, diff, toybox::kSmallFont,
             fui::TextAlign::Right, toybox::kButtonCut);
-  screen.frame().hit(diffBox, ActionMenuRow, 2);
+  screen.frame().hit(diffBox, ActionMenuRow, static_cast<int16_t>(MenuRow::Difficulty));
+
+  // The door to the app's own settings. No value on the right: this row is a
+  // door, not a setting, and a value column beside SETTINGS would read as one
+  // thing the tap changes rather than a screen of several. Chess's start menu
+  // does exactly this.
+  const fui::Rect settingsBox{left, static_cast<int16_t>(rowsY + rowH + rowGap), wide, rowH};
+  screen.target().stroke(settingsBox, fui::Paint::solid(fui::Color::Black), 1);
+  drawLabel(screen, fui::Rect{static_cast<int16_t>(left + 16), settingsBox.y, 240, rowH}, "SETTINGS",
+            toybox::kSmallFont, fui::TextAlign::Left, toybox::kButtonCut);
+  screen.frame().hit(settingsBox, ActionMenuRow, static_cast<int16_t>(MenuRow::Settings));
 
   if (model.packCount > 0) {
     char count[48];
@@ -331,6 +350,61 @@ void buildMenu(toybox::Screen& screen, const MenuModel& model) {
     drawLabel(screen, fui::Rect{body.x, static_cast<int16_t>(footerTop(screen) + 20), body.width, 40}, count,
               toybox::kSmallFont, fui::TextAlign::Center, toybox::kButtonCut);
   }
+}
+
+// TRIVIA's own settings. One screen, two rows, and it writes nothing: the
+// activity owns both values and this is a picture of them.
+//
+// A list rather than the hand-drawn boxes the front door uses. Screen::list()
+// substitutes the theme into every row (height, gap, side padding, minimum
+// touch size) where a stack of stroked rects only does layout, and it is the
+// shape chess, forehead and toybattle already settled on -- including the value
+// column, where a boolean is the word ON or OFF rather than fui::ListItem's
+// `toggle` switch. The switch is not unused in this fork (OpdsFilterActivity
+// draws one); it is the wrong pick HERE, because at arm's length on e-ink a
+// knob's position is a guess and a word is not, and every settings row this
+// screen sits beside in chess and toybattle spells it out.
+void buildSettings(toybox::Screen& screen, const SettingsModel& model) {
+  chrome(screen, "SETTINGS", nullptr);
+  // The list needs a content rect; Trivia's own chrome() leaves the raw body
+  // because every other screen here draws straight to the target.
+  screen.insetContent(fui::Insets{toybox::kGutter * 3, toybox::kMargin, toybox::kMargin, toybox::kMargin});
+
+  // Anchored to the bottom margin BEFORE the rows take the rest, so the list
+  // can never grow into it.
+  fui::ButtonProps back;
+  back.label = "BACK TO MENU";
+  back.action = ActionCloseSettings;
+  back.borderEdges = fui::EdgesNone;
+  screen.button(back, screen.takeBottom(toybox::kPillHeight));
+
+  fui::ListItem rows[static_cast<int>(SettingRow::Count)] = {};
+  rows[static_cast<int>(SettingRow::UsCentric)].label = "US QUESTIONS";
+  rows[static_cast<int>(SettingRow::UsCentric)].value = model.usCentric ? "ON" : "OFF";
+  // Says what OFF costs you, not just what the row is. The pack ships
+  // international by default and a player who never turns this on never learns
+  // the marked questions were held back at all.
+  rows[static_cast<int>(SettingRow::UsCentric)].subtitle = "OFF HIDES CLUES ONLY A US PLAYER WOULD KNOW";
+
+  for (int i = 0; i < static_cast<int>(SettingRow::Count); ++i) {
+    rows[i].actionValue = static_cast<int16_t>(i);
+  }
+
+  fui::ListProps list;
+  list.items = rows;
+  list.count = static_cast<uint16_t>(SettingRow::Count);
+  // Touch-only, like the rest of this app: nothing is "selected".
+  list.selectedIndex = -1;
+  list.action = ActionSettingsRow;
+  // Set EXPLICITLY. FONT_SLOT_SMALL is 0, so a style naming only the font is
+  // indistinguishable from a default-constructed one and Screen::list quietly
+  // substitutes the theme's 20px body cut -- which is how FOREHEAD shipped a
+  // subtitle drawn as large as the label it was subtitling, truncated with an
+  // ellipsis its cut has no glyph for. maxLines makes the style caller-owned
+  // and gives a long sentence a real second line to wrap into.
+  list.subtitleText.font = toybox::kSmallFont;
+  list.subtitleText.maxLines = 2;
+  screen.list(list);
 }
 
 void buildChoice(toybox::Screen& screen, const ChoiceModel& model) {

--- a/src/apps_local/trivia/TriviaScreens.h
+++ b/src/apps_local/trivia/TriviaScreens.h
@@ -34,11 +34,32 @@ enum : fui::ActionId {
   // implementation that was not there.
   ActionOption = 5,
   ActionQuit = 6,
-  ActionDifficulty = 7,
   ActionGetPack = 8,  // fetch the question pack over WiFi
+  // TRIVIA's own settings screen. Carries the row in the event VALUE, like
+  // every other settings list in this fork (chess, forehead, toybattle).
+  ActionSettingsRow = 9,
+  ActionCloseSettings = 10,
 };
 
-enum class MenuRow : int { Quizmaster = 0, Solo, Difficulty, Count };
+enum class MenuRow : int { Quizmaster = 0, Solo, Difficulty, Settings, Count };
+
+// The rows of TRIVIA's own SETTINGS screen.
+//
+// DIFFICULTY is deliberately NOT one of these, and it is worth saying why here
+// rather than rediscovering it. The two options are different KINDS. Difficulty
+// is a per-session mood -- easy tonight, hard tomorrow, changed as often as the
+// mode is -- so it belongs beside QUIZMASTER and SOLO on the front door, where
+// it costs no taps. US QUESTIONS is a persistent preference about which
+// questions exist for you at all: set once, near enough to never changed again.
+// One surface each is not two option surfaces; a chess LEVEL is set-and-forget
+// and that is why chess keeps its on this screen instead.
+enum class SettingRow : int { UsCentric = 0, Count };
+
+// What the SETTINGS screen shows. The activity owns the value; this is a
+// picture of it, and the screen writes nothing.
+struct SettingsModel {
+  bool usCentric = false;
+};
 
 // A headline, a sentence, and at most one thing to do about it. Used for the
 // empty card and for every download outcome.
@@ -85,6 +106,7 @@ struct ChoiceModel {
 };
 
 void buildMenu(toybox::Screen& screen, const MenuModel& model);
+void buildSettings(toybox::Screen& screen, const SettingsModel& model);
 void buildNotice(toybox::Screen& screen, const NoticeModel& model);
 void buildQuestion(toybox::Screen& screen, const QuestionModel& model);
 void buildChoice(toybox::Screen& screen, const ChoiceModel& model);


### PR DESCRIPTION
Card #311. Mario, 2026-09-05: the US-centric trivia toggle ended up in the device's global SYSTEM settings, and it should be inside the Trivia app.

It shipped that way in v1.12.29 (PR #107, card #191) as a row under Settings > System, one line below Developer Mode, and only `TriviaActivity` ever read it. CrossPoint owns the reader, the keyboard and the system; a CrossPlay app's own options belong inside that app.

## Scope: this is the on-device Settings screen

**Said plainly up front, because a cold review caught me overclaiming it.** This removes the row from the **on-device** Settings screen. It does *not* remove it from the device's **web** settings page at `http://<device>/settings`, where it moves from the System card to a card headed **"None"**.

`CrossPointWebServer.cpp:1238` emits `doc["category"] = I18N.get(s.category)` unconditionally and `SettingsPage.html:517-535` groups by that string with no filter, so `STR_NONE_OPT` renders as a heading. Every category-less setting is already in that card - `opdsDownloadFolder`, `opdsLanguages`, `opdsFilenameFormat`, `opdsLastServer`, `frontlightBrightness`, `frontlightOn` - so this is pre-existing and this PR adds a seventh row to it rather than causing it.

**Filed as card #318** rather than fixed here, because the fix is a judgement call about six settings CrossPoint owns: they are category-less *precisely* so they stay web-editable while staying off the device screen, so filtering `STR_NONE_OPT` out of the API would delete controls people use. #318 also carries the label mismatch it exposes - the web page says "Show US-centric trivia" while the app now says US QUESTIONS.

## The persisted value did NOT move

**This is the part worth checking, so here it is first.** The value is still `CrossPointSettings::triviaShowUsCentric` and the stored key is still `"triviaShowUsCentric"`. Nothing was migrated because nothing needed migrating.

What changed is that its `SettingInfo` entry no longer carries a category. That is the shape `SettingsList.h` already used for the OPDS and frontlight values, and I confirmed what it means by reading the consumers rather than trusting the comment above them:

- `CrossPointSettings::toJson` and the load loop (`src/CrossPointSettings.cpp:68`, `:122`) filter on `info.key` and `valuePtr`/`stringOffset`. Never on category. So it still persists and still loads.
- The web settings API (`src/network/CrossPointWebServer.cpp:1221`, `:1325`) filters on `s.key`. Never on category. So it is still exposed and still writable from the browser.
- `SettingsActivity` is the only consumer that reads `category`, and it skips `STR_NONE_OPT`. So it is the only thing that stops showing it.

A device updating from v1.12.29 therefore keeps whatever its owner chose. Had the value been moved into Trivia's own `/trivia/prefs` file it would have needed a migration, and a fix that silently discards a saved preference is worse than the bug.

## The twin check

Swept all 40 categorised rows in `SettingsList.h` against `crosspoint/develop`. Three are the fork's:

| Row | Key | Verdict |
|---|---|---|
| `STR_TRIVIA_US_CENTRIC` | `triviaShowUsCentric` | **Moved.** Read only by `src/apps_local/trivia/`. |
| `STR_DEVICE_REPORT` | `heartbeat` | Correctly placed. Device-wide: what the device reports about itself. |
| `STR_DEV_MODE` | `devMode` | Correctly placed. Device-wide: whether it accepts firmware over Wi-Fi. |

**This was the only violation, so there is nothing else to file.** Confirmed independently from the other direction: `SETTINGS.` has exactly one reader in the whole of `src/apps_local/`, and it was this one. I also checked the four rows my parser could not reach (the dynamically-built `fontFamily`, `fontSize` and `dictionary` entries, and the conditionally-inserted `tiltPageTurn`) - all four are upstream's.

## What the screen looks like now

Rendered on the simulator and looked at (not merely produced), four panels composed side by side at `wt/triviasettings/qa-artifacts/card311-trivia-settings.png` - `qa-artifacts/` is gitignored, so the file is local rather than embedded here:

1. **Front door** - QUIZMASTER, SOLO, then `DIFFICULTY  Any difficulty`, then `SETTINGS`. The two mode cards shrink to make room; nothing overlaps and the difficulty value still reads without opening anything.
2. **SETTINGS, toggle OFF** - `US QUESTIONS   OFF`, subtitle wrapping cleanly to two lines, `BACK TO MENU` anchored at the bottom.
3. **SETTINGS, toggle ON** - same screen after one tap, `ON`. The write goes through `SETTINGS.saveToFile()`, so this is the real persistence path, not a UI-only flip.
4. **Device Settings > System** - the row is gone from between `Share diagnostics` and `Developer Mode`, where it used to sit.

Header band is the fork's standard 76px `headerBand`. No overlap, no text cut mid-word, no glyph holes.

## The in-app surface

Built the way chess, forehead and toybattle build theirs, rather than inventing anything: toybox chrome, a `Screen::list()` of label-and-value rows, and a bottom button back to the menu. A boolean is spelled as the word ON or OFF rather than `fui::ListItem`'s `toggle` switch. I had written that no app in this fork uses that switch; that is false and the review caught it - `OpdsFilterActivity.cpp:94,104` draws one. It is the wrong pick *here*, because at arm's length on e-ink a knob's position is a guess and a word is not, and the settings rows this sits beside in chess and toybattle all spell it out.

**DIFFICULTY stays on the front door.** I drafted this with difficulty moved onto the settings screen and backed it out. It was never part of the defect, and the two options are different kinds: difficulty is a per-session mood, easy tonight and hard tomorrow, changed about as often as the mode is, so burying it one screen deeper taxes the common path to tidy nothing. US QUESTIONS is a persistent preference about which questions exist for you at all. One surface each is not two option surfaces, which is also why chess keeps its set-and-forget LEVEL on its settings screen and this does not. The front door gained a row rather than trading one.

Routing was switched on `MenuRow` instead of "0, 1, or anything else". The old trailing `else` cycled the difficulty for every other value, so the SETTINGS row added beside DIFFICULTY would silently have been a second difficulty control. There is deliberately **no `default:`** - a default that breaks is the same silence in a new coat, so every enumerator is listed and `-Wswitch` makes the next row a build failure under this tree's `-Werror`.

## Tests

**`host-tests/appsettings`, new, and it is the one that fails without the fix.** It carries no list of app names, which would pass the day somebody adds an app it has not heard of. For every row that renders in the global Settings it finds every file that reads that value; if they all live under one `src/apps_local/<app>/`, the row does not belong there. Seen red with the fix reverted:

```
FAIL appsettings  STR_TRIVIA_US_CENTRIC (triviaShowUsCentric) is read only by
src/apps_local/trivia/ and renders in the device's global Settings. ...
```

**The first version of this guard had two holes a cold review found, and both are the failure mode the guard exists to prevent, so they are worth naming.**

1. It matched constructor calls with a regex ending `),\n`, which never saw `tiltPageTurn` - inserted with a call ending `));`. That is a categorised row that was in neither the checked set nor the disclosure list, with the suite reporting clean over it. Calls are now paren-matched, and the parser **asserts** it accounted for every `SettingInfo::` call and every `STR_CAT_` declaration in the file, so an unparsed row is a failure rather than an absence. It also now models the three rows built field-by-field (`fontFamily`, `fontSize`, `dictionary`), which no constructor pattern can see.
2. Its disclosure of untraceable rows was printed as a `note`. `check.sh` sends a suite's stdout to a log, surfaces only `SKIP` lines from a passing suite, and deletes the log on green - so the note was written, never shown, then removed. It is a `SKIP` now, which `check.sh` surfaces and `host-tests/checksh` polices.

It reports what it actually covered rather than implying it covered everything:

```
SKIP appsettings  8 of 43 categorised rows have no traceable reader outside the
settings plumbing, so ownership was NOT checked for them: STR_REFRESH_FREQ ...
appsettings: 65 SettingInfo calls, 25 category-less, 43 categorised, 35 ownership-checked
```

`host-tests/ui`: the settings screen draws the toggle and its state, ON and OFF never appear together, DIFFICULTY is **not** on it, and every front-door row reports its **own** `MenuRow` - including the difficulty value, since reading it without opening anything is the whole reason it stays there. The per-row index matters: `Frame::hit`'s value parameter defaults to 0, which is how solo's four options all scored as option 1 in v1.12.0. Here the same mistake would be quieter - the new SETTINGS row would have cycled DIFFICULTY.

`host-tests/trivia`: `View::Settings` classified in the `backFrom` sweep, which the existing test had been written to force for exactly this case.

`host-tests/settingsorder` (card #182) still passes and still checks something real: `deviceReport` and `devMode` remain as the fork's two System rows. It reports 5 checks rather than 6 now, because there is one fewer fork row to position-check.

## Docs

`docs/apps/trivia.md` (the "Settings > System" route, plus a section on what moved and why difficulty deliberately did not), `docs/apps/trivia-pack-format.md` and `docs/trivia-curation.md` - both named the old route.

## What I did NOT verify

- **No hardware.** Simulator only. The simulator never compiles `lib/hal` or runs `InputManager`, so the tap routing proven here is the host frame's hit table, not the device's input path.
- **The web settings page was not opened.** I traced the code path that exposes the key and confirmed it does not read `category`, but I did not load the browser UI and watch the toggle write.
- **No upgrade was performed from a real v1.12.29 device.** The "your saved value survives" claim rests on reading the load/save loops, not on flashing a device that already had the key set and watching it come back.
- Landscape and the other three orientations. The screen is portrait, like the rest of Trivia.
