### PR TITLE
fix: tell the reader the device is working before it blocks (#306)

### DIFF
--- a/host-tests/paintfirst/run.sh
+++ b/host-tests/paintfirst/run.sh
@@ -1,0 +1,233 @@
+#!/bin/sh
+# The busy screen has to be ASKED FOR before the socket opens.
+#
+#   host-tests/paintfirst/run.sh
+#
+# THE DEFECT (card #306). Activity::requestUpdate() defaults to DEFERRED: it
+# sets a flag ActivityManager::loop() consumes at its own tail, and that tail
+# cannot be reached while a blocking call sits in the same call stack. So
+#
+#     requestUpdate();
+#     fetchSomethingSlow();
+#
+# never notifies the render task AT ALL. The busy state is set, the busy screen
+# exists and is correct, and the panel holds the PREVIOUS screen for the whole
+# transfer. Two cold testers concluded the device had died; see the memory
+# a-silent-screen-reads-as-a-crash.
+#
+# THE FIX is requestUpdate(true), which calls xTaskNotify immediately. The frame
+# then RACES the socket rather than being guaranteed ahead of it. That is the
+# deliberate trade: rendering is milliseconds and a network call is seconds, so
+# it wins in practice, and if it ever loses the reader sees the message slightly
+# late instead of never. The ask was "it doesn't feel like it crashed", not a
+# guarantee -- and a guarantee (requestUpdateAndWait) costs a synchronous window
+# in which a render can overlap the fetch, which is a worse bug than the one it
+# fixes.
+#
+# WHERE A PROGRESS CALLBACK EXISTS, IT IS BETTER THAN ANY OF THIS. Get Books'
+# downloadBook() survives a whole transfer because HttpDownloader's abortPoll()
+# (src/network/HttpDownloader.cpp) invokes the progress callback every 50ms --
+# through the connect and the headers, not just the body -- and that callback
+# both repaints and pumps input. That is why Back works mid-download. Nothing
+# here changes it; the sites below are the ones with no such callback.
+#
+# WHY A SOURCE SCAN. Which frame is on the panel when a socket opens is an ORDER
+# between statements in different functions, on classes needing Storage, WiFi, a
+# GfxRenderer and a FreeRTOS render task. Nothing freestanding can hold it.
+#
+# WHY EVERY PATTERN IS ANCHORED. A cold critic defeated the first version of
+# this suite five ways: a COMMENT containing the call satisfied a grep; a
+# displayBuffer() nested in an `if` satisfied a presence check; an early
+# `return` above it did too; `auto lock = RenderLock(...)` evaded a check that
+# grepped the spelling; and a string literal counted as code. So: comments and
+# string literals are stripped properly (block comments too), every pattern
+# matches a STATEMENT at an exact indent, and reachability is checked rather
+# than presence.
+set -e
+cd "$(dirname "$0")/../.."
+
+checks=0
+failed=0
+ok()  { checks=$((checks + 1)); }
+bad() { checks=$((checks + 1)); failed=$((failed + 1)); echo "FAIL paintfirst  $1"; }
+
+need_file() {
+  [ -f "$1" ] || { echo "FAIL paintfirst  $1 is missing -- every scan below would pass by finding nothing"; exit 1; }
+}
+
+# Comments AND string literals, gone. Block state is tracked across lines: a
+# previous version dropped only lines STARTING with // or /*, so the interior of
+# a /* ... */ block survived and commenting out the call kept every check green.
+nocomment() {
+  awk '
+    {
+      line = $0; out = ""; i = 1; n = length(line)
+      while (i <= n) {
+        c = substr(line, i, 1); d = substr(line, i, 2)
+        if (inblock) { if (d == "*/") { inblock = 0; i += 2 } else i++ }
+        else if (instr) { if (c == "\\") { i += 2 } else { if (c == "\"") instr = 0; out = out " "; i++ } }
+        else if (d == "/*") { inblock = 1; i += 2 }
+        else if (d == "//") break
+        else if (c == "\"") { instr = 1; out = out " "; i++ }
+        else { out = out c; i++ }
+      }
+      print out
+    }'
+}
+
+# Body of the function whose signature matches $2, in file $1, comments stripped.
+body() {
+  awk -v sig="$2" '
+    !inside && $0 ~ sig { inside = 1 }
+    inside { print }
+    inside && /^\}/ { exit }
+  ' "$1" | nocomment
+}
+
+# A statement at exactly $1 spaces of indent. Anything in a comment, a string or
+# a deeper scope fails to match -- the indent IS the assertion.
+stmt() { printf '^%s%s;[[:space:]]*$' "$1" "$2"; }
+
+ahead_re() {
+  text=$(cat)
+  a=$(printf '%s\n' "$text" | grep -nE -- "$1" | head -1 | cut -d: -f1)
+  b=$(printf '%s\n' "$text" | grep -nE -- "$2" | head -1 | cut -d: -f1)
+  [ -n "$a" ] && [ -n "$b" ] && [ "$a" -lt "$b" ]
+}
+
+has_re() { printf '%s\n' "$2" | grep -qE -- "$1"; }
+
+# REACHABILITY, not presence: no `return` of any kind may precede the statement.
+# None of these render()s has an early return, so this is strict without being
+# brittle; one that grows a return has to say so by failing.
+reached() {
+  line=$(printf '%s\n' "$2" | grep -nE -- "$1" | head -1 | cut -d: -f1)
+  [ -n "$line" ] || return 1
+  [ "$(printf '%s\n' "$2" | sed -n "1,$((line - 1))p" | grep -cE '(^|[^A-Za-z_])return([; ]|$)')" -eq 0 ]
+}
+
+# Every call matching $2 must have a call matching $1 within $3 CODE lines
+# before it. Blank lines do not count (nocomment blanks in place), and the guard
+# must be a bare statement -- `if (kNeverTrue) guard();` guards nothing.
+preceded_within() {
+  awk -v guard="$1" -v danger="$2" -v span="$3" '
+    /^[[:space:]]*$/ { next }
+    { code++ }
+    $0 ~ guard { last = code }
+    $0 ~ danger { if (last == 0 || code - last > span) bad = 1 }
+    END { exit bad ? 1 : 0 }
+  '
+}
+
+# Is the statement matching $1 executed while a RenderLock declared in an
+# ENCLOSING scope is still alive? Brace depth, not proximity: an unrelated lock
+# further up satisfies "is there a lock above" while the write itself runs
+# unlocked. A lock protects a SCOPE. Declaration forms only, so a log message
+# mentioning RenderLock does not count.
+LOCKDECL='(RenderLock[[:space:]]+[A-Za-z_]|=[[:space:]]*RenderLock[(]|new[[:space:]]+RenderLock)'
+locked_at() {
+  printf '%s\n' "$2" | awk -v target="$1" -v lockdecl="$LOCKDECL" '
+    {
+      if ($0 ~ target && lockdepth > 0 && depth >= lockdepth) found = 1
+      # Character by character, not a net brace count per line: a lock whose
+      # scope OPENS AND CLOSES on one line (`if (x) { RenderLock d(...); }`)
+      # nets to zero and stayed "alive" for the rest of the function, so a decoy
+      # further up satisfied the check while the real write ran unlocked.
+      lp = 0
+      if (match($0, lockdecl)) lp = RSTART
+      n = length($0)
+      for (i = 1; i <= n; i++) {
+        if (i == lp) lockdepth = (depth > 0 ? depth : 1)
+        ch = substr($0, i, 1)
+        if (ch == "{") depth++
+        else if (ch == "}") { depth--; if (lockdepth > 0 && depth < lockdepth) lockdepth = 0 }
+      }
+    }
+    END { exit found ? 0 : 1 }
+  '
+}
+
+I2="  "
+I4="    "
+
+# ---------------------------------------------------------------------------
+# CASE 1: Get Books. The cold start is the worst of them -- it is what a new
+# reader hits first, and the screen left behind is the shelf.
+# ---------------------------------------------------------------------------
+OPDS=src/activities/browser/OpdsBookBrowserActivity.cpp
+need_file "$OPDS"
+
+# THE COST OF PAINTING IMMEDIATELY, and the reason this suite still has a lock
+# check after the handshake work was dropped. requestUpdate(true) wakes the
+# render task on the other core while this one blocks, so a render overlaps the
+# fetch BY CONSTRUCTION -- wider than the deferred call it replaced, which could
+# not run during a blocking call at all. fetchFeed() replaces `entries` and
+# rebuilds `rowItems`, whose ListItems hold const char* INTO entries[i].title.
+# Without the lock that is a use-after-free by design rather than by race.
+ff=$(body "$OPDS" '^void OpdsBookBrowserActivity::fetchFeed[(]')
+if locked_at 'entries = std::move' "$ff"; then ok
+else bad "fetchFeed() replaces entries with no RenderLock alive in an enclosing scope; requestUpdate(true) means a render is concurrent by construction, and rowItems points into the strings being freed"; fi
+
+if locked_at 'rebuildRowItems[(][)];' "$ff"; then ok
+else bad "fetchFeed() rebuilds rowItems with no RenderLock alive in an enclosing scope"; fi
+
+if locked_at 'swap[(]entries[)]' "$(body "$OPDS" '^void OpdsBookBrowserActivity::releaseEntries[(]')"; then ok
+else bad "releaseEntries() frees entries with no RenderLock alive; three navigation paths reach it while a render woken by an earlier requestUpdate(true) may still be reading rowItems"; fi
+
+# ...and every path in is painted, not just the ones an audit happened to list.
+# Six reach fetchFeed(); the definition line starts at column 0 and is excluded.
+if nocomment < "$OPDS" | preceded_within '^[[:space:]]+requestUpdate[(]true[)];' '^[[:space:]]+fetchFeed[(]' 3; then ok
+else bad "a fetchFeed() in $OPDS is not preceded by requestUpdate(true); that path blocks with no repaint asked for -- see bounding-one-of-two-input-paths"; fi
+
+# The render that has to publish the frame, at function-body level and not
+# behind an early return. See the memory activity-render-contract.
+if reached "$(stmt "$I2" 'renderer\.displayBuffer\(\)')" "$(body "$OPDS" '^void OpdsBookBrowserActivity::render[(]')"; then ok
+else bad "OpdsBookBrowserActivity::render() has no REACHABLE displayBuffer() at function-body level; the busy frame would be built and never shown"; fi
+
+# ---------------------------------------------------------------------------
+# CASE 2: KOReader authentication, over TLS, reachable straight from onEnter().
+# The AUTHENTICATING screen existed, was correct, and had never been seen.
+# ---------------------------------------------------------------------------
+KOA=src/activities/settings/KOReaderAuthActivity.cpp
+need_file "$KOA"
+auth=$(body "$KOA" '^void KOReaderAuthActivity::onWifiSelectionComplete[(]')
+
+if has_re "$(stmt "$I4" 'state = AUTHENTICATING')" "$auth"; then ok
+else bad "onWifiSelectionComplete() no longer sets AUTHENTICATING -- there is no busy state to paint"; fi
+
+if printf '%s\n' "$auth" | ahead_re "$(stmt "$I2" 'requestUpdate\(true\)')" "$(stmt "$I2" 'performAuthentication\(\)')"; then ok
+else bad "performAuthentication() is not preceded by an unconditional requestUpdate(true); it opens TLS on this task and the panel keeps the settings page the reader just left"; fi
+
+sites=$(nocomment < "$KOA" | grep -cE '^ +performAuthentication\(\);' || true)
+if [ "$sites" = "1" ]; then ok
+else bad "performAuthentication() is called $sites times; each extra site is an unpainted handshake"; fi
+
+if reached "$(stmt "$I2" 'renderer\.displayBuffer\(\)')" "$(body "$KOA" '^void KOReaderAuthActivity::render[(]')"; then ok
+else bad "KOReaderAuthActivity::render() has no REACHABLE displayBuffer() at function-body level"; fi
+
+# ---------------------------------------------------------------------------
+# CASE 3: Instapaper. Not a mis-ordered busy state -- there was NONE, on both
+# of its blocking pairAbandon() calls, one switch branch apart.
+# ---------------------------------------------------------------------------
+INS=src/apps_local/instapaper/InstapaperActivity.cpp
+need_file "$INS"
+paint=$(body "$INS" '^void InstapaperActivity::paintBusyNow[(]')
+
+if has_re "$(stmt "$I4" 'phase_ = Phase::Busy')" "$paint"; then ok
+else bad "paintBusyNow() sets no busy phase; there is nothing for the repaint to show"; fi
+
+# IMMEDIATE. The default would defer to a loop tail the caller's socket call
+# never lets it reach, which is the whole defect.
+if has_re "$(stmt "$I2" 'requestUpdate\(true\)')" "$paint"; then ok
+else bad "paintBusyNow() does not requestUpdate(true) at function-body level; a deferred update never notifies the render task before the caller blocks"; fi
+
+# EVERY pairAbandon, not the one in front of me. The first fix landed on
+# performDisconnect() and left the identical call in the Back handler alone.
+if nocomment < "$INS" | preceded_within '^[[:space:]]+paintBusyNow[(]' 'sync_[.]pairAbandon[(]' 8; then ok
+else bad "a sync_.pairAbandon() in $INS is not preceded by paintBusyNow(); that is a blocking TLS revoke with whatever screen the reader was on left frozen behind it"; fi
+
+if reached "$(stmt "$I2" 'renderer\.displayBuffer\(\)')" "$(body "$INS" '^void InstapaperActivity::render[(]')"; then ok
+else bad "InstapaperActivity::render() has no REACHABLE displayBuffer() at function-body level"; fi
+
+echo "$checks checks, $failed failed"
+[ "$failed" -eq 0 ]

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -216,7 +216,10 @@ void OpdsBookBrowserActivity::loop() {
       if (WiFi.status() == WL_CONNECTED && WiFi.localIP() != IPAddress(0, 0, 0, 0)) {
         state = BrowserState::LOADING;
         statusMessage = tr(STR_LOADING);
-        requestUpdate();
+        // immediate: fetchFeed() blocks this task, and a deferred update is a
+        // flag ActivityManager::loop() consumes at its tail -- a tail it cannot
+        // reach until the fetch returns, so nothing would repaint at all. #306.
+        requestUpdate(true);
         fetchFeed(currentPath);
       } else {
         launchWifiSelection();
@@ -704,49 +707,71 @@ void OpdsBookBrowserActivity::fetchFeed(const std::string& path) {
   const auto& nextUrl = parser.getNextPageUrl();
   const auto& prevUrl = parser.getPrevPageUrl();
   const bool feedTruncated = parser.truncated();
-  // Reset the selection before the swap: the render task reads
-  // entries[selectorIndex] under only an empty() guard, and the new feed can
-  // be shorter than the old selection.
-  selectorIndex = 0;
-  listNav.reset();
-  entries = std::move(parser).getEntries();
+  // THE NARROW LOCK, and the only one this branch adds. Read this before
+  // deleting it as redundant.
+  //
+  // requestUpdate(true) above wakes the render task IMMEDIATELY: it paints on
+  // core 1 while this task continues on core 0 into the fetch, so a render is
+  // concurrent with the block below BY CONSTRUCTION. That is WIDER than the
+  // deferred requestUpdate() it replaced, which could not run during a blocking
+  // call at all -- which is exactly why these writes were safe for years and
+  // stopped being safe here. The paint is not the simplification it looks like.
+  //
+  // What it costs: this replaces `entries` and rebuilds `rowItems` from it, and
+  // rowItems' ListItems hold const char* INTO entries[i].title, which
+  // buildBrowsingScreen() reads on the render task. An overlapping render is a
+  // use-after-free, not a torn frame. And not argued away by timing:
+  // displayBuffer() blocks 0.3-2s (HALF_REFRESH is 1720ms), so a small feed can
+  // return inside one refresh.
+  //
+  // Released before the tail reaches launchSearch(); the mutex is non-recursive
+  // and nothing inside re-enters it.
+  {
+    RenderLock lock(*this);
+    // Reset the selection before the swap: the render task reads
+    // entries[selectorIndex] under only an empty() guard, and the new feed can
+    // be shorter than the old selection.
+    selectorIndex = 0;
+    listNav.reset();
+    entries = std::move(parser).getEntries();
 
-  // Language filter. Navigation rows are never dropped -- hiding the way into a
-  // folder because the folder itself carries a language tag would strand the
-  // user -- and neither are books the feed did not tag. See opdsLanguageAllowed.
-  const uint32_t languageMask = opdsLanguageMaskFromCodes(SETTINGS.opdsLanguages);
-  if (languageMask != 0 && languageMask != opdsAllLanguagesMask()) {
-    const size_t before = entries.size();
-    entries.erase(std::remove_if(entries.begin(), entries.end(),
-                                 [languageMask](const OpdsEntry& entry) {
-                                   return entry.type == OpdsEntryType::BOOK &&
-                                          !opdsLanguageAllowed(entry.language, languageMask);
-                                 }),
-                  entries.end());
-    if (before != entries.size()) {
-      LOG_DBG("OPDS", "Language filter hid %zu of %zu entries", before - entries.size(), before);
+    // Language filter. Navigation rows are never dropped -- hiding the way into a
+    // folder because the folder itself carries a language tag would strand the
+    // user -- and neither are books the feed did not tag. See opdsLanguageAllowed.
+    const uint32_t languageMask = opdsLanguageMaskFromCodes(SETTINGS.opdsLanguages);
+    if (languageMask != 0 && languageMask != opdsAllLanguagesMask()) {
+      const size_t before = entries.size();
+      entries.erase(std::remove_if(entries.begin(), entries.end(),
+                                   [languageMask](const OpdsEntry& entry) {
+                                     return entry.type == OpdsEntryType::BOOK &&
+                                            !opdsLanguageAllowed(entry.language, languageMask);
+                                   }),
+                    entries.end());
+      if (before != entries.size()) {
+        LOG_DBG("OPDS", "Language filter hid %zu of %zu entries", before - entries.size(), before);
+      }
     }
-  }
 
-  entries.reserve(entries.size() + (prevUrl.empty() ? 0 : 1) + (nextUrl.empty() ? 0 : 1));
-  if (!prevUrl.empty()) {
-    entries.insert(entries.begin(), OpdsEntry{OpdsEntryType::NAVIGATION, tr(STR_PREV_PAGE), "", prevUrl, ""});
-  }
-  if (!nextUrl.empty()) {
-    entries.push_back(OpdsEntry{OpdsEntryType::NAVIGATION, tr(STR_NEXT_PAGE), "", nextUrl, ""});
-  }
-  if (feedTruncated) {
-    LOG_INF("OPDS", "Feed truncated to fit memory");
-  }
+    entries.reserve(entries.size() + (prevUrl.empty() ? 0 : 1) + (nextUrl.empty() ? 0 : 1));
+    if (!prevUrl.empty()) {
+      entries.insert(entries.begin(), OpdsEntry{OpdsEntryType::NAVIGATION, tr(STR_PREV_PAGE), "", prevUrl, ""});
+    }
+    if (!nextUrl.empty()) {
+      entries.push_back(OpdsEntry{OpdsEntryType::NAVIGATION, tr(STR_NEXT_PAGE), "", nextUrl, ""});
+    }
+    if (feedTruncated) {
+      LOG_INF("OPDS", "Feed truncated to fit memory");
+    }
 
-  // A catalog with nothing to browse but a search link is not broken -- that is
-  // what a lookup-only catalog looks like, and LibGen is one. The feed itself
-  // tells us which shape it is, so no per-catalog setting is needed.
-  searchOnlyCatalog = entries.empty() && !searchTemplate.empty();
+    // A catalog with nothing to browse but a search link is not broken -- that is
+    // what a lookup-only catalog looks like, and LibGen is one. The feed itself
+    // tells us which shape it is, so no per-catalog setting is needed.
+    searchOnlyCatalog = entries.empty() && !searchTemplate.empty();
 
-  state = (entries.empty() && !searchOnlyCatalog) ? BrowserState::ERROR : BrowserState::BROWSING;
-  if (entries.empty() && !searchOnlyCatalog) errorMessage = tr(STR_NO_ENTRIES);
-  rebuildRowItems();
+    state = (entries.empty() && !searchOnlyCatalog) ? BrowserState::ERROR : BrowserState::BROWSING;
+    if (entries.empty() && !searchOnlyCatalog) errorMessage = tr(STR_NO_ENTRIES);
+    rebuildRowItems();
+  }
   requestUpdate();
 
   // Where the reader lands depends on the catalog's shape, not on a
@@ -780,6 +805,10 @@ void OpdsBookBrowserActivity::rebuildRowItems() {
 }
 
 void OpdsBookBrowserActivity::releaseEntries() {
+  // Same container, same reason as the swap in fetchFeed(): this frees every
+  // string rowItems points into, and a render woken by an earlier
+  // requestUpdate(true) may still be reading them.
+  RenderLock lock(*this);
   // The app's interaction table holds row indices (and hit rects) for the old
   // entries; stop routing touches against it until the next render.
   closeRouting();
@@ -823,7 +852,8 @@ void OpdsBookBrowserActivity::navigateBack() {
     statusMessage = tr(STR_LOADING);
     releaseEntries();
     selectorIndex = 0;
-    requestUpdate();
+    // immediate, like the other five paths into a feed. See #306.
+    requestUpdate(true);
     fetchFeed(currentPath);
   }
 }
@@ -1060,7 +1090,10 @@ void OpdsBookBrowserActivity::checkAndConnectWifi() {
   if (WiFi.status() == WL_CONNECTED && WiFi.localIP() != IPAddress(0, 0, 0, 0)) {
     state = BrowserState::LOADING;
     statusMessage = tr(STR_LOADING);
-    requestUpdate();
+    // immediate. This is the COLD START: onEnter() -> checkAndConnectWifi(),
+    // so the screen left on the panel by a deferred update is the shelf, for
+    // the length of a catalog fetch. #306.
+    requestUpdate(true);
     fetchFeed(currentPath);
     return;
   }

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -33,7 +33,11 @@ void KOReaderAuthActivity::onWifiSelectionComplete(const bool success) {
     state = AUTHENTICATING;
     statusMessage = mode == Mode::SIGN_UP ? tr(STR_CREATING_ACCOUNT) : tr(STR_AUTHENTICATING);
   }
-  requestUpdate();
+  // immediate: performAuthentication() opens TLS and blocks this task, and a
+  // deferred update is only a flag ActivityManager::loop() consumes at a tail
+  // it cannot reach until that returns -- so the AUTHENTICATING screen below
+  // existed, was correct, and never once reached the panel. #306.
+  requestUpdate(true);
 
   performAuthentication();
 }

--- a/src/apps_local/instapaper/InstapaperActivity.cpp
+++ b/src/apps_local/instapaper/InstapaperActivity.cpp
@@ -164,7 +164,40 @@ void InstapaperActivity::showDisconnectConfirm() {
   requestUpdate();
 }
 
+// Busy screen, painted immediately, for a caller that is about to block on a
+// socket in this same call stack. requestUpdate(true) notifies the render task
+// now; the default defers to a flag ActivityManager::loop() consumes at a tail
+// it cannot reach until the blocking call returns, so nothing would repaint at
+// all. The frame RACES the socket rather than being guaranteed ahead of it --
+// rendering is milliseconds and a network call is seconds, so it wins in
+// practice, and losing means the message is late rather than absent.
+//
+// request() above defers on purpose: its work happens on the NEXT loop pass, so
+// that tail IS reached. This is for the callers that block inline. Card #306.
+//
+// A helper because there are TWO of these on the same TLS client one switch
+// branch apart, and the first fix landed only on the one in front of me. See
+// fix-the-twin-too.
+void InstapaperActivity::paintBusyNow(const char* headline) {
+  {
+    RenderLock lock(*this);
+    phase_ = Phase::Busy;
+    busyMessage_ = headline;
+    // Only the download step writes this, and nothing else cleared it, so a
+    // busy screen could carry "3 of 5" left over from a previous download.
+    busyDetail_[0] = '\0';
+    step_ = Step::None;
+  }
+  requestUpdate(true);
+}
+
 void InstapaperActivity::performDisconnect() {
+  // pairAbandon() below is a TLS round trip on a blocking socket, and this
+  // function had no busy state of any kind: the panel held the DISCONNECT
+  // confirm -- the question the reader had just answered -- for the length of
+  // a handshake, which reads as the wipe having hung half way.
+  paintBusyNow("DISCONNECTING");
+
   // Best-effort server revoke, and only if the radio is already up. Possession
   // of the device token is the whole authorization -- POST /api/pair/abandon
   // resolves it to a uid and revokes it with no session -- so this hands the
@@ -235,6 +268,12 @@ void InstapaperActivity::loop() {
         // Walking away from a pairing is worth telling the bridge about: the
         // code stops being claimable, and a registration the confirm screen
         // declined is revoked rather than left as a device nobody holds.
+        //
+        // Painted first for the same reason performDisconnect() is: the same
+        // blocking TLS call on the same client, one switch branch away, and
+        // without it the QR code sits frozen on the glass through the
+        // handshake. #306, and fix-the-twin-too.
+        paintBusyNow("CANCELLING");
         sync_.pairAbandon(pollToken_, pendingToken_);
         pollToken_.clear();
         pendingToken_.clear();

--- a/src/apps_local/instapaper/InstapaperActivity.h
+++ b/src/apps_local/instapaper/InstapaperActivity.h
@@ -96,6 +96,9 @@ class InstapaperActivity final : public Activity {
   // happens only in performDisconnect(), reached by a deliberate press on the
   // confirm's marked control.
   void showDisconnectConfirm();
+  // Busy screen painted immediately, for callers that then BLOCK inline.
+  // request() above defers to the next loop pass instead. Card #306.
+  void paintBusyNow(const char* headline);
   void performDisconnect();
 
   // Epoch seconds, or 0 when the clock has never been set. A progress stamp


### PR DESCRIPTION
Three screens open a network connection on the main task. Until now the panel
kept showing the PREVIOUS screen for the whole transfer, and two cold testers
concluded the device had died (memory `a-silent-screen-reads-as-a-crash`).

**What this does**

- **Get Books, KOReader auth** — paint the busy screen before blocking, by
  passing `true` to `requestUpdate()`. Four words.
- **Instapaper** — gains a busy state it never had, on *both* of its blocking
  `pairAbandon()` calls. The second leaves a QR code frozen on the glass through
  a TLS handshake; it is one switch branch from the first (`fix-the-twin-too`).
- **One narrow lock** covers the two places `fetchFeed()` replaces the container
  the screen model points into.

Five files. **~41 added lines in CrossPoint-owned code**; `ActivityManager.cpp`
is untouched.

## The defect

`Activity::requestUpdate()` defaults to **deferred**: it sets a flag
`ActivityManager::loop()` consumes at its own tail, and that tail cannot be
reached while a blocking call sits in the same call stack. So

```cpp
requestUpdate();
fetchFeed(...);      // never notifies the render task at all
```

The busy state was set, the busy screen existed and was correct, and nothing was
painted. `requestUpdate(true)` calls `xTaskNotify` immediately.

Three OPDS sites needed it — the error screen's retry, `navigateBack`, and
`checkAndConnectWifi`, which is the **cold start**, where the screen left behind
is the shelf. The other three paths into a feed already passed `true`.

## This does not guarantee the frame, and that is the point

The paint **races** the fetch. Rendering is milliseconds, a network call is
seconds, so it wins in practice; if it ever loses, the reader sees the message
slightly late rather than never. The ask was *"tell me it's working"*, not a
guarantee.

An earlier version of this branch used `requestUpdateAndWait()` to make it a
guarantee. That was the wrong trade: the wait opens a synchronous window in
which a render overlaps the fetch, which then needed a handshake change in
`ActivityManager` and a lock on seventeen sites — ~400 lines in upstream-owned
files, and a use-after-free of its own if any of it was wrong.

Where a progress callback already exists it beats all of this anyway.
`downloadBook()` survives an entire transfer because `HttpDownloader`'s
`abortPoll()` (`src/network/HttpDownloader.cpp:85`) invokes the callback **every
50ms — through the connect and the headers**, not just the body — and that
callback both repaints and pumps input. That is why Back works mid-download. It
is untouched here.

## Why the lock is NOT redundant

**Read this before deleting it.** `requestUpdate(true)` **widens** render/fetch
overlap compared with the deferred call it replaces. "Immediate" means the
render task wakes on core 1 while this task continues on core 0 into the
blocking call, so a render is concurrent with the fetch **by construction** —
whereas the deferred call could never run during a blocking call at all. That is
precisely why these writes were safe for years and stopped being safe here. The
paint is not the pure simplification it looks like.

`fetchFeed()` replaces `entries` and rebuilds `rowItems` from it, and
`rowItems`' `ListItems` hold `const char*` **into** `entries[i].title`, which
`buildBrowsingScreen()` reads on the render task. An overlapping render there is
a use-after-free, not a torn frame.

**The measurement that settles it:** `displayBuffer()` blocks **0.3–2s**
(`HalDisplay::HALF_REFRESH` is **1720ms**). A small feed on fast wifi returns
**inside one refresh** — so "the render has long finished by the time the swap
lands" is false on the fast path, not merely unsafe in theory. On a dual-core
part a timing argument is not a safety argument anyway.

Two sites: the swap in `fetchFeed()`, and the same container in
`releaseEntries()`.

## Not fixed here

- **Card #330** — fifteen other unlocked writes in `OpdsBookBrowserActivity`
  that the render task reads. They were unlocked *before* this branch and this
  is not their fix.
- **`InstapaperActivity::request()`** — the deferred `Step` machinery paints on
  the next loop pass, which releases the render task to begin but never waits.
  Stays on #306's weaker tier, with Hacker News, xkcd and Study's SNTP wait.
- **Card #120** — the unpolled TLS connect window, `ensureConnected` with no
  abort hook. That is the systemic freeze; painting makes it *legible*, #120
  makes it *interruptible*.

## Tests

`host-tests/paintfirst/`, **13 checks**, every one watched RED against its own
mutation. Deliberately small: an earlier 32-check version mostly policed a
handshake and a lock that no longer exist, and a check with no subject is worse
than no check.

Kept defeat-proof, because a cold critic broke the previous suite five ways —
a comment containing the call satisfied a grep; a `displayBuffer()` nested in an
`if`, or behind an early `return`, satisfied a presence check; a lock matched by
**spelling** let `auto lock = RenderLock(...)` through; and a lock merely
*above* the write satisfied a scope check. Comments and string literals are now
stripped properly (block comments included), reachability is checked rather than
presence, only declaration forms count as a lock, and scope is brace depth
tracked **character by character** — a lock whose scope opens and closes on one
line nets to zero and used to stay "alive" for the rest of the function, which a
decoy exploited.

## Not verified

**No hardware.** Nobody has watched any of these three screens on a panel. The
overlap reasoning follows from the FreeRTOS notify semantics and the refresh
measurement; no device has run it. The simulator compiles no `lib/hal` and has
no render task, so it sees none of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
