### PR TITLE
gate: a test file its suite never runs is a failure, not a green

### DIFF
--- a/host-tests/checksh/run.sh
+++ b/host-tests/checksh/run.sh
@@ -1947,5 +1947,30 @@ else
   fi
 fi
 
+
+# --- a test file its suite never runs -----------------------------------------
+#
+# The block that lists test files run.sh never names is lifted between its
+# markers and run against fixture suite directories: one that names every file,
+# one that forgot a file, one that globs test_* and therefore runs whatever is
+# there.
+python3 - "$CHECK" >"$WORK/unrun.sh" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+a = next(i for i, l in enumerate(lines) if 'unrun test files begin' in l)
+b = next(i for i, l in enumerate(lines) if 'unrun test files end' in l)
+print('\n'.join(lines[a + 1:b]))
+PY
+[ -s "$WORK/unrun.sh" ] || { echo "FAIL checksh  could not lift the unrun-test-file block out of check.sh"; failed=$((failed + 1)); }
+unrun_case() {  # label, run.sh body, wanted unrun value (space-led names, or empty)
+  local d="$WORK/suite"; rm -rf "$d"; mkdir -p "$d"; printf '%s\n' "$2" >"$d/run.sh"; : >"$d/test_a.py"; : >"$d/test_b.cpp"
+  local got; got="$(suite="$d" bash -c '. "'"$WORK"'/unrun.sh"; printf "%s" "$unrun"')"
+  checks=$((checks + 1))
+  if [ "$got" != "$3" ]; then failed=$((failed + 1)); echo "FAIL checksh  unrun test files: $1: got '$got', wanted '$3'"; fi
+}
+unrun_case "every test file named is clean"            'python3 test_a.py && g++ test_b.cpp -o t && ./t' ""
+unrun_case "a file run.sh never names is reported"     'python3 test_a.py' " test_b.cpp"
+unrun_case "a run.sh that globs test_* runs everything" 'for f in test_*.py; do python3 "$f"; done; for c in test_*.cpp; do g++ "$c"; done' ""
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -579,10 +579,26 @@ for suite in host-tests/*/; do
   "$suite/run.sh" > "$SUITE_LOG" 2>&1
   code=$?
   passed=$(grep -c "checks, 0 failed" "$SUITE_LOG" || true)
+  # --- unrun test files begin ---
+  # A test file the suite's run.sh never invokes reports the same green as one
+  # that passes: a third sub-suite once landed and this line said "ok (2
+  # sub-suite(s))". Every test_*.cpp and test_*.py in the directory must be
+  # named in run.sh, unless run.sh globs test_* and so runs whatever is there.
+  unrun=""
+  if ! grep -q 'test_\*' "$suite/run.sh"; then
+    for tf in "$suite"/test_*.cpp "$suite"/test_*.py; do
+      [ -e "$tf" ] || continue
+      grep -qF -- "$(basename "$tf")" "$suite/run.sh" || unrun="$unrun $(basename "$tf")"
+    done
+  fi
+  # --- unrun test files end ---
   if [ "$code" -ne 0 ]; then
     printf "  %-12s FAILED (exit %d, %s)\n" "$name" "$code" "$(since $T0)"
     grep -E "FAIL|error:" "$SUITE_LOG" | head -5 | sed 's/^/      /'
     infra_fault_note "$name" "$T0" "$SUITE_LOG"
+    FAILED=1
+  elif [ -n "$unrun" ]; then
+    printf "  %-12s FAILED: in the directory but never run by run.sh:%s (%s)\n" "$name" "$unrun" "$(since $T0)"
     FAILED=1
   else
     printf "  %-12s ok (%s sub-suite(s), %s)\n" "$name" "$passed" "$(since $T0)"


### PR DESCRIPTION
An agent added a third sub-suite to a host suite and the gate said `trivia ok (2 sub-suite(s))` (Main's friction report, section F): a test file `run.sh` never invokes reports the same green as one that passes, and nothing compared the directory with what ran.

The suite loop now lists every `test_*.cpp` and `test_*.py` in the suite directory and fails the suite when `run.sh` names none of them, naming the file; a `run.sh` that globs `test_*` runs whatever is there and is exempt. Zero hits on xteink today, so it lands green and fires on the next forgotten file.

Card #341. Touches the same two files as #129 (different regions); merge either first and the other rebases clean.

**Verified**: `host-tests/checksh` lifts the block between its markers and runs it on three fixture suites: every file named is clean, a forgotten file is reported by name, a globbing `run.sh` is clean. 138 checks green.

**Not verified**: suites whose sub-suites are not named `test_*` (none today) stay outside this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)