### PR TITLE
site: no Vercel preview per pull request

### DIFF
--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -694,6 +694,24 @@ fi
 grep -q '"outputDirectory"' "$VERCEL" \
   && ok || bad "site/vercel.json declares no outputDirectory; a dashboard override can then skip the build step and the emulator is never fetched"
 
+# Only xteink deploys. Every pull request used to get a preview deployment,
+# and on the free plan a night of ten agents hit the deployment rate limit, so
+# the Vercel check went red on every PR; every agent explained it away, which
+# is how a real red gets ignored. Nobody used the previews. The ignore command
+# is run here as Vercel runs it (exit 0 skips the build, anything else builds),
+# in a repository with and without a change under site/.
+IGN="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["ignoreCommand"])' "$VERCEL")"
+IGNREPO="$(mktemp -d)"; trap 'rm -rf "$IGNREPO"' EXIT; ( cd "$IGNREPO" && git init -q -b xteink && git config user.email t@t && git config user.name t \
+  && echo a > index.html && mkdir -p ../x && git add -A && git commit -qm one && echo b > index.html && git commit -qam two ) >/dev/null 2>&1
+ignore() {  # ref, "changed"|"same" -> prints build|skip
+  local rev=HEAD; [ "$2" = same ] && rev=HEAD^ && ( cd "$IGNREPO" && git commit -q --allow-empty -m empty ) >/dev/null 2>&1
+  ( cd "$IGNREPO" && VERCEL_GIT_COMMIT_REF="$1" sh -c "$IGN" ) >/dev/null 2>&1 && echo skip || echo build
+  [ "$2" = same ] && ( cd "$IGNREPO" && git reset -q --hard HEAD^ ) >/dev/null 2>&1
+}
+[ "$(ignore xteink changed)" = build ] && ok || bad "vercel.json ignoreCommand: xteink with a site change must build"
+[ "$(ignore xteink same)" = skip ] && ok || bad "vercel.json ignoreCommand: xteink with no site change must skip, as before"
+[ "$(ignore app/anything changed)" = skip ] && ok || bad "vercel.json ignoreCommand: a pull request branch must not deploy a preview"
+
 # .vercelignore exists to keep laptop-only tooling off a public URL, and both
 # halves of the fetch look exactly like that. Ignoring either leaves the build
 # unable to find the file it was told to run.

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD ./",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"xteink\" ] || git diff --quiet HEAD^ HEAD ./",
   "buildCommand": "node fetch-emulator.mjs",
   "installCommand": "",
   "outputDirectory": ".",


### PR DESCRIPTION
Every pull request got a Vercel preview deployment, and on the free plan a night of ten agents hit the deployment rate limit, so the Vercel check went red on every PR (Main's friction report, section F). Every agent investigated it and every one wrote a paragraph explaining it away, which trains people to dismiss red checks. Nobody used the previews; the site is looked at on production after the merge.

`vercel.json`'s `ignoreCommand` now builds only on `xteink`, and there only when `site/` changed (as before); every other ref is skipped, so no preview deploy, no rate limit, no red.

Card #339.

**Verified**: `host-tests/site` lifts the command from `vercel.json` and runs it as Vercel does (exit 0 skips, anything else builds) in a repository with and without a change under `site/`: xteink with a change builds, xteink without skips, a branch skips. 203 checks green.

**Confirmed from Vercel's project settings, not the repository** (`vercel api /v9/projects/crossplay`): the git link is github `ma-r-s/crossplay` with `productionBranch = xteink`, root directory `site`, and the dashboard's own Ignored Build Step is empty, so `vercel.json`'s `ignoreCommand` is the only rule and production keeps deploying from xteink pushes as it does today (GitHub records the last five production deployments on xteink commits). Nothing in the tree deploys the site; the git integration does, and this change leaves that path exactly as it was for xteink.

**Not verified**: Vercel's reading of the new command text itself; the next merge to xteink that touches `site/` is the proof (it must deploy), and the next pull request the counter-proof (no Vercel check at all, or a skipped one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
