### PR TITLE
gate: a branch that undoes what trunk recently landed is refused

### DIFF
--- a/docs/workflow/worker-contract.md
+++ b/docs/workflow/worker-contract.md
@@ -63,6 +63,13 @@ are enforced by hooks and will refuse rather than remind.
   host suites green in your tree, pushed, a pull request open, and
   `board state <id> review`. Say in the PR what was not verified. Hardware
   always counts as not verified.
+- **Your diff is the three-dot one.** `git diff origin/xteink...HEAD
+  --name-only` (the merge base) is what your branch changes; the two-dot
+  `git diff origin/xteink` lists everything trunk did since you branched and
+  cried wolf twice in one night. `check.sh --committed` refuses a branch
+  whose commits undo lines trunk landed just before it branched, the shape
+  of a stale tree committed after `git reset --soft`; `CHECK_ALLOW_UNDO=1`
+  only if you mean to revert.
 - **Review means merge on green.** To stop a merge, move the card first
   (`board state <id> working`, or a blocker) and only then say why: the
   orchestrator merges from cards, and a message reaches it after its

--- a/host-tests/checksh/run.sh
+++ b/host-tests/checksh/run.sh
@@ -1947,5 +1947,50 @@ else
   fi
 fi
 
+
+# --- the undo guard: a branch that undoes what trunk recently landed ---------
+#
+# The block is lifted between its own markers and run in a fixture repository
+# with a trunk of sixty-line commits and refs/remotes/origin/xteink pointing at
+# its tip. Fires on a stale tree committed on top of the moved trunk; stays
+# silent on an ordinary branch, on a branch deleting its own additions, and
+# when CHECK_ALLOW_UNDO says the revert is meant.
+python3 - "$CHECK" >"$WORK/undo.sh" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+a = next(i for i, l in enumerate(lines) if 'undo guard begin' in l)
+b = next(i for i, l in enumerate(lines) if 'undo guard end' in l)
+print('\n'.join(lines[a + 1:b]))
+PY
+[ -s "$WORK/undo.sh" ] || { echo "FAIL checksh  could not lift the undo guard out of check.sh"; failed=$((failed + 1)); }
+grep -q 'die$' "$WORK/undo.sh" || { echo "FAIL checksh  the undo guard no longer calls die, so it cannot refuse"; failed=$((failed + 1)); }
+
+undo_repo() {  # builds $WORK/undo with trunk T (base + 3 commits x 30 lines) and origin/xteink = T
+  rm -rf "$WORK/undo"; mkdir -p "$WORK/undo"
+  ( cd "$WORK/undo" && git init -q -b xteink && git config user.email t@t && git config user.name t
+    seq 1 5 | sed 's/^/base line number /' > a.txt && git add -A && git commit -qm base && git tag base
+    for f in f1 f2 f3; do seq 1 30 | sed "s/^/trunk $f added this distinctive line /" > "$f.txt"; git add -A; git commit -qm "add $f"; done
+    git update-ref refs/remotes/origin/xteink HEAD )
+}
+undo_run() {  # echoes fired|silent for HEAD of $WORK/undo; die leaves a marker, since the block's own output is captured
+  rm -f "$WORK/undo.fired"
+  ( cd "$WORK/undo" && die() { : >"$WORK/undo.fired"; exit 0; } && . "$WORK/undo.sh" >"$WORK/undo.out" 2>&1 )
+  [ -e "$WORK/undo.fired" ] && echo fired || echo silent
+}
+undo_expect() {  # label, fired|silent
+  local got; got="$(undo_run)"
+  checks=$((checks + 1))
+  if [ "$got" != "$2" ]; then failed=$((failed + 1)); echo "FAIL checksh  undo guard: $1: got $got, wanted $2"; sed 's/^/       /' "$WORK/undo.out"; fi
+}
+undo_repo; ( cd "$WORK/undo" && git checkout -q -b app/ok && echo "my own new file" > mine.txt && git add -A && git commit -qm mine )
+undo_expect "an ordinary branch on top of trunk is silent" silent
+undo_repo; ( cd "$WORK/undo" && git checkout -q -b app/stale && git read-tree base && git commit -qm "stale tree committed on the moved trunk" >/dev/null )
+undo_expect "a stale tree committed on the moved trunk fires" fired
+grep -q 'f1.txt (-30)' "$WORK/undo.out" && checks=$((checks + 1)) || { checks=$((checks + 1)); failed=$((failed + 1)); echo "FAIL checksh  undo guard: the refusal does not name the undone files"; }
+rm -f "$WORK/undo.fired"; ( cd "$WORK/undo" && export CHECK_ALLOW_UNDO=1 && die() { : >"$WORK/undo.fired"; exit 0; } && . "$WORK/undo.sh" >"$WORK/undo.out" 2>&1 )
+[ ! -e "$WORK/undo.fired" ] && checks=$((checks + 1)) || { checks=$((checks + 1)); failed=$((failed + 1)); echo "FAIL checksh  undo guard: CHECK_ALLOW_UNDO=1 did not let a meant revert through"; }
+undo_repo; ( cd "$WORK/undo" && git checkout -q -b app/own && seq 1 80 | sed 's/^/my branch added this line and took it back /' > tmp.txt && git add -A && git commit -qm add && git rm -q tmp.txt && git commit -qm remove )
+undo_expect "a branch deleting its own additions is silent" silent
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -191,6 +191,32 @@ if [ "$_committed" = "1" ]; then
   if ! git fetch --quiet origin 2>/dev/null; then
     echo "  could not fetch origin; staleness below is measured against the ref as it stands"
   fi
