### PR TITLE
site: stop creating a Vercel deployment per branch push (card #357)

### DIFF
--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -725,7 +725,52 @@ ignore() {  # ref, "changed"|"same" -> prints build|skip
 }
 [ "$(ignore xteink changed)" = build ] && ok || bad "vercel.json ignoreCommand: xteink with a site change must build"
 [ "$(ignore xteink same)" = skip ] && ok || bad "vercel.json ignoreCommand: xteink with no site change must skip, as before"
-[ "$(ignore app/anything changed)" = skip ] && ok || bad "vercel.json ignoreCommand: a pull request branch must not deploy a preview"
+[ "$(ignore app/anything changed)" = skip ] && ok || bad "vercel.json ignoreCommand: a pull request branch must not BUILD"
+
+# ...and the ignore command cannot be the thing that stops a preview. It runs
+# INSIDE the deployment. By the time it speaks, Vercel has created the
+# deployment, booked a build machine and cloned the repository; the build log
+# then reads "The deployment was canceled because the Ignored Build Step
+# command returned exit code 0". The free plan's limit is worded "Deployments
+# Created per Day: 100" over a rolling 86400s, and a deployment canceled that
+# way was still created, so it still counts. That is why the commit which
+# taught the ignore command about $VERCEL_GIT_COMMIT_REF did not stop the rate
+# limit: measured over Sep 3-5 2026, 265 deployments, 159 of them previews off
+# app/** and sync/** branches, peaking at 154 in one rolling 24 hours against a
+# limit of 100. Denying those two namespaces takes the same peak to 64.
+#
+# git.deploymentEnabled is the only setting that stops the deployment being
+# CREATED. Its patterns are checked against where branch names actually come
+# from, not repeated here as literals, so renaming the worktree prefix fails
+# this test instead of silently reopening the tap.
+DEPLOY_ENABLED() { python3 -c '
+import json, sys
+g = json.load(open(sys.argv[1])).get("git", {}).get("deploymentEnabled")
+print(json.dumps(g if isinstance(g, dict) else {}))' "$VERCEL"; }
+DE="$(DEPLOY_ENABLED)"
+
+# Every worktree gets branch app/<name>; scripts_local/wt.sh is the only thing
+# that decides that, so read the prefix out of it.
+WT_PREFIX="$(sed -nE 's/.*branch="([A-Za-z0-9_-]+)\/\$name".*/\1/p' "$ROOT/scripts_local/wt.sh" | head -1)"
+if [ -z "$WT_PREFIX" ]; then
+  bad "scripts_local/wt.sh no longer names a branch prefix, so nothing here knows which namespace must not deploy"
+else
+  ok
+  printf '%s' "$DE" | grep -q "\"$WT_PREFIX/\*\*\": *false" \
+    && ok || bad "site/vercel.json git.deploymentEnabled does not deny '$WT_PREFIX/**'; every push to a worktree branch then CREATES a Vercel deployment and spends one of the free plan's 100 a day, whatever the ignore command later does with it"
+fi
+
+# The daily upstream sync opens sync/upstream-<date> (docs/workflow/upstream-sync.md).
+grep -q 'sync/upstream-' "$ROOT/docs/workflow/upstream-sync.md" \
+  && ok || bad "docs/workflow/upstream-sync.md no longer names the sync/upstream- branch namespace that vercel.json denies"
+printf '%s' "$DE" | grep -q '"sync/\*\*": *false' \
+  && ok || bad "site/vercel.json git.deploymentEnabled does not deny 'sync/**'; the daily upstream sync branch then creates preview deployments"
+
+# The other half of the rule: production must still deploy. A catch-all that
+# swept xteink up with the rest would stop the site updating at all, and
+# nothing would go red -- a deployment that is never created cannot fail.
+printf '%s' "$DE" | grep -q '"xteink": *false' \
+  && bad "site/vercel.json git.deploymentEnabled disables xteink; the site would never update again and no check anywhere would report it" || ok
 
 # .vercelignore exists to keep laptop-only tooling off a public URL, and both
 # halves of the fetch look exactly like that. Ignoring either leaves the build

--- a/site/README.md
+++ b/site/README.md
@@ -9,29 +9,61 @@ button** below before touching it.
 
 ## When it deploys, and when it does not
 
-`vercel.json` carries `"ignoreCommand": "git diff --quiet HEAD^ HEAD ./"`.
-Vercel runs it from this directory: **exit 0 skips the build, non-zero builds**.
-`git diff --quiet` exits 0 when nothing here changed, so a commit that does not
-touch `site/` never deploys.
+Two settings, and they act at different moments. Confusing them is what cost
+the fork a day: the account was deploy-rate-limited on 2026-09-04 and again on
+2026-09-05, and the first fix went in believing the second setting could do the
+first one's job.
 
-This is not tidiness. On 2026-09-04 the account hit its deployment rate limit
-and every pull request in the fork went red on a Vercel check, including ones
-whose diff was a word list or a shell script. Of the 305 commits on `xteink`
-that day, **57 touched `site/`** -- so four deploys in five built nothing new
-and the fifth could not run.
+**`git.deploymentEnabled` decides whether a deployment is CREATED.** Vercel
+reads it before anything runs. `app/**` and `sync/**` are `false`, so a push to
+a worktree branch or to the daily upstream sync branch produces nothing at all:
+no deployment, no build, no Vercel check on the pull request. `xteink` is the
+only branch left enabled.
 
-Two properties worth keeping if you edit it:
+**`ignoreCommand` decides whether an already-created deployment BUILDS.** It
+runs from this directory, inside the deployment, after Vercel has booked a
+build machine and cloned the repository. **Exit 0 skips the build, non-zero
+builds** -- the reverse of the intuitive reading. The command is:
 
-- **It fails towards building.** If the command errors -- a shallow clone with
-  no `HEAD^`, a git that is not there -- it exits non-zero and the deploy
+```
+[ "$VERCEL_GIT_COMMIT_REF" != "xteink" ] || git diff --quiet HEAD^ HEAD ./
+```
+
+so on `xteink` it builds only when this directory changed, and on any other ref
+it skips. The build log for a skip reads *"The deployment was canceled because
+the Ignored Build Step command returned exit code 0"*.
+
+**A skipped build is still a deployment, and it still counts.** The free plan's
+limit is worded *Deployments Created per Day: 100*, over a rolling 86400
+seconds. That is why the ref guard above did not stop the rate limit on its own
+and `git.deploymentEnabled` had to be added: measured across 2026-09-03..05,
+265 deployments, **159 of them previews** off `app/**` and `sync/**`, peaking at
+**154 in one rolling 24 hours against a limit of 100**. Denying those two
+namespaces takes the same peak to **64**. The remaining 106 are production:
+64 pull-request merges, 22 emulator rebuilds, 16 release version bumps.
+
+Properties worth keeping if you edit any of it:
+
+- **`ignoreCommand` fails towards building.** If it errors -- a shallow clone
+  with no `HEAD^`, a git that is not there -- it exits non-zero and the deploy
   proceeds. Never skip when unsure.
+- **`HEAD^` is the first parent**, so on the merge commit a pull request lands
+  as, `git diff HEAD^ HEAD ./` is exactly that pull request's changes to this
+  directory. That is the case that actually runs, and it is correct.
 - **`./` means this directory, not the repository root**, because the Vercel
   project root is `site/`. Changing the project root without changing this
   path silently stops every deploy.
+- **Never write a catch-all into `git.deploymentEnabled`.** The deny list names
+  the two namespaces branches are actually created in
+  (`scripts_local/wt.sh`, `docs/workflow/upstream-sync.md`), and
+  `host-tests/site/run.sh` checks it against them rather than against a copy.
+  A pattern that swept `xteink` up would stop the site updating for good, and
+  nothing would go red: a deployment that is never created cannot fail.
 
-The emulator rebuild CI commits after a firmware merge DOES touch `site/` --
-it writes `site/emulator-manifest.json` -- so it still deploys. That is correct:
-the page really did change.
+The emulator rebuild CI commits after a firmware merge DO touch `site/` -- they
+write `site/emulator-manifest.json`, which is the pointer `fetch-emulator.mjs`
+follows -- so they still deploy, and they must: without that deploy the live
+page keeps serving the previous emulator.
 
 ## Before it deploys
 

--- a/site/vercel.json
+++ b/site/vercel.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "app/**": false,
+      "sync/**": false,
+      "xteink": true
+    }
+  },
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"xteink\" ] || git diff --quiet HEAD^ HEAD ./",
   "buildCommand": "node fetch-emulator.mjs",
   "installCommand": "",


