### PR TITLE
board: two open pull requests that touch one file are named before either merges

### DIFF
--- a/docs/workflow/orchestrator.md
+++ b/docs/workflow/orchestrator.md
@@ -45,6 +45,10 @@ answers>'`. Never forward a worker's wording; write the three lines
    cap are `working`: start a worker with the card, the contract, and the
    app's doc. One worker per app at a time.
 5. **Land.** Merges are pull requests; you hold the integration claim (`board
+   Before a batch, `python3 tools_local/board/overlap.py`: two open pull
+   requests that touch one file are each green alone and can be wrong
+   together, and the bug would bisect to whichever landed second. Merge one,
+   re-verify the other on the result, then merge it.
 integrator --session <your id>`) only while you resolve a conflict or
    rebuild the emulator, and release it after. **After every merge, pull:**
    `git -C firmware-next pull --ff-only origin xteink` under the claim. The

--- a/host-tests/bugflow/fixtures/prs.json
+++ b/host-tests/bugflow/fixtures/prs.json
@@ -1,0 +1,5 @@
+[
+  {"number": 10, "title": "render: draw off the main task", "headRefName": "app/render", "files": [{"path": "src/apps_local/link/LinkPlay.cpp"}, {"path": "src/render/Task.cpp"}, {"path": "site/emulator/crossplay.wasm"}]},
+  {"number": 11, "title": "browser: read the title while rendering", "headRefName": "app/browser", "files": [{"path": "src/apps_local/link/LinkPlay.cpp"}, {"path": "src/activities/browser/Opds.cpp"}, {"path": "site/emulator/crossplay.wasm"}]},
+  {"number": 12, "title": "docs: a paragraph", "headRefName": "app/docs", "files": [{"path": "docs/workflow/README.md"}]}
+]

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -105,6 +105,17 @@ expect "orchestrator to anyone allowed"         0 pretool "{\"session_id\":\"$OR
 expect "worker asking Mario refused"            2 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"board ask 3 --ask 'ship?' --default hold\"}}"
 expect "orchestrator asking Mario allowed"      0 pretool "{\"session_id\":\"$ORCH\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"board ask 3 --ask 'ship?' --default hold\"}}"
 
+echo "two open pull requests that touch one file"
+OVERLAP="$ROOT/tools_local/board/overlap.py"
+[ -f "$OVERLAP" ] || OVERLAP="$(dirname "$BOARD")/overlap.py"
+python3 "$OVERLAP" --from-json "$HERE/fixtures/prs.json" >"$WORK/overlap.out" 2>&1
+grep -q "#10 (app/render) and #11 (app/browser) both touch:" "$WORK/overlap.out" && ok "the overlapping pair is named with its branches" || bad "overlap: pair not named: $(cat "$WORK/overlap.out")"
+grep -q "    src/apps_local/link/LinkPlay.cpp" "$WORK/overlap.out" && ok "and the shared file" || bad "overlap: shared file missing"
+grep -q "crossplay.wasm" "$WORK/overlap.out" && bad "overlap: CI's emulator artefact counted as a shared file" || ok "the emulator artefact both carry is not an overlap"
+grep -q "#12" "$WORK/overlap.out" && bad "overlap: a pull request sharing nothing was named" || ok "a pull request sharing nothing is not named"
+grep -q "1 overlapping pair(s) among 3 open" "$WORK/overlap.out" && ok "the count is right" || bad "overlap: count line wrong: $(tail -1 "$WORK/overlap.out")"
+printf '[]' >"$WORK/none.json"; python3 "$OVERLAP" --from-json "$WORK/none.json" | grep -q "no two touch the same file" && ok "no pull requests is said plainly" || bad "overlap: empty input not handled"
+
 echo "ending a turn"
 T="$WORK/transcript.jsonl"
 mk_transcript() { # mk_transcript "<last assistant text>"

--- a/tools_local/board/overlap.py
+++ b/tools_local/board/overlap.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Open pull requests that touch the same file, named before either merges.
+
+Two pull requests from different sessions once touched one file: one made
+concurrent renders the norm, the other added render-side readers of exactly
+the strings that made unsafe. Each was correct and green alone; the bug would
+have looked intermittent and bisected to whichever landed second. Nothing in
+the tooling said "these two open branches interact". This does, mechanically:
+for every pair of open pull requests sharing a file, the pair and the files.
+
+    tools_local/board/overlap.py                 asks gh for the open PRs
+    tools_local/board/overlap.py --from-json F   reads gh's JSON from a file
+
+Exit 0 always; the output is the point. Paths under site/emulator/ (CI's own
+rebuilt artefact) are ignored.
+"""
+import argparse
+import itertools
+import json
+import subprocess
+import sys
+
+REPO = "ma-r-s/crossplay"
+IGNORE_PREFIXES = ("site/emulator/",)
+
+
+def open_prs(from_json=None):
+    if from_json:
+        return json.load(open(from_json))
+    out = subprocess.run(
+        ["gh", "pr", "list", "-R", REPO, "--state", "open", "--limit", "100",
+         "--json", "number,title,headRefName,files"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return json.loads(out or "[]")
+
+
+def overlaps(prs):
+    """[(a, b, [paths])] for every pair of PRs sharing a file, paths sorted."""
+    files = {}
+    for pr in prs:
+        files[pr["number"]] = {
+            f["path"] for f in pr.get("files") or [] if not f["path"].startswith(IGNORE_PREFIXES)
+        }
+    by_num = {pr["number"]: pr for pr in prs}
+    out = []
+    for a, b in itertools.combinations(sorted(files), 2):
+        shared = sorted(files[a] & files[b])
+        if shared:
+            out.append((by_num[a], by_num[b], shared))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--from-json", help="gh pr list --json number,title,headRefName,files, saved to a file")
+    a = ap.parse_args()
+    prs = open_prs(a.from_json)
+    pairs = overlaps(prs)
+    if not pairs:
+        print(f"{len(prs)} open pull request(s), no two touch the same file")
+        return 0
+    for x, y, shared in pairs:
+        print(f"#{x['number']} ({x['headRefName']}) and #{y['number']} ({y['headRefName']}) both touch:")
+        for p in shared:
+            print(f"    {p}")
+    print(f"{len(pairs)} overlapping pair(s) among {len(prs)} open pull request(s); merge one, then re-verify the other on the result")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Main's friction report, section C: two pull requests from different sessions touched one file; one made concurrent renders the norm, the other added render-side readers of exactly the strings that made unsafe. Each was correct and green alone, and the bug would have bisected to whichever landed second. Nothing said "these two open branches interact".

`tools_local/board/overlap.py` lists, for the open pull requests, every pair sharing a file and the files (CI's rebuilt emulator artefact excluded); `--from-json` takes `gh`'s output for the test. The orchestrator's landing step (docs/workflow/orchestrator.md, step 5) runs it before a batch: merge one, re-verify the other on the result, then merge it.

Card #342.

**Verified**: `host-tests/bugflow` drives it on a fixture of three pull requests: the overlapping pair named with its branches and the shared file, the emulator artefact not counted, the unrelated pull request not named, the count line, the empty input. 157 checks green. Live, right now, it names #129 and #130 (both touch `scripts_local/check.sh` and `host-tests/checksh/run.sh`), which is true and intended.

**Not verified**: it reads file lists from `gh`, so a pull request GitHub has not finished computing files for can show fewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)