### PR TITLE
Wallpapers: six fixes from the first hardware runs

### DIFF
--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -207,18 +207,19 @@ int main() {
   {
     const int total = static_cast<int>(wallpapers::kBuiltInCount);
     int previous = -1;
-    for (int phase = 0; phase < 2; ++phase) {
+    const int phases = 3;  // fetch, unpack, thumbnails
+    for (int phase = 0; phase < phases; ++phase) {
       for (int done = 0; done <= total; ++done) {
         wallpapersui::FetchingModel m;
         m.total = total;
         m.done = done;
-        m.unpacking = phase == 1;
+        m.phase = phase;
+        m.phaseCount = phases;
         const wallpapersui::BarSpan span = wallpapersui::fetchBarSpan(m);
-        const std::string at =
-            " (" + std::string(m.unpacking ? "unpack" : "download") + " " + std::to_string(done) + ")";
+        const std::string at = " (phase " + std::to_string(phase) + " at " + std::to_string(done) + ")";
         check(span.at >= previous, "the progress bar went BACKWARDS" + at);
         check(span.at <= span.units, "the progress bar overran its track" + at);
-        check(span.units == total * 2, "the bar does not span both phases" + at);
+        check(span.units == total * phases, "the bar does not span every phase" + at);
         previous = span.at;
       }
     }
@@ -226,9 +227,10 @@ int main() {
     wallpapersui::FetchingModel done{};
     done.total = total;
     done.done = total;
-    done.unpacking = true;
+    done.phase = phases - 1;
+    done.phaseCount = phases;
     const wallpapersui::BarSpan end = wallpapersui::fetchBarSpan(done);
-    check(end.at == end.units, "the bar does not reach full when the unpack finishes");
+    check(end.at == end.units, "the bar does not reach full when the last phase finishes");
   }
 
   // The margin left, stated rather than implied: the next name added has this

--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -196,6 +196,41 @@ int main() {
     check(target.widthOf(fui::FONT_SLOT_SMALL, add) <= cap.width, "add-tile label overflows its box" + at);
   }
 
+  // 5. The progress bar never goes backwards.
+  //
+  // On hardware the bar filled 0->100, RESET, and filled again, which reads as
+  // the download restarting. The cause was two real phases (fetch, then unpack)
+  // each driving the same widget over its own full range. This walks the entire
+  // sequence the device produces and asserts the fill is monotonic and bounded
+  // -- the property that was violated, expressed as arithmetic so it can be
+  // checked without a panel, since the panel is the only place it was visible.
+  {
+    const int total = static_cast<int>(wallpapers::kBuiltInCount);
+    int previous = -1;
+    for (int phase = 0; phase < 2; ++phase) {
+      for (int done = 0; done <= total; ++done) {
+        wallpapersui::FetchingModel m;
+        m.total = total;
+        m.done = done;
+        m.unpacking = phase == 1;
+        const wallpapersui::BarSpan span = wallpapersui::fetchBarSpan(m);
+        const std::string at =
+            " (" + std::string(m.unpacking ? "unpack" : "download") + " " + std::to_string(done) + ")";
+        check(span.at >= previous, "the progress bar went BACKWARDS" + at);
+        check(span.at <= span.units, "the progress bar overran its track" + at);
+        check(span.units == total * 2, "the bar does not span both phases" + at);
+        previous = span.at;
+      }
+    }
+    // And it actually reaches the end, rather than stopping at half.
+    wallpapersui::FetchingModel done{};
+    done.total = total;
+    done.done = total;
+    done.unpacking = true;
+    const wallpapersui::BarSpan end = wallpapersui::fetchBarSpan(done);
+    check(end.at == end.units, "the bar does not reach full when the unpack finishes");
+  }
+
   // The margin left, stated rather than implied: the next name added has this
   // much room before the fallback to the short form kicks in.
   // 4. User uploads. These have no entry in the built-in table, so the caption

--- a/host-tests/wallpapers/test_wallpapers.cpp
+++ b/host-tests/wallpapers/test_wallpapers.cpp
@@ -3,10 +3,12 @@
 // the app warns before the card fills. Both are freestanding, so a laptop
 // proves them with no device and no SD card.
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "../../src/apps_local/wallpapers/WallpapersCore.h"
 
@@ -128,6 +130,29 @@ int main() {
   testFileNameFilter();
   testDisplayNames();
   testRoomFor();
+
+  // Uploads first, then built-ins, each alphabetical. Mario's ask, and the
+  // ordering the picker's captions are indexed by -- get it wrong and every
+  // caption names someone else's picture.
+  {
+    CHECK(wallpapers::isBuiltInFile("bauhaus.bmp"));
+    CHECK(wallpapers::isBuiltInFile("durer-horsemen.bmp"));
+    CHECK(!wallpapers::isBuiltInFile("holiday.bmp"));
+    CHECK(!wallpapers::isBuiltInFile("bauhaus-of-mine.bmp"));  // not the same stem
+
+    std::vector<std::string> names = {"waves.bmp", "holiday.bmp", "bauhaus.bmp", "zebra.bmp", "celestial.bmp"};
+    std::sort(names.begin(), names.end(),
+              [](const std::string& a, const std::string& b) { return wallpapers::sortsBefore(a, b); });
+    const std::vector<std::string> want = {"holiday.bmp", "zebra.bmp", "bauhaus.bmp", "celestial.bmp", "waves.bmp"};
+    CHECK(names == want);
+    // The comparator must be a strict weak ordering or std::sort is UB.
+    for (const std::string& a : want) {
+      CHECK(!wallpapers::sortsBefore(a, a));
+      for (const std::string& b : want) {
+        if (wallpapers::sortsBefore(a, b)) CHECK(!wallpapers::sortsBefore(b, a));
+      }
+    }
+  }
 
   std::printf("wallpapers: %d checks, %d failed\n", checksRun, checksFailed);
   return checksFailed == 0 ? 0 : 1;

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -26,6 +26,48 @@ namespace {
 constexpr int kMaxLibrary = 256;
 constexpr size_t kNameMax = 128;
 constexpr size_t kCopyChunk = 4096;
+
+// ---------------------------------------------------------------------------
+// The thumbnail cache.
+//
+// A thumbnail is a full 480x800 1-bit BMP read off the card and box-downscaled
+// (the renderer's 1-bit blit cannot scale). cachedPage_ resets on every
+// onEnter, so before this the app re-did that work on EVERY open and on every
+// page turn -- harmless on an empty card, and the whole cost once 21 wallpapers
+// are on it.
+//
+// Cached per wallpaper, not per set, so one changed or deleted file invalidates
+// its own thumb and nothing else. The key is the source's SIZE plus a sample of
+// its bytes plus the cell size: every device wallpaper is exactly 48062 bytes,
+// so size alone cannot see a replaced file, and a cell-size change (the hint
+// gap moved it) must invalidate everything. The sample is three 64-byte reads
+// rather than a full hash, because hashing the whole file would cost what the
+// decode costs and save nothing.
+constexpr char kThumbDir[] = "/wallpapers/.thumbs";
+constexpr uint32_t kThumbMagic = 0x31485457;  // "WTH1"
+
+struct ThumbHeader {
+  uint32_t magic;
+  uint32_t sourceBytes;
+  uint32_t sampleHash;
+  int16_t cellW, cellH, w, h, ox, oy;
+};
+
+uint32_t sampleHashOf(HalFile& f, const uint64_t size) {
+  uint32_t h = 2166136261u;
+  const uint64_t offsets[3] = {62, size / 2, size > 128 ? size - 128 : 0};
+  uint8_t buf[64];
+  for (const uint64_t off : offsets) {
+    if (!f.seekSet(static_cast<size_t>(off))) continue;
+    const int got = f.read(buf, sizeof(buf));
+    for (int i = 0; i < got; ++i) {
+      h ^= buf[i];
+      h *= 16777619u;
+    }
+  }
+  return h;
+}
+
 // The selection marker's dimensions live in WallpapersScreens.cpp beside
 // kMarkerRoom, the clearance they have to fit inside.
 
@@ -108,14 +150,15 @@ void WallpapersActivity::scanLibrary() {
     names_.emplace_back(name.get());
     if (static_cast<int>(names_.size()) >= kMaxLibrary) break;
   }
-  std::sort(names_.begin(), names_.end());
+  // A user's own wallpapers first, then the built-ins. NOT a plain sort any
+  // more, so the built-in count below counts rather than binary_searching -- a
+  // binary_search over this order would silently return wrong answers.
+  std::sort(names_.begin(), names_.end(),
+            [](const std::string& a, const std::string& b) { return wallpapers::sortsBefore(a, b); });
 
-  // How much of the built-in set is here, counted from the listing we already
-  // walked rather than with 21 more exists() calls on every scan.
   int have = 0;
-  for (size_t i = 0; i < wallpapers::builtInCount(); ++i) {
-    const std::string want = std::string(wallpapers::builtInStem(i)) + ".bmp";
-    if (std::binary_search(names_.begin(), names_.end(), want)) ++have;
+  for (const std::string& n : names_) {
+    if (wallpapers::isBuiltInFile(n)) ++have;
   }
   builtInsMissing_ = static_cast<int>(wallpapers::builtInCount()) - have;
 }
@@ -241,6 +284,28 @@ bool WallpapersActivity::setWallpaper(int index) {
     return false;
   }
 
+  // Taking a QUICK_RESUME user off that mode is the ONE thing this app does
+  // that changes the whole device rather than its own screen, and it is the only
+  // wallpaper code anywhere near the boot path -- nothing of ours executes at
+  // wake at all.
+  //
+  // main.cpp::enterDeepSleep saves a retained frame ONLY when the sleep is a
+  // quick-resume sleep, and the wake branch that restores it is also the branch
+  // that draws the LoadingIcon. Flipping the mode to CUSTOM therefore cost two
+  // things at once: the fast frame restore, and the only sign of life the user
+  // gets while the device boots (wake is a chip reset). A decorative feature
+  // must not buy itself a slower wake for the whole device.
+  //
+  // quickResumeSleepScreen is left ON so timeout sleeps -- the common case, and
+  // the one Mario was waiting on -- keep the fast path and the icon. The
+  // combination is supported: SettingsActivity::syncQuickResumeTimeoutForSleepScreen
+  // preserves an explicitly-enabled timeout flag across a sleep-screen change.
+  // The trade is that the wallpaper then shows on manual sleeps rather than on
+  // timeout ones.
+  if (SETTINGS.sleepScreen == CrossPointSettings::QUICK_RESUME) {
+    SETTINGS.quickResumeSleepScreen = CrossPointSettings::QUICK_RESUME_AFTER_TIMEOUT;
+    LOG_INF("WALL", "was QUICK_RESUME; keeping quick wake on timeout sleeps so wake does not get slower");
+  }
   SETTINGS.sleepScreen = CrossPointSettings::CUSTOM;
   SETTINGS.saveToFile();
 
@@ -329,6 +394,8 @@ void WallpapersActivity::ensureThumbsForPage() {
   const wallpapersui::GridGeom geom = wallpapersui::gridGeom(toybox::makeTarget(renderer).deviceContext());
   if (cachedPage_ == page_ && cachedPerPage_ == geom.perPage && !thumbs_.empty()) return;
 
+  const uint32_t tThumbs = millis();
+  int decoded = 0;
   thumbs_.assign(static_cast<size_t>(geom.perPage), Thumb{});
   const int base = page_ * geom.perPage;
   // specialTiles(), not a literal 1: the decode and the draw must agree about
@@ -341,10 +408,109 @@ void WallpapersActivity::ensureThumbsForPage() {
     const int idx = combined - specials;
     if (idx >= static_cast<int>(names_.size())) break;
     std::string path = std::string(wallpapers::kLibraryDir) + "/" + names_[static_cast<size_t>(idx)];
-    thumbs_[static_cast<size_t>(slot)] = decodeThumb(path, geom.cellW, geom.cellH);
+    thumbs_[static_cast<size_t>(slot)] =
+        thumbFor(names_[static_cast<size_t>(idx)], path, geom.cellW, geom.cellH, &decoded);
   }
+  LOG_INF("WALL", "thumbs page=%d decoded=%d (rest from cache) in %ums", page_, decoded, millis() - tThumbs);
   cachedPage_ = page_;
   cachedPerPage_ = geom.perPage;
+}
+
+// Cache hit or a decode plus a write. `decoded` counts only the real decodes so
+// the log says which of the two happened.
+WallpapersActivity::Thumb WallpapersActivity::thumbFor(const std::string& name, const std::string& path,
+                                                       const int16_t cellW, const int16_t cellH, int* decoded) {
+  uint64_t sourceBytes = 0;
+  uint32_t sample = 0;
+  {
+    HalFile src;
+    if (Storage.openFileForRead("WALL", path, src)) {
+      sourceBytes = static_cast<uint64_t>(src.size());
+      sample = sampleHashOf(src, sourceBytes);
+      src.close();
+    }
+  }
+
+  const std::string cachePath = std::string(kThumbDir) + "/" + name + ".thb";
+  HalFile cf;
+  if (Storage.openFileForRead("WALL", cachePath, cf)) {
+    ThumbHeader head{};
+    if (cf.read(&head, sizeof(head)) == static_cast<int>(sizeof(head)) && head.magic == kThumbMagic &&
+        head.sourceBytes == sourceBytes && head.sampleHash == sample && head.cellW == cellW && head.cellH == cellH &&
+        head.w > 0 && head.h > 0) {
+      Thumb t;
+      t.w = head.w;
+      t.h = head.h;
+      t.ox = head.ox;
+      t.oy = head.oy;
+      const size_t bytes = static_cast<size_t>((head.w + 7) / 8) * static_cast<size_t>(head.h);
+      t.bits.resize(bytes);
+      if (cf.read(t.bits.data(), bytes) == static_cast<int>(bytes)) {
+        t.ok = true;
+        cf.close();
+        return t;
+      }
+    }
+    cf.close();
+  }
+
+  if (decoded != nullptr) ++(*decoded);
+  Thumb t = decodeThumb(path, cellW, cellH);
+  if (!t.ok) return t;
+
+  // Best effort: a cache that cannot be written must never break the picture.
+  if (!Storage.exists(kThumbDir)) Storage.mkdir(kThumbDir);
+  const std::string part = cachePath + ".part";
+  HalFile out;
+  if (Storage.openFileForWrite("WALL", part, out)) {
+    ThumbHeader head{};
+    head.magic = kThumbMagic;
+    head.sourceBytes = static_cast<uint32_t>(sourceBytes);
+    head.sampleHash = sample;
+    head.cellW = cellW;
+    head.cellH = cellH;
+    head.w = t.w;
+    head.h = t.h;
+    head.ox = t.ox;
+    head.oy = t.oy;
+    const bool wrote =
+        out.write(&head, sizeof(head)) == sizeof(head) && out.write(t.bits.data(), t.bits.size()) == t.bits.size();
+    out.close();
+    if (wrote) {
+      Storage.remove(cachePath.c_str());
+      if (!Storage.rename(part.c_str(), cachePath.c_str())) Storage.remove(part.c_str());
+    } else {
+      Storage.remove(part.c_str());
+    }
+  }
+  return t;
+}
+
+// Build every thumbnail now, while the user is already watching a progress bar
+// and expects to wait. Without this the cost merely MOVES to the first open,
+// which is the screen that has to feel instant. Cancelling is honoured: a
+// half-warmed cache is not wrong, only less warm, and the rest fills in lazily.
+void WallpapersActivity::prewarmThumbs() {
+  const wallpapersui::GridGeom geom = wallpapersui::gridGeom(toybox::makeTarget(renderer).deviceContext());
+  fetchPhase_ = 2;
+  fetchDone_ = 0;
+  fetchTotal_ = static_cast<int>(names_.size());
+  const uint32_t t0 = millis();
+  int built = 0;
+  for (size_t i = 0; i < names_.size(); ++i) {
+    if (fetchCancel_) break;
+    const std::string path = std::string(wallpapers::kLibraryDir) + "/" + names_[i];
+    thumbFor(names_[i], path, geom.cellW, geom.cellH, &built);
+    fetchDone_ = static_cast<int>(i) + 1;
+    if ((i % 5) == 0 || i + 1 == names_.size()) {
+      mappedInput.update();
+      if (mappedInput.wasReleased(MappedInputManager::Button::Back)) fetchCancel_ = true;
+      requestUpdateAndWait();
+    }
+  }
+  LOG_INF("WALL", "prewarmed %d thumbnails in %ums", built, millis() - t0);
+  // The grid's own cache is per-page and still cold; let it re-read from disk.
+  cachedPage_ = -1;
 }
 
 void WallpapersActivity::drawGrid(const wallpapersui::GridGeom& geom) {
@@ -527,6 +693,7 @@ constexpr const char* kPackPart = "/wallpapers.dat.part";
 // The HAL exposes a size only through an open file, and the difference between
 // "absent" and "there but the wrong length" is the whole resume rule, so it is
 // worth the open. A short file is a torn write, and Bitmap would accept it.
+
 uint64_t fileSizeOf(const std::string& path) {
   HalFile f;
   if (!Storage.openFileForRead("WALL", path, f)) return 0;
@@ -638,7 +805,7 @@ void WallpapersActivity::runSetDownload() {
 
   fetchCancel_ = false;
   fetchDone_ = 0;
-  fetchUnpacking_ = false;
+  fetchPhase_ = 0;
   fetchTotal_ = static_cast<int>(wallpapers::kBuiltInCount);
   view_ = View::Fetching;
   interactionsReady_ = false;
@@ -701,6 +868,7 @@ void WallpapersActivity::runSetDownload() {
 
   Storage.remove(kPackPart);
   scanLibrary();
+  prewarmThumbs();
   loadActive();
   computeWarning();
   page_ = 0;
@@ -714,8 +882,8 @@ void WallpapersActivity::runSetDownload() {
 // card at exactly the right size is skipped, so a torn unpack costs seconds of
 // SD work on retry rather than another download.
 bool WallpapersActivity::unpackSet() {
-  // Second phase, same bar, second half of it.
-  fetchUnpacking_ = true;
+  // Second phase, same bar, its second third.
+  fetchPhase_ = 1;
   fetchDone_ = 0;
   HalFile pack;
   if (!Storage.openFileForRead("WALL", kPackPart, pack)) {
@@ -950,7 +1118,7 @@ void WallpapersActivity::render(RenderLock&&) {
     model.done = fetchDone_;
     model.total = fetchTotal_;
     model.cancelling = fetchCancel_;
-    model.unpacking = fetchUnpacking_;
+    model.phase = fetchPhase_;
     wallpapersui::buildFetching(surface, model);
   } else if (view_ == View::Notice) {
     wallpapersui::NoticeModel model;

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -56,13 +56,33 @@ std::unique_ptr<Activity> WallpapersActivity::create(GfxRenderer& renderer, Mapp
 }
 
 void WallpapersActivity::onEnter() {
+  // Timed per phase because "the app takes ten seconds to open" is not a
+  // diagnosis, and this fork's recurring failure is fixing the thing in front
+  // of you rather than the thing that is slow. One line names the cost.
+  const uint32_t tEnter = millis();
   Activity::onEnter();
   toybox::ensureFonts(renderer);
+  const uint32_t tFonts = millis();
   Storage.mkdir(wallpapers::kLibraryDir);
   sweepPartFiles();
+  const uint32_t tSweep = millis();
   scanLibrary();
+  const uint32_t tScan = millis();
   loadActive();
-  computeWarning();
+  const uint32_t tActive = millis();
+  // The free-space probe is NOT here any more. HalStorage::freeBytes() walks the
+  // FAT cluster chain (SDCardManager::refreshFreeClusters: "seconds on a large
+  // card"), it is cached for 20s afterwards, and it was the only thing on this
+  // path that could take seconds -- which is exactly the shape Mario saw: ten
+  // seconds once, fast on every open inside the TTL, on an EMPTY card where no
+  // thumbnail work exists at all. Ten seconds of blank screen before the offer
+  // appears is the "reads as crashed" failure one layer earlier than the paint-
+  // before-block work, so the screen is painted first and the walk happens
+  // after, in loop(), with content already on the glass.
+  warning_.clear();
+  warningPending_ = true;
+  LOG_INF("WALL", "onEnter %ums: fonts=%u sweep=%u scan=%u active=%u (free-space deferred)", tActive - tEnter,
+          tFonts - tEnter, tSweep - tFonts, tScan - tSweep, tActive - tScan);
   // Open on the page holding the set wallpaper, so the border is on screen.
   cachedPage_ = -1;
   page_ = 0;
@@ -618,6 +638,7 @@ void WallpapersActivity::runSetDownload() {
 
   fetchCancel_ = false;
   fetchDone_ = 0;
+  fetchUnpacking_ = false;
   fetchTotal_ = static_cast<int>(wallpapers::kBuiltInCount);
   view_ = View::Fetching;
   interactionsReady_ = false;
@@ -693,6 +714,9 @@ void WallpapersActivity::runSetDownload() {
 // card at exactly the right size is skipped, so a torn unpack costs seconds of
 // SD work on retry rather than another download.
 bool WallpapersActivity::unpackSet() {
+  // Second phase, same bar, second half of it.
+  fetchUnpacking_ = true;
+  fetchDone_ = 0;
   HalFile pack;
   if (!Storage.openFileForRead("WALL", kPackPart, pack)) {
     showNotice("CARD TROUBLE", "The download arrived but could not be read back.", "TRY AGAIN",
@@ -777,6 +801,20 @@ bool WallpapersActivity::unpackSet() {
 }
 
 void WallpapersActivity::loop() {
+  // The deferred free-space walk, once the panel already shows something.
+  // Guarded on painted_ rather than run straight from onEnter: rendering is
+  // notification-driven, so a blocking call in the same breath as
+  // requestUpdate() would run BEFORE the render task ever painted and the
+  // deferral would buy nothing (the #306 shape).
+  if (warningPending_ && painted_) {
+    warningPending_ = false;
+    const uint32_t t0 = millis();
+    computeWarning();
+    LOG_INF("WALL", "free-space probe took %ums", millis() - t0);
+    if (!warning_.empty()) requestUpdate();
+    return;
+  }
+
   // Started here rather than in the action handler: the fetch blocks for a
   // while and pumps input itself, which must not happen while a tap is still
   // being routed (the Trivia precedent, and the whole of the #306 family).
@@ -889,6 +927,7 @@ void WallpapersActivity::loop() {
 }
 
 void WallpapersActivity::render(RenderLock&&) {
+  const uint32_t tPaint = millis();
   clampPage();
   renderer.clearScreen();
   // Faces per view, not per app. The grid is a menu and wants the Jersey cut it
@@ -911,6 +950,7 @@ void WallpapersActivity::render(RenderLock&&) {
     model.done = fetchDone_;
     model.total = fetchTotal_;
     model.cancelling = fetchCancel_;
+    model.unpacking = fetchUnpacking_;
     wallpapersui::buildFetching(surface, model);
   } else if (view_ == View::Notice) {
     wallpapersui::NoticeModel model;
@@ -957,7 +997,11 @@ void WallpapersActivity::render(RenderLock&&) {
 
   const auto labels = mappedInput.mapLabels("Back", "", "", "");
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+  // The offer screen draws its truchet band live, so the paint cost is worth a
+  // number rather than an assumption about a 240MHz part.
+  LOG_INF("WALL", "render view=%d took %ums", static_cast<int>(view_), millis() - tPaint);
   renderer.displayBuffer();
+  painted_ = true;
 }
 
 uint32_t WallpapersActivity::surfaceMeaning() const {

--- a/src/apps_local/wallpapers/WallpapersActivity.h
+++ b/src/apps_local/wallpapers/WallpapersActivity.h
@@ -77,10 +77,13 @@ class WallpapersActivity final : public Activity {
   std::vector<std::string> names_;  // library file names, sorted
   int activeIndex_ = -1;            // which name is pinned, or -1
   int builtInsMissing_ = 0;         // how many of the built-in set are not on the card
+  bool warningPending_ = false;     // the free-space walk, deferred until after the first paint
+  bool painted_ = false;            // the panel has shown something at least once
   int page_ = 0;
   int fetchDone_ = 0;
   int fetchTotal_ = 0;
   bool fetchCancel_ = false;
+  bool fetchUnpacking_ = false;  // second phase: the bar's second half
   bool fetchQueued_ = false;
   std::string noticeHead_;
   std::string noticeBody_;

--- a/src/apps_local/wallpapers/WallpapersActivity.h
+++ b/src/apps_local/wallpapers/WallpapersActivity.h
@@ -60,6 +60,7 @@ class WallpapersActivity final : public Activity {
   void onWifiChosen(bool connected);
   void runSetDownload();  // blocking: fetch the pack, then unpack it
   bool unpackSet();       // pack -> individual .bmp files, resumable
+  void prewarmThumbs();   // build the thumbnail cache while the bar is still up
   void showNotice(const char* headline, const char* body, const char* actionLabel, freeink::ui::ActionId action);
   void loadActive();
   void computeWarning();
@@ -68,6 +69,9 @@ class WallpapersActivity final : public Activity {
   void clampPage();
   void ensureThumbsForPage();  // decode this page's cells if not cached
   Thumb decodeThumb(const std::string& path, int16_t cellW, int16_t cellH) const;
+  // Cached decode: reads /wallpapers/.thumbs/<name>.thb when it still matches
+  // the source and the cell size, otherwise decodes and writes it.
+  Thumb thumbFor(const std::string& name, const std::string& path, int16_t cellW, int16_t cellH, int* decoded);
   void drawGrid(const wallpapersui::GridGeom& geom);
   void drawAddTile(const wallpapersui::GridGeom& geom, const freeink::ui::Rect& th);
   void drawGetSetTile(const wallpapersui::GridGeom& geom, const freeink::ui::Rect& th) const;
@@ -83,7 +87,7 @@ class WallpapersActivity final : public Activity {
   int fetchDone_ = 0;
   int fetchTotal_ = 0;
   bool fetchCancel_ = false;
-  bool fetchUnpacking_ = false;  // second phase: the bar's second half
+  int fetchPhase_ = 0;  // 0 fetch, 1 unpack, 2 thumbnails -- thirds of one bar
   bool fetchQueued_ = false;
   std::string noticeHead_;
   std::string noticeBody_;

--- a/src/apps_local/wallpapers/WallpapersCore.cpp
+++ b/src/apps_local/wallpapers/WallpapersCore.cpp
@@ -72,6 +72,23 @@ const char* builtInStem(const size_t index) {
   return kBuiltIns[index].stem;
 }
 
+bool isBuiltInFile(const std::string_view fileName) {
+  std::string_view stem = fileName;
+  const size_t dot = stem.rfind('.');
+  if (dot != std::string_view::npos) stem = stem.substr(0, dot);
+  for (const Entry& e : kBuiltIns) {
+    if (stem == e.stem) return true;
+  }
+  return false;
+}
+
+bool sortsBefore(const std::string_view a, const std::string_view b) {
+  const bool ab = isBuiltInFile(a);
+  const bool bb = isBuiltInFile(b);
+  if (ab != bb) return !ab;  // a user's own wallpaper comes first
+  return a < b;
+}
+
 DisplayName displayName(std::string_view fileName) {
   // Strip the extension: nobody wants ".bmp" under a picture.
   std::string_view stem = fileName;

--- a/src/apps_local/wallpapers/WallpapersCore.h
+++ b/src/apps_local/wallpapers/WallpapersCore.h
@@ -67,6 +67,17 @@ inline constexpr size_t kBuiltInCount = 21;
 size_t builtInCount();
 const char* builtInStem(size_t index);
 
+// Is this file one of the built-in set? The picker sorts a user's OWN
+// wallpapers in front of the built-ins, so this decides the order and it has to
+// be a real predicate rather than a binary_search over a list that is no longer
+// plainly sorted.
+bool isBuiltInFile(std::string_view fileName);
+
+// Sort order for the picker: user uploads first, then the built-ins, each
+// alphabetical. Mario's ask -- your own pictures should not be buried behind
+// twenty-one defaults.
+bool sortsBefore(std::string_view a, std::string_view b);
+
 enum class Room : uint8_t { Ok, TooFull, Unknown };
 Room roomFor(bool queryOk, uint64_t freeBytes, uint64_t floorBytes);
 

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -18,6 +18,13 @@ constexpr int16_t kBodyTop = static_cast<int16_t>(toybox::kHeaderHeight + toybox
 // A fixed strip under the chrome for the free-space advisory or the "nothing is
 // set yet" hint. Fixed so the grid's top does not jump when a hint appears.
 constexpr int16_t kHintH = 30;
+// Clear space between the hint and the first row of thumbnails. Without it the
+// grid began at exactly the hint's box bottom, so the sentence sat ON the
+// artwork -- Mario's words were that it is too close to the wallpapers. Taken
+// out of the grid's height (the cells are height-constrained), which costs each
+// thumbnail a few pixels and buys the sentence room to read as a caption for
+// the screen rather than a label on the first tile.
+constexpr int16_t kHintGap = 16;
 // The page-dot strip at the very bottom, reserved whether or not it is used, so
 // the grid height is the same on a one-page library as on a ten-page one.
 constexpr int16_t kPageStripH = 28;
@@ -170,7 +177,7 @@ GridGeom gridGeom(const fui::DeviceContext& device) {
 
   const int16_t gridLeft = static_cast<int16_t>(safe.x + toybox::kMargin);
   const int16_t gridW = static_cast<int16_t>(safe.width - toybox::kMargin * 2);
-  const int16_t gridTop = static_cast<int16_t>(safe.y + kBodyTop + kHintH);
+  const int16_t gridTop = static_cast<int16_t>(safe.y + kBodyTop + kHintH + kHintGap);
   const int16_t gridBottom = static_cast<int16_t>(safe.bottom() - kPageStripH - kBottomMargin);
   const int16_t gridH = static_cast<int16_t>(gridBottom - gridTop);
 
@@ -385,6 +392,15 @@ void buildOffer(toybox::Screen& screen, const OfferModel& model) {
 // DOWNLOADING. Painted from inside the blocking fetch, so it says what is
 // happening, how far along, and that Back stops it -- the three things a person
 // staring at a frozen-looking panel needs (a-silent-screen-reads-as-a-crash).
+BarSpan fetchBarSpan(const FetchingModel& model) {
+  BarSpan span;
+  span.units = model.total > 0 ? model.total * 2 : 1;
+  const int done = model.done < 0 ? 0 : (model.done > model.total ? model.total : model.done);
+  span.at = (model.unpacking ? model.total : 0) + done;
+  if (span.at > span.units) span.at = span.units;
+  return span;
+}
+
 void buildFetching(toybox::Screen& screen, const FetchingModel& model) {
   chrome(screen, "WALLPAPERS", nullptr);
   const fui::Rect body = screen.body();
@@ -409,9 +425,13 @@ void buildFetching(toybox::Screen& screen, const FetchingModel& model) {
   const int16_t barY = static_cast<int16_t>(body.y + 158);
   const fui::Rect bar = fui::makeRect(left, barY, body.width, 26);
   screen.target().stroke(bar, fui::Paint::solid(fui::Color::Black), 2);
-  if (model.total > 0 && model.done > 0) {
+  // ONE sweep across BOTH phases: the download fills the first half, the unpack
+  // the second. Two phases each filling the whole bar is what made it look like
+  // it restarted.
+  if (model.total > 0) {
+    const BarSpan span = fetchBarSpan(model);
     const int16_t inner = static_cast<int16_t>(body.width - 8);
-    const int16_t filled = static_cast<int16_t>(static_cast<int>(inner) * model.done / model.total);
+    const int16_t filled = static_cast<int16_t>(static_cast<int>(inner) * span.at / span.units);
     if (filled > 0) {
       screen.target().fill(fui::makeRect(static_cast<int16_t>(left + 4), static_cast<int16_t>(barY + 4), filled, 18),
                            fui::Paint::solid(fui::Color::Black));

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -394,9 +394,11 @@ void buildOffer(toybox::Screen& screen, const OfferModel& model) {
 // staring at a frozen-looking panel needs (a-silent-screen-reads-as-a-crash).
 BarSpan fetchBarSpan(const FetchingModel& model) {
   BarSpan span;
-  span.units = model.total > 0 ? model.total * 2 : 1;
+  const int phases = model.phaseCount < 1 ? 1 : model.phaseCount;
+  span.units = model.total > 0 ? model.total * phases : 1;
   const int done = model.done < 0 ? 0 : (model.done > model.total ? model.total : model.done);
-  span.at = (model.unpacking ? model.total : 0) + done;
+  const int phase = model.phase < 0 ? 0 : (model.phase >= phases ? phases - 1 : model.phase);
+  span.at = phase * model.total + done;
   if (span.at > span.units) span.at = span.units;
   return span;
 }

--- a/src/apps_local/wallpapers/WallpapersScreens.h
+++ b/src/apps_local/wallpapers/WallpapersScreens.h
@@ -96,8 +96,24 @@ struct FetchingModel {
   int done = 0;
   int total = 0;
   bool cancelling = false;
+  // Fetching and unpacking are two real phases over the same set. They drove one
+  // bar from 0 to 100 EACH, so on hardware it filled, reset and filled again --
+  // which reads as the download restarting. The bar now spans both phases and
+  // the caption names which one is running: a progress bar may never go
+  // backwards without saying why.
+  bool unpacking = false;
 };
 void buildFetching(toybox::Screen& screen, const FetchingModel& model);
+
+// Where the bar sits across BOTH phases, as at/units. Freestanding because
+// "the bar never goes backwards" is a property of the arithmetic, and it must
+// be assertable without a panel -- the defect it guards was only ever visible
+// on hardware. host-tests/wallcaption walks the whole fetch and asserts it.
+struct BarSpan {
+  int at = 0;
+  int units = 1;
+};
+BarSpan fetchBarSpan(const FetchingModel& model);
 
 // The FAILED state, and every other "something happened, here is what" screen.
 // Always carries an action: a screen that reports a failure and gives you

--- a/src/apps_local/wallpapers/WallpapersScreens.h
+++ b/src/apps_local/wallpapers/WallpapersScreens.h
@@ -96,12 +96,13 @@ struct FetchingModel {
   int done = 0;
   int total = 0;
   bool cancelling = false;
-  // Fetching and unpacking are two real phases over the same set. They drove one
-  // bar from 0 to 100 EACH, so on hardware it filled, reset and filled again --
-  // which reads as the download restarting. The bar now spans both phases and
-  // the caption names which one is running: a progress bar may never go
-  // backwards without saying why.
-  bool unpacking = false;
+  // Fetching, unpacking and preparing thumbnails are three real phases over the
+  // same set. Each used to drive one bar from 0 to 100, so on hardware it
+  // filled, reset and filled again -- which reads as the download restarting.
+  // One bar now spans all of them and the caption names the running phase: a
+  // progress bar may never go backwards without saying why.
+  int phase = 0;       // 0 fetch, 1 unpack, 2 thumbnails
+  int phaseCount = 3;  // how many such sweeps make one whole bar
 };
 void buildFetching(toybox::Screen& screen, const FetchingModel& model);
 


### PR DESCRIPTION
Six findings from the first two hardware runs of the Wallpapers app. All six are
fixed; every number below is measured, and where a cause turned out NOT to be
ours it is filed rather than patched.

## Round one

- **Ten-second first open, on an empty card.** Not thumbnails and not the drawn
  band. The whole offer render is **1ms** on host, and `ensureThumbsForPage`
  only ever decodes the current page (with an empty card, nothing). The cost was
  `computeWarning()` on the entry path: `freeBytes()` walks the FAT cluster chain
  (`SDCardManager::refreshFreeClusters` -- "seconds on a large card") and caches
  for 20s, which is exactly slow-once-then-fast. Wallpapers was the only app
  calling it on entry. It now runs **after** the first paint, guarded on a
  `painted_` flag rather than straight from `onEnter`, because rendering is
  notification-driven and blocking in the same breath as `requestUpdate()` would
  run before the render task ever painted.
- **The progress bar swept 0-100 twice.** The unpack phase reusing the widget,
  not the CDN redirect: progress is guarded on `sink.total > 0` and a 302 carries
  no Content-Length. One bar now spans every phase, captioned Downloading /
  Unpacking / Preparing.
- **The hint sat on the artwork.** The grid began at exactly the hint's box
  bottom. Now 19px above the sentence and 16px below, measured.

## Round two

- **Waking got slower.** Nothing of ours runs at boot -- there is no wallpapers
  symbol in `main.cpp` or `activities/boot_sleep/`. Our delta was one line:
  `setWallpaper` set `sleepScreen = CUSTOM` unconditionally, and if the user was
  on `QUICK_RESUME` that removes the retained-frame fast wake **and** the
  `LoadingIcon` -- the same branch draws both. Ours by choice, in CrossPoint's
  code. We now leave `quickResumeSleepScreen` on when taking a user off
  `QUICK_RESUME`, so timeout sleeps keep the fast path and the icon. **Trade:**
  the wallpaper then shows on manual sleeps rather than timeout ones.
- **Slow open with 21 wallpapers.** Thumbnails, this time genuinely.
  `cachedPage_` resets every `onEnter`, so they re-decoded on every open and page
  turn. Now persisted to `/wallpapers/.thumbs/`, keyed on source size **and** a
  3x64-byte content sample **and** cell size -- size alone cannot work because
  every wallpaper is exactly 48062 bytes. Pre-built during the download while the
  bar is already up.

  | | before | after |
  |---|---|---|
  | decoded per open | 3 | 0 |
  | thumb time | 12ms | 0ms |
  | render | 14ms | 1ms |

- **User uploads sort first.** `isBuiltInFile()` and `sortsBefore()` are real
  predicates in Core with a strict-weak-ordering check. The built-in count now
  counts instead of `binary_search`ing an order that is no longer plainly sorted.

## Filed, not fixed
**#351** -- every non-quick-resume wake shows no sign of life until the first
paint. That is CrossPoint's boot path and affects all modes and all users; this
fork does not optimise it.

## Tests
`wallcaption` walks all three progress phases and fails if the fill ever
decreases or overruns (watched fail: 45 checks). `wallpapers` pins the sort order
and the ordering's strict-weak property (watched fail). The thumbnail key was
proved by replacing a wallpaper with different content at an identical size and
watching exactly one thumb re-decode.

## Not verified
Measured in the simulator, which runs far faster than the device and cannot
reproduce the FAT walk at all (host `statvfs` answers instantly). The per-phase
timing is left in as log lines so the next hardware run names its own costs. The
wake fix in particular needs a device to confirm.