### PR DESCRIPTION
Card #357. Vercel refused to deploy the site on 2026-09-05 (`Deployment rate limited -- retry in 24 hours`, `upgradeToPro=build-rate-limit`), surfacing as a red Vercel check on #135. The live site kept serving off the last good deploy, but nothing new could reach crossplay.ma-r-s.com, and the board and Mario's inbox are on that domain.

## Where the deploys were actually going

Measured from the Vercel API rather than from git, because the limit counts what Vercel **created**, not what we pushed. Team `mario-alejandro-ruizs-projects`, plan **hobby**. Every one of the 265 deployments over 2026-09-03..05 belongs to the `crossplay` project; no other project in the account contributes.

| | deploys, Sep 3-5 | share |
|---|---|---|
| **previews** off `app/**` (156) and `sync/**` (3) | **159** | **60%** |
| production off `xteink` | 106 | 40% |
| &nbsp;&nbsp;of which pull-request merges | 64 | 24% |
| &nbsp;&nbsp;of which emulator rebuilds | 21 | 8% |
| &nbsp;&nbsp;of which release version bumps | 16 | 6% |
| &nbsp;&nbsp;other | 5 | 2% |

The limit is documented as **"Deployments Created per Day: 100"** over a rolling 86400s.

| | peak in any rolling 24h |
|---|---|
| **before, actual** | **154** |
| after, previews denied | **64** |
| (previews *and* emulator denied) | 55 |