+  # --- undo guard begin ---
+  # A branch that UNDOES trunk. Built with `git reset --soft` after trunk had
+  # moved, one branch committed its stale tree on top of the new trunk: 1190
+  # deletions, four merged pull requests gone, a live Supabase migration among
+  # them (2026-09-05) -- and its gate PASSED, because every suite that would
+  # have failed was deleted in the same commit. A green gate is not evidence
+  # when the diff can delete the tests. So: the lines this branch removes
+  # against its merge base, intersected with the lines trunk added in the
+  # sixty commits before that base. A handful is editing; dozens is a revert
+  # nobody asked for. CHECK_ALLOW_UNDO=1 says you mean it.
+  undo_base="$(git merge-base HEAD origin/xteink 2>/dev/null || true)"
+  if [ -n "$undo_base" ] && [ -z "${CHECK_ALLOW_UNDO:-}" ]; then
+    undo_from="$(git rev-parse --verify --quiet "$undo_base~60" || git rev-list --max-parents=0 "$undo_base" | tail -1)"
+    undone="$(comm -12 \
+      <(git diff "$undo_from" "$undo_base" -- . ':!site/emulator' | grep '^+[^+]' | cut -c2- | awk 'length($0) >= 12' | sort -u) \
+      <(git diff "$undo_base" HEAD -- . ':!site/emulator' | grep '^-[^-]' | cut -c2- | awk 'length($0) >= 12' | sort -u) | grep -c . || true)"
+    if [ "${undone:-0}" -ge 40 ]; then
+      echo "  this branch UNDOES trunk: $undone lines that landed on xteink shortly before it branched are removed by its own commits."
+      echo "  That is the shape of a stale tree committed on top of a moved trunk (git reset --soft, then commit), and a green"
+      echo "  gate here would prove nothing: the suites that would fail are among the deletions. Most undone, by file:"
+      git diff "$undo_base" HEAD --numstat -- . ':!site/emulator' | sort -k2 -rn | head -5 | awk '{printf "    %s (-%s)\n", $3, $2}'
+      echo "  Rebuild the branch on origin/xteink (git rebase, or cherry-pick your commits onto it). CHECK_ALLOW_UNDO=1 if you mean to revert."
+      die
+    fi
+  fi
+  # --- undo guard end ---
   # Unique paths mean a run killed hard (kill -9 skips the trap below) leaves
   # an orphan that no later run would inherit, so sweep siblings whose owning
   # process is gone: ~600MB each, and a half-populated worktree is a state


### PR DESCRIPTION
**Against the real failure, not a fixture** (run by Main on commit `55e258fa`, the branch that silently reverted #116 through #119 last night): merge base `0bdd2b8a`, sixty commits back `a731204a`, **926 undone lines against a threshold of 40**; the files named are exactly the four pull requests being undone (board.py -159, instapaper/test_index.cpp -155, bugflow/run.sh -104, ui/test_ui.cpp -86, logsweep/run.sh -84). That branch's own gate passed, because every suite that would have failed was among the deletions.

Main's friction report, section C: a branch built with `git reset --soft` after trunk had moved committed its stale tree on top of the new trunk, 1190 deletions, four merged pull requests undone (a live Supabase migration among them), and its gate **passed**, because every suite that would have failed was deleted in the same commit. A green gate is not evidence when the diff can delete the tests.

`check.sh --committed` now intersects the lines the branch removes (against its merge base) with the lines trunk added in the sixty commits before that base. Forty or more is a revert nobody asked for: refused, with the most-undone files named and the remedy (rebase onto origin/xteink, or `CHECK_ALLOW_UNDO=1` when the revert is meant). The worker contract gets the three-dot diff, `origin/xteink...HEAD`; the two-dot form agents were handed lists everything trunk did since they branched and cried wolf twice.

Card #340.

**Verified**: `host-tests/checksh` lifts the block between its markers and runs it on a fixture trunk (base plus three thirty-line commits, `origin/xteink` at the tip): an ordinary branch is silent, the stale tree fires and names f1/f2/f3 with -30 each, `CHECK_ALLOW_UNDO=1` lets it through, a branch deleting its own eighty added lines is silent. 140 checks green.

**Not verified**: the threshold (40 lines, 60 trunk commits) is a first setting; a legitimate large revert must say `CHECK_ALLOW_UNDO=1`, and a very old branch (more than sixty trunk commits behind) that reverts is not caught by this window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
