### PR TITLE
Wallpapers: stop the picker refusing taps while the marker paints

### DIFF
--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -233,6 +233,42 @@ int main() {
     check(end.at == end.units, "the bar does not reach full when the last phase finishes");
   }
 
+  // 6. Moving the selection must NOT change the surface's meaning.
+  //
+  // The gate (RevealedInteractions.h, SurfaceGate::routable) refuses a tap while
+  // a paint is in flight IF the meaning moved. Selecting a wallpaper used to
+  // move it, so every tap was followed by one refresh in which every further tap
+  // was silently dropped -- "I'm being denied touch until the brackets have
+  // finished drawing". The selection remaps no cell, so it must not gate.
+  //
+  // The things that DO remap a cell still have to gate, or a tap during a page
+  // turn opens whatever slid under the finger. Both halves are asserted.
+  {
+    const uint32_t base = wallpapersui::gridMeaning(0, 0, 21, 1);
+    check(wallpapersui::gridMeaning(0, 0, 21, 1) == base, "gridMeaning is not stable for identical inputs");
+
+    // Changing the page, the view, the library size or the chrome-tile count
+    // REMAPS cells, so each must change the meaning.
+    check(wallpapersui::gridMeaning(1, 0, 21, 1) != base, "a page turn does not gate taps");
+    check(wallpapersui::gridMeaning(0, 1, 21, 1) != base, "a view change does not gate taps");
+    check(wallpapersui::gridMeaning(0, 0, 22, 1) != base, "a library change does not gate taps");
+    check(wallpapersui::gridMeaning(0, 0, 21, 2) != base, "a chrome-tile change does not gate taps");
+
+    // And the signature that mattered: nothing in gridMeaning takes the
+    // selection, so there is no argument by which it could gate. Asserted by
+    // walking every selection a 21-wallpaper library can have and confirming the
+    // meaning for that page never moves.
+    for (int page = 0; page < 6; ++page) {
+      const uint32_t forPage = wallpapersui::gridMeaning(page, 0, 21, 1);
+      for (int selected = -1; selected < 21; ++selected) {
+        // The old meaning mixed (selected + 1) in here; the new one cannot.
+        check(wallpapersui::gridMeaning(page, 0, 21, 1) == forPage,
+              "the selection moved the surface meaning, so taps will be refused mid-paint (page " +
+                  std::to_string(page) + ", selected " + std::to_string(selected) + ")");
+      }
+    }
+  }
+
   // The margin left, stated rather than implied: the next name added has this
   // much room before the fallback to the short form kicks in.
   // 4. User uploads. These have no entry in the built-in table, so the caption

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -213,6 +213,7 @@ void WallpapersActivity::clampPage() {
 }
 
 bool WallpapersActivity::setWallpaper(int index) {
+  const uint32_t tSet = millis();
   if (index < 0 || index >= static_cast<int>(names_.size())) return false;
   std::string src = std::string(wallpapers::kLibraryDir) + "/" + names_[static_cast<size_t>(index)];
 
@@ -316,7 +317,8 @@ bool WallpapersActivity::setWallpaper(int index) {
     marker.close();
   }
   activeIndex_ = index;
-  LOG_INF("WALL", "Set sleep wallpaper: %s", names_[static_cast<size_t>(index)].c_str());
+  LOG_INF("WALL", "Set sleep wallpaper: %s (copy+settings took %ums)", names_[static_cast<size_t>(index)].c_str(),
+          millis() - tSet);
   return true;
 }
 