**Previews dominate; the emulator does not.** Denying previews clears the limit with 36 deploys of headroom. Removing the emulator instead would take the peak from 154 to 145 and fix nothing.

### The four candidates, each with its measured share

| candidate | share of the 265 | verdict |
|---|---|---|
| **per-pull-request previews** | **159 (60%)** | **the cause. Fixed here.** |
| deployments created then skipped | 51 of the 265 ended `CANCELED`; I pulled the build log for 8 of those at random and all 8 were the ignore command exiting 0. Every one is a preview or an `xteink` commit already counted above | not a separate cause, but the reason the previous fix could not work -- see below |
| emulator-rebuild production deploys | 21 (8%) | not the cause. Removing it takes the peak from 154 to 145. Left alone; see below |
| the autorelease workflow | 16 (6%), the `chore: crossplay X.Y.Z` bumps | not the cause. They land on `xteink`, do not touch `site/`, and are already skipped at build time -- they still spend a created-deployment slot each, about 5 a day, which is not worth more machinery at 64/100 |

## Why the previous attempt did not work

`a7a2e31f` ("site: no Vercel preview per pull request") taught `ignoreCommand` about `$VERCEL_GIT_COMMIT_REF`, and its message says *"every other ref is skipped, so no preview deploy"*. The ignore command cannot do that. It runs **inside** the deployment: Vercel has already created it, booked a build machine and cloned the repository by the time the command speaks. Vercel's own build log for `app/gcclist` at 18:00 on 09-05, 29 minutes *after* that fix merged:

```
Running "[ "$VERCEL_GIT_COMMIT_REF" != "xteink" ] || git diff --quiet HEAD^ HEAD ./"
The deployment was canceled because the Ignored Build Step command returned exit code 0
```

A deployment cancelled that way **was still created**, so it still counts. 47 of 09-05's 76 deployments were cancels of exactly that kind. The ignore command was working perfectly and measuring the wrong thing.

Confirming the two things the brief asked me to check rather than take on trust:

- **Direction.** Vercel's docs and the build log above agree: **exit 0 skips the build, non-zero builds**. The existing command's direction is correct.
- **`HEAD^` on a merge commit.** It is the first parent, so on the merge commit a PR lands as, `git diff HEAD^ HEAD ./` is exactly that PR's changes under `site/`. Verified on `b771d95d`, `f478056d`, `b64353eb`. That half was never the problem.

## The fix

`git.deploymentEnabled` in `site/vercel.json` is the only setting evaluated *before* a deployment exists. `app/**` (every worktree branch, from `scripts_local/wt.sh`) and `sync/**` (the daily upstream sync) are `false`; `xteink` stays enabled and its `ignoreCommand` is untouched, so **the site still deploys exactly when `site/` genuinely changes**.

No catch-all pattern. A pattern that swept `xteink` up would stop the site updating for good and nothing would go red, because a deployment that is never created cannot fail. The deny list covers 162 of the 162 preview deployments in the whole history I pulled.

`host-tests/site/run.sh` checks the deny list against `wt.sh`'s branch prefix rather than against a copy of it, so renaming the worktree prefix fails the suite instead of silently reopening the tap. All four new assertions were watched go red before this was committed (drop `app/**`, drop `sync/**`, set `xteink: false`, rename the prefix to `wip/`).

`site/README.md`'s "When it deploys, and when it does not" is rewritten: it quoted the pre-`a7a2e31f` command and asserted that a commit not touching `site/` "never deploys", which is the exact false belief this PR is about.

## Verified live, by accident of timing

Pushing this branch was itself the experiment, and the rate-limit window had reopened by then, so the comparison is clean. Same account, same twenty minutes:

| | branch carries `git.deploymentEnabled`? | deployment created? | check on the PR |
|---|---|---|---|
| **#136** `app/picrossimport`, pushed 18:42 | no | yes, built, `READY` | `Vercel pass` |
| **#137** this branch, pushed 18:56 and 18:57 | **yes** | **none** | **no Vercel check at all** |

`vercel`'s deployment list has **zero** entries for `app/vercelrate` after **three** pushes, while `app/bindheld` picked one up at 19:02 in the middle of them. That is the fix working, and it also answers a question Vercel does not document: **`git.deploymentEnabled` is read from the pushed commit**, so it takes effect immediately on any branch carrying it rather than only after that branch merges `xteink`.

It also gives a clean way to tell the two failures apart from a PR page from now on: **rate-limited shows a red `Vercel` check; denied shows no `Vercel` check at all.** #135 is the former, #137 the latter.

The patterns are separately verified against the real `minimatch` package Vercel's docs name as the matcher: every `app/**` and `sync/**` branch name in the deployment history resolves to disabled, `xteink` resolves to enabled, and the upstream branches the fork carries (`develop`, `master`, `feature/*`) fall through to the default `true` -- nothing pushes to them, so they produce nothing either way.

## Not verified

- **The steady-state number.** 64 is a projection from three days of history with previews subtracted, not an observed day. Merge volume is growing (44 production merges on 09-04, 54 on 09-05), so the honest claim is 36 deploys of headroom today, not forever. If it is ever tight again, the next lever is the 16 release-bump deploys, which build nothing.
- **The deny list is complete only for the namespaces that exist.** A branch pushed outside `app/**` and `sync/**` would still create a deployment; the `ignoreCommand` would then skip its build, so it costs a slot and not a build. Deliberate: a catch-all that swept `xteink` up would stop the site updating for good and nothing would go red.
- No device or hardware involvement; no firmware touched.
- No device or hardware involvement; no firmware touched.

**Emulator staleness is unchanged.** The emulator rebuild commits still deploy, and must: they write `site/emulator-manifest.json`, the pointer `fetch-emulator.mjs` follows. Nothing here makes the live emulator lag trunk by so much as a second.

## The emulator half is #139's, not this PR's

[#139](https://github.com/ma-r-s/crossplay/pull/139) debounces `crossplay-emulator.yml` to one rebuild per quiet window and stops `tree_freshness.sh` counting emulator-only commits as behind. Nothing here touches `.github/workflows/crossplay-emulator.yml`, `scripts_local/tree_freshness.sh` or `host-tests/freshness/`.

The two changes are complements, not alternatives, and the numbers say which one is load-bearing for the rate limit: **#139 takes the peak from 154 to 143 and leaves the account over the cap; this PR takes it to 64.** #139's real win is gate throughput, which is a separate currency -- over the last 72h, 44 of the 215 first-parent pushes to `xteink` were emulator rebuilds (20%), against 113 merges (53%) and 28 release bumps (13%), and `tree_freshness.sh` withholds a verdict for any of them.

Card #361, which I opened for the emulator half before #139 surfaced, is parked as a duplicate with that measurement recorded on it.

## What the gate said

`./scripts_local/check.sh --committed` ran twice. **Neither run failed anything**; both had the verdict withheld for freshness alone, which is a live instance of the throughput cost PR #139 is fixing.

| run | SHA | result | withheld because |
|---|---|---|---|
| 1 | `b2b01a3b` | every host suite green, **`site ok` (11s)**, GCC parity green, simulator build green, 0 FAIL | `d2e5369d chore: crossplay 1.12.36` landed mid-run |
| 2 | `58ef961f` | same, **`site ok` (9s)**, 0 FAIL | `b1a57381 chore: emulator rebuilt` landed 40s after it started |

Both read as `CHECKSH-VERDICT: withheld exit=3` -- the inert form, meaning none of the missing commits can reach a device image. Device builds were correctly skipped both times: *"3 changed path(s) in the changes against origin/xteink, none of which reach a device image"*. The verdict was read by `grep` for the token, never `tail -1` and never `$?`.

Rather than chase a moving trunk a third time, I merged the one inert commit (`b1a57381`, twelve hash lines in `site/emulator-manifest.json`) and re-ran the one suite that reads that file: `host-tests/site`, **210 checks, 0 failed**, on the pushed head `7151f6ff`, which is level with `origin/xteink`. CI on this PR is the authoritative green.