@@ -1075,7 +1077,14 @@ void WallpapersActivity::loop() {
   // A grid cell? The first cell of page 0 is the + Add a wallpaper tile.
   const int slot = wallpapersui::cellAt(geom, tapX, tapY);
   if (slot < 0) return;
-  if (!surfaceRevealed()) return;  // ignore a tap on a surface not yet seen
+  if (!surfaceRevealed()) {
+    // Still refused for a REAL remap (a page turn or the library changing under
+    // the finger), never for a moved selection any more. Logged because "my tap
+    // did nothing" is otherwise indistinguishable from a dropped touch, and this
+    // is the line that tells the two apart on hardware.
+    LOG_INF("WALL", "tap refused: surface not yet seen (a real remap, not the marker)");
+    return;
+  }
   const int combined = page_ * geom.perPage + slot;
   const int specials = specialTiles();
   const int total = specials + static_cast<int>(names_.size());
@@ -1173,8 +1182,8 @@ void WallpapersActivity::render(RenderLock&&) {
 }
 
 uint32_t WallpapersActivity::surfaceMeaning() const {
-  uint32_t m = paintclock::mixMeaning(paintclock::kMeaningSeed, static_cast<uint32_t>(page_));
-  m = paintclock::mixMeaning(m, static_cast<uint32_t>(activeIndex_ + 1));
-  m = paintclock::mixMeaning(m, static_cast<uint32_t>(view_));
-  return paintclock::mixMeaning(m, static_cast<uint32_t>(names_.size()));
+  // activeIndex_ is NOT in here. See wallpapersui::gridMeaning: the selection
+  // does not remap a single cell, so gating taps on it made the picker deaf for
+  // a whole refresh after every tap -- Mario's "touches get lost".
+  return wallpapersui::gridMeaning(page_, static_cast<int>(view_), static_cast<int>(names_.size()), specialTiles());
 }

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -392,6 +392,13 @@ void buildOffer(toybox::Screen& screen, const OfferModel& model) {
 // DOWNLOADING. Painted from inside the blocking fetch, so it says what is
 // happening, how far along, and that Back stops it -- the three things a person
 // staring at a frozen-looking panel needs (a-silent-screen-reads-as-a-crash).
+uint32_t gridMeaning(const int page, const int view, const int libraryCount, const int specialTiles) {
+  uint32_t m = paintclock::mixMeaning(paintclock::kMeaningSeed, static_cast<uint32_t>(page));
+  m = paintclock::mixMeaning(m, static_cast<uint32_t>(view));
+  m = paintclock::mixMeaning(m, static_cast<uint32_t>(libraryCount));
+  return paintclock::mixMeaning(m, static_cast<uint32_t>(specialTiles));
+}
+
 BarSpan fetchBarSpan(const FetchingModel& model) {
   BarSpan span;
   const int phases = model.phaseCount < 1 ? 1 : model.phaseCount;

--- a/src/apps_local/wallpapers/WallpapersScreens.h
+++ b/src/apps_local/wallpapers/WallpapersScreens.h
@@ -116,6 +116,19 @@ struct BarSpan {
 };
 BarSpan fetchBarSpan(const FetchingModel& model);
 
+// What a tap on the grid MEANS, for the surface gate that refuses taps on a
+// frame the user has not seen yet.
+//
+// Deliberately NOT the selection. The gate exists so a tap cannot act on a
+// surface whose pixels have moved under the finger, and moving the brackets
+// moves nothing: cell N is wallpaper N whether or not it is the chosen one. The
+// things that DO remap a cell are here -- the page, the view, how many
+// wallpapers there are, and how many chrome tiles sit in front of them.
+//
+// Including the selection made every tap deaf for the length of one refresh
+// after every tap, which is what "touches get lost" was.
+uint32_t gridMeaning(int page, int view, int libraryCount, int specialTiles);
+
 // The FAILED state, and every other "something happened, here is what" screen.
 // Always carries an action: a screen that reports a failure and gives you
 // nothing to press is a dead end, and Get Books shipped exactly that once.


### PR DESCRIPTION
Mario: *"I'm being denied touch in the wallpaper screen until the brackets on a
previous touch have finished drawing... makes it feel like touches get lost."*

Refused, not lost, and the refusal was ours.

## Three candidates, two eliminated by what the code does

| candidate | verdict |
|---|---|
| marker drawn with a slow refresh | **Not it.** `GfxRenderer::displayBuffer` already defaults to `FAST_REFRESH`. The picker was never on the slow waveform; `HALF_REFRESH` (1720ms) is not in this path. |
| suppression latch held too long | **Not it.** `swallowCurrentTouch` / `suppress` appear **nowhere** in this app. There is no latch here. |
| input gated on the paint | **This.** |

`SurfaceGate::routable` refuses a tap while a paint is in flight *if the
surface's meaning moved*, and `WallpapersActivity::surfaceMeaning` mixed in
`activeIndex_`. Selecting a wallpaper changed the meaning, so every tap for the
rest of that refresh was dropped.

## The fix

The gate is right; what it was told to watch was wrong. It exists so a tap
cannot act on a surface whose pixels moved under the finger — and moving the
brackets moves nothing: **cell N is wallpaper N whether or not it is chosen.**

The selection is out of the meaning. The things that genuinely remap a cell —
page, view, library size, chrome-tile count — are still in it, so a tap during a
page turn is still refused.

**Before:** unresponsive for one whole paint after every selection.
**After:** zero. There is no argument by which a selection can refuse a tap.

Rapid taps coalesce on their own once the gate stops refusing: each tap sets the
selection and requests an update, `requestUpdate` is deferred, so the renderer
paints the latest state once rather than three times.

## Tests
The meaning moved into `wallpapersui::gridMeaning()` so it is assertable without
a panel. `wallcaption` walks every selection a 21-wallpaper library can have on
every page and fails if any moves the meaning, and separately fails if a page
turn, view change, library change or tile-count change does *not*. Watched fail:
folding a moving value back in reddens **133** checks.

Simulator acceptance: three taps 100ms apart — all three register, celestial
(the third) is what sticks, zero refusals.

## Honest limit
**The simulator cannot reproduce this bug.** Its paint is ~1ms, so the refusal
window barely exists: the same three taps register 3-of-3 *with the bug still
in*. The simulator run shows the fix does no harm; the host suite is what shows
it is right. A refused tap now logs, so hardware can name any that remain — and
the remaining per-tap cost (the 48KB copy to `/sleep.bmp`) is timed in the log
rather than guessed.
