### PR TITLE
board: a card another session holds is not bound twice by accident

### DIFF
--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -543,5 +543,17 @@ grep -q "$SP/pr.md is at the top" "$WORK/err" \
   || bad "the refusal named a path the reader cannot paste: $(grep -o "$SP[^ ]*" "$WORK/err" | head -1)"
 
 echo
+echo "a held card is not bound twice"
+HELD=$(board new "Trivia: the timer keeps running on the score screen" --from trivia --kind bug | sed 's/^#\([0-9]*\).*/\1/')
+board bind "$HELD" --session "held-a" --tree wt/one --branch app/one >/dev/null
+if board bind "$HELD" --session "other-session" --tree wt/two >"$WORK/bind.out" 2>&1; then bad "a second session bound a held card"; else grep -q "held by session held-a" "$WORK/bind.out" && grep -q "wt/one" "$WORK/bind.out" && ok "the second bind is refused and the holder, its tree and branch are named" || bad "bind refusal lacks the holder: $(cat "$WORK/bind.out")"; fi
+grep -q -- "--take" "$WORK/bind.out" && ok "the refusal says how to take the card over on purpose" || bad "refusal lacks the --take remedy"
+board show "$HELD" | grep -q "session held-a" && ok "the card stayed with its holder" || bad "the card changed hands anyway"
+board bind "$HELD" --session "held-a" --tree wt/one >/dev/null 2>&1 && ok "the holder may bind its own card again" || bad "the holder was refused its own card"
+board bind "$HELD" --session "other-session" --tree wt/two --take | grep -q "bound to other-session" && ok "--take hands the card over" || bad "--take did not bind"
+board show "$HELD" | grep -q "taken over from session held-a" && ok "the takeover is a history line" || bad "no takeover line"
+board state "$HELD" done >/dev/null
+board bind "$HELD" --session "held-a" >/dev/null 2>&1 && ok "a settled card can be re-bound without --take" || bad "a settled card was treated as held"
+
 echo "$((PASS+FAIL)) checks, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -134,6 +134,17 @@ expect "a finished turn passes"                  0 stop "{\"session_id\":\"$WORK
 
 CID=$(board new "Sudoku loses the puzzle from the difficulty menu" --from sudoku --kind bug | sed 's/^#\([0-9]*\).*/\1/')
 board bind "$CID" --session "$WORKER" --tree wt/x --branch app/x >/dev/null
+echo "a tree another session holds refuses writes"
+expect "another session editing wt/x is refused"        2 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/x/src/a.cpp\"}}"
+grep -q "wt/x is bound to session $WORKER (card #$CID)" "$WORK/err" && ok "the refusal names the tree, its holder and the card" || bad "refusal lacks the holder: $(head -c 200 "$WORK/err")"
+grep -q "wt.sh new" "$WORK/err" && ok "and says to cut a tree of its own" || bad "refusal lacks the remedy"
+expect "the holder still edits its tree"                0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/x/src/a.cpp\"}}"
+expect "the orchestrator may edit any tree"             0 pretool "{\"session_id\":\"$ORCH\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/x/src/a.cpp\"}}"
+expect "an unbound tree is anyone's"                    0 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/free/src/a.cpp\"}}"
+expect "a write from inside the tree by another session is refused" 2 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sed -i '' src/a.cpp\"},\"cwd\":\"$ROOT/wt/x\"}"
+expect "a read from inside the tree by another session is fine"     0 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"grep -rn foo src\"},\"cwd\":\"$ROOT/wt/x\"}"
+expect "a write naming the tree from elsewhere is refused"          2 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cp /tmp/a.h $ROOT/wt/x/src/a.h\"},\"cwd\":\"$ROOT\"}"
+expect "the holder writes from inside its tree"                     0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -am x\"},\"cwd\":\"$ROOT/wt/x\"}"
 mk_transcript "I cannot see the panel from here. Let me know when you have flashed it."
 expect "hand-back with a card but no blocker refused" 2 stop "{\"session_id\":\"$WORKER\",\"transcript_path\":\"$T\",\"stop_hook_active\":false}"
 grep -q "card #$CID" "$WORK/err" && ok "refusal names the card" || bad "refusal does not name the card"
@@ -544,6 +555,9 @@ grep -q "$SP/pr.md is at the top" "$WORK/err" \
 
 echo
 echo "a held card is not bound twice"
+CID2=$(board new "Sudoku: a second card that wants the same tree" --from sudoku --kind task --anyway | sed 's/^#\([0-9]*\).*/\1/')
+if board bind "$CID2" --session "other-session" --tree wt/x >"$WORK/tree.out" 2>&1; then bad "a second card was bound to a held tree"; else grep -q "already the tree of #$CID" "$WORK/tree.out" && ok "binding a second card to a held tree is refused, naming the card" || bad "tree refusal lacks the card: $(cat "$WORK/tree.out")"; fi
+board bind "$CID2" --session "other-session" --tree wt/y | grep -q "bound to other-session" && ok "a tree of its own binds" || bad "a free tree was refused"
 HELD=$(board new "Trivia: the timer keeps running on the score screen" --from trivia --kind bug | sed 's/^#\([0-9]*\).*/\1/')
 board bind "$HELD" --session "held-a" --tree wt/one --branch app/one >/dev/null
 if board bind "$HELD" --session "other-session" --tree wt/two >"$WORK/bind.out" 2>&1; then bad "a second session bound a held card"; else grep -q "held by session held-a" "$WORK/bind.out" && grep -q "wt/one" "$WORK/bind.out" && ok "the second bind is refused and the holder, its tree and branch are named" || bad "bind refusal lacks the holder: $(cat "$WORK/bind.out")"; fi

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -582,6 +582,20 @@ expect "the new holder is live again (touched by its tool call)" 2 pretool "{\"s
 printf '{"session_id":"held-d"}' | python3 "$GUARD" session-end >/dev/null 2>&1
 grep -q '"ended_at"' "$ROOT/.board/sessions/held-d.json" && ok "SessionEnd marks the session ended" || bad "session_end wrote no ended_at"
 expect "an ended holder's tree is free at once"       0 pretool "{\"session_id\":\"held-e\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
+# a gate still verifying the tree is a sign of life whatever its session does:
+# a worker waiting on a backgrounded gate makes no tool calls for as long as
+# the gate takes (95 minutes one night), and its tree must not count as free
+mkdir -p "$ROOT/wt/gone"
+GATE_TAG="$(python3 -c 'import hashlib,pathlib,sys; print(hashlib.sha1(str(pathlib.Path(sys.argv[1]).resolve()).encode()).hexdigest()[:8])' "$ROOT/wt/gone")"
+export TMPDIR="$WORK"
+bash -c 'exec -a check.sh sleep 30' & GATEPID=$!
+sleep 0.2; echo "$GATEPID" >"$WORK/xteink-check-$GATE_TAG.running"
+expect "a tree with a living gate is held even when its session is gone" 2 pretool "{\"session_id\":\"held-e\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
+grep -q "check.sh still verifying it (pid $GATEPID" "$WORK/err" && ok "the refusal names the gate's pid" || bad "refusal lacks the gate: $(head -c 240 "$WORK/err")"
+if board bind "$GONE" --session "held-e" --tree wt/gone >"$WORK/gate.out" 2>&1; then bad "bind took a tree with a living gate"; else grep -q "check.sh still verifying it (pid $GATEPID" "$WORK/gate.out" && ok "bind refuses a tree with a living gate and names it" || bad "bind's refusal lacks the gate: $(cat "$WORK/gate.out")"; fi
+kill "$GATEPID" 2>/dev/null; wait "$GATEPID" 2>/dev/null
+expect "the gate gone, the tree is free"                0 pretool "{\"session_id\":\"held-e\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
+unset TMPDIR
 
 echo "$((PASS+FAIL)) checks, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -579,7 +579,7 @@ board bind "$GONE" --session "held-d" --tree wt/gone | grep -q "bound to held-d"
 board show "$GONE" | grep -q "taken over from session held-c (it had ended, or was silent" && ok "and says why on the card" || bad "no takeover reason on the card"
 printf '{"session_id":"held-d","tool_name":"Bash","tool_input":{"command":"ls"}}' | python3 "$GUARD" pretool >/dev/null 2>&1
 expect "the new holder is live again (touched by its tool call)" 2 pretool "{\"session_id\":\"held-e\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
-printf '{"session_id":"held-d"}' | python3 "$GUARD" session_end >/dev/null 2>&1
+printf '{"session_id":"held-d"}' | python3 "$GUARD" session-end >/dev/null 2>&1
 grep -q '"ended_at"' "$ROOT/.board/sessions/held-d.json" && ok "SessionEnd marks the session ended" || bad "session_end wrote no ended_at"
 expect "an ended holder's tree is free at once"       0 pretool "{\"session_id\":\"held-e\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
 

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -136,7 +136,7 @@ CID=$(board new "Sudoku loses the puzzle from the difficulty menu" --from sudoku
 board bind "$CID" --session "$WORKER" --tree wt/x --branch app/x >/dev/null
 echo "a tree another session holds refuses writes"
 expect "another session editing wt/x is refused"        2 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/x/src/a.cpp\"}}"
-grep -q "wt/x is bound to session $WORKER (card #$CID)" "$WORK/err" && ok "the refusal names the tree, its holder and the card" || bad "refusal lacks the holder: $(head -c 200 "$WORK/err")"
+grep -q "wt/x is bound to session $WORKER (card #$CID," "$WORK/err" && ok "the refusal names the tree, its holder and the card" || bad "refusal lacks the holder: $(head -c 200 "$WORK/err")"
 grep -q "wt.sh new" "$WORK/err" && ok "and says to cut a tree of its own" || bad "refusal lacks the remedy"
 expect "the holder still edits its tree"                0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/x/src/a.cpp\"}}"
 expect "the orchestrator may edit any tree"             0 pretool "{\"session_id\":\"$ORCH\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/x/src/a.cpp\"}}"
@@ -568,6 +568,20 @@ board bind "$HELD" --session "other-session" --tree wt/two --take | grep -q "bou
 board show "$HELD" | grep -q "taken over from session held-a" && ok "the takeover is a history line" || bad "no takeover line"
 board state "$HELD" done >/dev/null
 board bind "$HELD" --session "held-a" >/dev/null 2>&1 && ok "a settled card can be re-bound without --take" || bad "a settled card was treated as held"
+GONE=$(board new "Jaipur: the market never refills after a bonus" --from jaipur --kind bug --anyway | sed 's/^#\([0-9]*\).*/\1/')
+board bind "$GONE" --session "held-c" --tree wt/gone --branch app/gone >/dev/null
+expect "a live holder keeps its tree from others"     2 pretool "{\"session_id\":\"held-d\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
+grep -q "active 0 min ago" "$WORK/err" && ok "the refusal says how recently the holder was seen" || bad "refusal lacks the holder's activity: $(head -c 240 "$WORK/err")"
+grep -q -- "--take" "$WORK/err" && grep -q "idle for 45 minutes counts as gone" "$WORK/err" && ok "and names --take and the idle rule" || bad "refusal lacks --take or the idle rule"
+touch -t 202001010000 "$ROOT/.board/sessions/held-c.json"
+expect "a holder silent for longer than the idle window is gone" 0 pretool "{\"session_id\":\"held-d\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
+board bind "$GONE" --session "held-d" --tree wt/gone | grep -q "bound to held-d" && ok "bind takes a silent holder's card over without a flag" || bad "bind refused a silent holder's card"
+board show "$GONE" | grep -q "taken over from session held-c (it had ended, or was silent" && ok "and says why on the card" || bad "no takeover reason on the card"
+printf '{"session_id":"held-d","tool_name":"Bash","tool_input":{"command":"ls"}}' | python3 "$GUARD" pretool >/dev/null 2>&1
+expect "the new holder is live again (touched by its tool call)" 2 pretool "{\"session_id\":\"held-e\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
+printf '{"session_id":"held-d"}' | python3 "$GUARD" session_end >/dev/null 2>&1
+grep -q '"ended_at"' "$ROOT/.board/sessions/held-d.json" && ok "SessionEnd marks the session ended" || bad "session_end wrote no ended_at"
+expect "an ended holder's tree is free at once"       0 pretool "{\"session_id\":\"held-e\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
 
 echo "$((PASS+FAIL)) checks, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/scripts_local/hooks/guard.py
+++ b/scripts_local/hooks/guard.py
@@ -22,11 +22,13 @@ input, including the ones that must NOT block.
 """
 
 import datetime as dt
+import hashlib
 import json
 import time
 import os
 import pathlib
 import re
+import subprocess
 import sys
 
 HANDBACK = re.compile(
@@ -261,7 +263,45 @@ class Board:
     def is_integrator(self, sid):
         return norm_sid(sid) in self.claim_ids(self.integrator())
 
+    # Chosen against two clocks. The Bash tool caps one call at ten minutes, so
+    # no session goes quiet that long from a single command; and a worker
+    # waiting on a backgrounded gate makes no tool calls at all, which is why
+    # a living gate on the tree counts as life below (tree_gate_pid) rather
+    # than this number growing to cover it. Forty-five is well past the first
+    # and does not need to cover the second.
     IDLE_MINUTES = 45
+
+    @staticmethod
+    def tree_gate_pid(tree_path):
+        """The pid of a check.sh still verifying `tree_path`, or None.
+
+        check.sh keeps ${TMPDIR:-/tmp}/xteink-check-<tag>.running with its pid
+        while it runs (tag = the first eight hex of sha1 of the tree's real
+        path, as check.sh computes it). A tree with a living gate is in use
+        whatever its session is doing, and an edit landing in it would make
+        that verdict meaningless while looking green.
+        """
+        try:
+            real = str(pathlib.Path(tree_path).resolve())
+        except OSError:
+            return None
+        tag = hashlib.sha1(real.encode()).hexdigest()[:8]
+        lock = pathlib.Path(os.environ.get("TMPDIR") or "/tmp") / f"xteink-check-{tag}.running"
+        try:
+            pid = int((lock.read_text() or "0").split()[0])
+        except (OSError, ValueError, IndexError):
+            return None
+        if pid <= 0:
+            return None
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return None
+        try:
+            cmd = subprocess.run(["ps", "-o", "command=", "-p", str(pid)], capture_output=True, text=True).stdout
+        except OSError:
+            return None
+        return pid if "check.sh" in cmd else None
 
     def session_seen(self, sid):
         """When the session last touched a tool, or None if the board never saw it.
@@ -351,9 +391,10 @@ class Board:
         # a dead session (card 44) again, once per worktree. The write is
         # allowed; binding the card afterwards records the takeover.
         live = [(h, c) for h, c in holders if self.session_live(h)]
-        if not live:
+        gate = self.tree_gate_pid(self.root / tree)
+        if not live and gate is None:
             return None
-        return (tree, live)
+        return (tree, live, gate)
 
     def note_session(self, sid, cwd):
         d = self.dir / "sessions"
@@ -472,11 +513,14 @@ def writes_into_tree(cmd):
 
 
 def foreign_tree_refusal(board, sid, where):
-    tree, holders = where
-    who = ", ".join(
+    tree, holders, gate = where
+    parts = [
         f"session {h} (card #{c}, active {int((time.time() - (board.session_seen(h) or time.time())) // 60)} min ago)"
         for h, c in holders
-    )
+    ]
+    if gate is not None:
+        parts.append(f"a check.sh still verifying it (pid {gate}; ps -p {gate} -o etime,command)")
+    who = ", ".join(parts) or "another session"
     return (
         f"Refused: {tree} is bound to {who}, and two sessions writing one tree verify nothing "
         "(the gates each ran against a tree the other was still changing). Work in your own tree: "

--- a/scripts_local/hooks/guard.py
+++ b/scripts_local/hooks/guard.py
@@ -707,7 +707,7 @@ def main():
     CURRENT.update(root=root, sid=norm_sid(data.get("session_id")), tool=data.get("tool_name") or mode)
     if mode == "pretool":
         pretool(board, data)
-    elif mode == "session_end":
+    elif mode == "session-end":
         session_end(board, data)
     elif mode == "stop":
         stop(board, data)

--- a/scripts_local/hooks/guard.py
+++ b/scripts_local/hooks/guard.py
@@ -260,6 +260,50 @@ class Board:
     def is_integrator(self, sid):
         return norm_sid(sid) in self.claim_ids(self.integrator())
 
+    def tree_holders(self, tree):
+        """Open cards bound to `tree` (as `wt/<name>`), as (session, card id).
+
+        Two sessions once wrote into one worktree for an hour and ran two gates
+        against it at the same time; the identical resulting SHAs read as
+        "independently converged" and meant "there was only ever one tree"
+        (2026-09-05). The cards know who holds a tree; the guard reads them.
+        """
+        out = []
+        d = self.dir / "cards"
+        if not d.is_dir():
+            return out
+        for p in d.glob("*.json"):
+            c = read_json(p) or {}
+            if str(c.get("tree") or "").rstrip("/") != tree:
+                continue
+            if c.get("state") in ("done", "released", "parked") or not c.get("session"):
+                continue
+            out.append((norm_sid(c.get("session")), c.get("id")))
+        return out
+
+    def foreign_tree(self, sid, path_or_cwd):
+        """The `wt/<name>` under the workspace that `path_or_cwd` is inside, if a
+        card binds it to a session other than `sid`; else None."""
+        try:
+            p = pathlib.Path(path_or_cwd)
+            if not p.is_absolute():
+                p = pathlib.Path(os.getcwd()) / p
+            p = p.resolve()
+            wt = (self.root / "wt").resolve()
+            if wt not in p.parents:
+                return None
+            name = p.relative_to(wt).parts[0]
+        except (OSError, ValueError, IndexError):
+            return None
+        tree = f"wt/{name}"
+        holders = self.tree_holders(tree)
+        if not holders:
+            return None
+        me = norm_sid(sid)
+        if any(h == me for h, _ in holders) or self.is_orchestrator(sid):
+            return None
+        return (tree, holders)
+
     def note_session(self, sid, cwd):
         d = self.dir / "sessions"
         d.mkdir(parents=True, exist_ok=True)
@@ -376,6 +420,16 @@ def writes_into_tree(cmd):
     return False
 
 
+def foreign_tree_refusal(board, sid, where):
+    tree, holders = where
+    who = ", ".join(f"session {h} (card #{c})" for h, c in holders)
+    return (
+        f"Refused: {tree} is bound to {who}, and two sessions writing one tree verify nothing "
+        "(the gates each ran against a tree the other was still changing). Work in your own tree: "
+        f"./scripts/wt.sh new <name>, then {board_cmd(board.root)} bind <card> --session {norm_sid(sid)} --tree wt/<name>"
+    )
+
+
 def pretool(board, data):
     sid = data.get("session_id", "")
     tool = data.get("tool_name", "")
@@ -387,6 +441,9 @@ def pretool(board, data):
         sroot = scratch_root_of(path, root)
         if sroot is not None:
             block(scratch_refusal(board, sid, data.get("cwd"), path, sroot))
+        where = board.foreign_tree(sid, path)
+        if where:
+            block(foreign_tree_refusal(board, sid, where))
         if under_integration_tree(root, path) and not board.is_integrator(sid):
             block(
                 "Refused: that file is in firmware-next, the integration tree. Work happens in "
@@ -406,6 +463,19 @@ def pretool(board, data):
                 "Refused: a raw `pio run` bypasses the workspace build lock and can corrupt another "
                 "tree's build. Use ./scripts_local/check.sh (or dev.sh / sim-shot.sh) from your tree."
             )
+        # A write from inside another session's tree (the shell's cwd), or one
+        # that names such a tree: the same rule as firmware-next, per tree.
+        body = QUOTED.sub(" ", HEREDOC.sub(" ", cmd))
+        if WRITE_VERB.search(body) or REDIRECT.search(body):
+            candidates = [data.get("cwd") or ""]
+            candidates += [m.group(0) for m in re.finditer(r"(?:/[^\s'\"]*)?wt/[A-Za-z0-9_.-]+/?", cmd)]
+            for cand in candidates:
+                if not cand:
+                    continue
+                cpath = cand if cand.startswith("/") else str(root / cand)
+                where = board.foreign_tree(sid, cpath)
+                if where:
+                    block(foreign_tree_refusal(board, sid, where))
         if (
             writes_into_tree(cmd) and not board.is_integrator(sid)
         ):

--- a/scripts_local/hooks/guard.py
+++ b/scripts_local/hooks/guard.py
@@ -23,6 +23,7 @@ input, including the ones that must NOT block.
 
 import datetime as dt
 import json
+import time
 import os
 import pathlib
 import re
@@ -260,6 +261,48 @@ class Board:
     def is_integrator(self, sid):
         return norm_sid(sid) in self.claim_ids(self.integrator())
 
+    IDLE_MINUTES = 45
+
+    def session_seen(self, sid):
+        """When the session last touched a tool, or None if the board never saw it.
+
+        The hook touches the session file on every tool call, so its mtime is
+        the last sign of life; SessionEnd (when wired) writes ended_at.
+        """
+        p = self.dir / "sessions" / f"{norm_sid(sid)}.json"
+        try:
+            st = p.stat()
+        except OSError:
+            return None
+        cur = read_json(p) or {}
+        if cur.get("ended_at"):
+            return None
+        return st.st_mtime
+
+    def session_live(self, sid):
+        seen = self.session_seen(sid)
+        return seen is not None and (time.time() - seen) < self.IDLE_MINUTES * 60
+
+    def touch_session(self, sid):
+        p = self.dir / "sessions" / f"{norm_sid(sid)}.json"
+        try:
+            if p.exists():
+                os.utime(p, None)
+        except OSError:
+            pass
+
+    def end_session(self, sid):
+        d = self.dir / "sessions"
+        p = d / f"{norm_sid(sid)}.json"
+        cur = read_json(p) or {"session_id": norm_sid(sid)}
+        cur["ended_at"] = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+        try:
+            d.mkdir(parents=True, exist_ok=True)
+            with open(p, "w") as f:
+                json.dump(cur, f, indent=1)
+        except OSError:
+            pass
+
     def tree_holders(self, tree):
         """Open cards bound to `tree` (as `wt/<name>`), as (session, card id).
 
@@ -302,7 +345,15 @@ class Board:
         me = norm_sid(sid)
         if any(h == me for h, _ in holders) or self.is_orchestrator(sid):
             return None
-        return (tree, holders)
+        # A holder that has ended, or has not touched a tool for IDLE_MINUTES,
+        # is gone: sessions end all the time without unbinding, and a tree
+        # locked to a session that no longer exists is the claims stranded by
+        # a dead session (card 44) again, once per worktree. The write is
+        # allowed; binding the card afterwards records the takeover.
+        live = [(h, c) for h, c in holders if self.session_live(h)]
+        if not live:
+            return None
+        return (tree, live)
 
     def note_session(self, sid, cwd):
         d = self.dir / "sessions"
@@ -422,11 +473,16 @@ def writes_into_tree(cmd):
 
 def foreign_tree_refusal(board, sid, where):
     tree, holders = where
-    who = ", ".join(f"session {h} (card #{c})" for h, c in holders)
+    who = ", ".join(
+        f"session {h} (card #{c}, active {int((time.time() - (board.session_seen(h) or time.time())) // 60)} min ago)"
+        for h, c in holders
+    )
     return (
         f"Refused: {tree} is bound to {who}, and two sessions writing one tree verify nothing "
         "(the gates each ran against a tree the other was still changing). Work in your own tree: "
-        f"./scripts/wt.sh new <name>, then {board_cmd(board.root)} bind <card> --session {norm_sid(sid)} --tree wt/<name>"
+        f"./scripts/wt.sh new <name>, then {board_cmd(board.root)} bind <card> --session {norm_sid(sid)} --tree wt/<name>. "
+        f"A holder idle for {board.IDLE_MINUTES} minutes counts as gone and this refusal lifts by itself; "
+        f"to take a tree over now: {board_cmd(board.root)} bind <card> --session {norm_sid(sid)} --tree {tree} --take"
     )
 
 
@@ -435,6 +491,7 @@ def pretool(board, data):
     tool = data.get("tool_name", "")
     inp = data.get("tool_input") or {}
     root = board.root
+    board.touch_session(sid)
 
     if tool in ("Edit", "Write", "MultiEdit", "NotebookEdit"):
         path = inp.get("file_path") or inp.get("notebook_path") or ""
@@ -578,6 +635,11 @@ def stop(board, data):
     )
 
 
+def session_end(board, data):
+    """SessionEnd: the session file says so, and every tree it held is free."""
+    board.end_session(data.get("session_id", ""))
+
+
 def session_start(board, data):
     sid = norm_sid(data.get("session_id", ""))
     board.note_session(sid, data.get("cwd", ""))
@@ -645,6 +707,8 @@ def main():
     CURRENT.update(root=root, sid=norm_sid(data.get("session_id")), tool=data.get("tool_name") or mode)
     if mode == "pretool":
         pretool(board, data)
+    elif mode == "session_end":
+        session_end(board, data)
     elif mode == "stop":
         stop(board, data)
     elif mode == "session-start":

--- a/tools_local/board/board.py
+++ b/tools_local/board/board.py
@@ -813,6 +813,23 @@ def session_live(root, sid):
     return (time.time() - st.st_mtime) < IDLE_MINUTES * 60
 
 
+def tree_gate_pid(root, tree):
+    """The pid of a check.sh still verifying wt/<name>, or None (the guard's rule)."""
+    import hashlib
+    try:
+        real = str((root / tree).resolve())
+    except OSError:
+        return None
+    lock = pathlib.Path(os.environ.get("TMPDIR") or "/tmp") / f"xteink-check-{hashlib.sha1(real.encode()).hexdigest()[:8]}.running"
+    try:
+        pid = int((lock.read_text() or "0").split()[0])
+        os.kill(pid, 0)
+        cmd = subprocess.run(["ps", "-o", "command=", "-p", str(pid)], capture_output=True, text=True).stdout
+    except (OSError, ValueError, IndexError):
+        return None
+    return pid if "check.sh" in cmd else None
+
+
 def cmd_bind(st, a):
     with st.lock():
         c = st.get_card(a.id)
@@ -847,6 +864,12 @@ def cmd_bind(st, a):
                 sys.exit(
                     f"board: {tree} is already the tree of #{k['id']} ({k['title'][:60]}), held by session {norm_sid(k['session'])}.\n"
                     f"  One card, one branch, one worktree: ./scripts/wt.sh new <name> for yours, or --take if that session is gone."
+                )
+            gate = tree_gate_pid(st.root, tree)
+            if gate is not None:
+                sys.exit(
+                    f"board: {tree} has a check.sh still verifying it (pid {gate}); an edit there now would make that verdict meaningless.\n"
+                    f"  Wait for it (ps -p {gate} -o etime,command), or ./scripts/wt.sh new <name> for a tree of your own."
                 )
         if held and held != sid:
             card_history(st, c, f"taken over from session {held}" + ("" if getattr(a, "take", False) else " (it had ended, or was silent for %d minutes)" % IDLE_MINUTES))

--- a/tools_local/board/board.py
+++ b/tools_local/board/board.py
@@ -812,6 +812,22 @@ def cmd_bind(st, a):
                 + (f" on {c['branch']}" if c.get("branch") else "")
                 + f" since {since}.\n  If that session is gone, take it over on purpose: board bind {c['id']} --session {a.session} --take"
             )
+        # And a tree another session's card holds: one card, one branch, one
+        # worktree was a convention until two sessions shared wt/gcclist for an
+        # hour (2026-09-05). --take covers this too, since it is the same call.
+        if a.tree and not getattr(a, "take", False):
+            tree = a.tree.rstrip("/")
+            others = [
+                k for k in st.list_cards()
+                if k["id"] != c["id"] and str(k.get("tree") or "").rstrip("/") == tree
+                and k.get("session") and norm_sid(k.get("session")) != sid and k["state"] not in SETTLED
+            ]
+            if others:
+                k = others[0]
+                sys.exit(
+                    f"board: {tree} is already the tree of #{k['id']} ({k['title'][:60]}), held by session {norm_sid(k['session'])}.\n"
+                    f"  One card, one branch, one worktree: ./scripts/wt.sh new <name> for yours, or --take if that session is gone."
+                )
         if held and held != sid:
             card_history(st, c, f"taken over from session {held}")
         c["session"] = sid

--- a/tools_local/board/board.py
+++ b/tools_local/board/board.py
@@ -799,6 +799,21 @@ def cmd_bind(st, a):
     with st.lock():
         c = st.get_card(a.id)
         sid = norm_sid(a.session)
+        # A card another session holds is not bound twice by accident: the
+        # orchestrator once dispatched a worker onto a card whose holder was
+        # mid-rebase on the same branch, and both did the work (2026-09-05).
+        # Taking a card over is a decision, so it has a flag and a history line.
+        held = norm_sid(c.get("session"))
+        if held and held != sid and c["state"] not in SETTLED and not getattr(a, "take", False):
+            since = next((h["at"] for h in reversed(c.get("history", [])) if str(h.get("what", "")).startswith("bound to session")), c.get("updated"))
+            sys.exit(
+                f"board: #{c['id']} is held by session {held}"
+                + (f" in {c['tree']}" if c.get("tree") else "")
+                + (f" on {c['branch']}" if c.get("branch") else "")
+                + f" since {since}.\n  If that session is gone, take it over on purpose: board bind {c['id']} --session {a.session} --take"
+            )
+        if held and held != sid:
+            card_history(st, c, f"taken over from session {held}")
         c["session"] = sid
         if a.tree:
             c["tree"] = a.tree
@@ -1493,6 +1508,7 @@ def main(argv=None):
     s.add_argument("--session", required=True)
     s.add_argument("--tree")
     s.add_argument("--branch")
+    s.add_argument("--take", action="store_true", help="bind a card another session still holds (its holder is gone, or this is the orchestrator's call)")
     s.set_defaults(fn=cmd_bind)
     s = sub.add_parser("block")
     s.add_argument("id", type=int)

--- a/tools_local/board/board.py
+++ b/tools_local/board/board.py
@@ -49,6 +49,7 @@ import argparse
 import datetime as dt
 import fcntl
 import json
+import time
 import os
 import pathlib
 import re
@@ -795,6 +796,23 @@ def cmd_new(st, a):
     print(f"#{c['id']} {c['title']}" + ("  (in Mario's inbox)" if inbox else ""))
 
 
+IDLE_MINUTES = 45
+
+
+def session_live(root, sid):
+    """The hook touches .board/sessions/<sid>.json on every tool call and marks
+    ended_at at SessionEnd; a holder silent for IDLE_MINUTES or ended is gone."""
+    p = root / ".board" / "sessions" / f"{norm_sid(sid)}.json"
+    try:
+        st = p.stat()
+        cur = json.loads(p.read_text() or "{}")
+    except (OSError, ValueError):
+        return False
+    if cur.get("ended_at"):
+        return False
+    return (time.time() - st.st_mtime) < IDLE_MINUTES * 60
+
+
 def cmd_bind(st, a):
     with st.lock():
         c = st.get_card(a.id)
@@ -804,7 +822,8 @@ def cmd_bind(st, a):
         # mid-rebase on the same branch, and both did the work (2026-09-05).
         # Taking a card over is a decision, so it has a flag and a history line.
         held = norm_sid(c.get("session"))
-        if held and held != sid and c["state"] not in SETTLED and not getattr(a, "take", False):
+        take = getattr(a, "take", False) or (held and held != sid and not session_live(st.root, held))
+        if held and held != sid and c["state"] not in SETTLED and not take:
             since = next((h["at"] for h in reversed(c.get("history", [])) if str(h.get("what", "")).startswith("bound to session")), c.get("updated"))
             sys.exit(
                 f"board: #{c['id']} is held by session {held}"
@@ -821,6 +840,7 @@ def cmd_bind(st, a):
                 k for k in st.list_cards()
                 if k["id"] != c["id"] and str(k.get("tree") or "").rstrip("/") == tree
                 and k.get("session") and norm_sid(k.get("session")) != sid and k["state"] not in SETTLED
+                and session_live(st.root, k["session"])
             ]
             if others:
                 k = others[0]
@@ -829,7 +849,7 @@ def cmd_bind(st, a):
                     f"  One card, one branch, one worktree: ./scripts/wt.sh new <name> for yours, or --take if that session is gone."
                 )
         if held and held != sid:
-            card_history(st, c, f"taken over from session {held}")
+            card_history(st, c, f"taken over from session {held}" + ("" if getattr(a, "take", False) else " (it had ended, or was silent for %d minutes)" % IDLE_MINUTES))
         c["session"] = sid
         if a.tree:
             c["tree"] = a.tree


### PR DESCRIPTION
The orchestrator dispatched a worker onto card 316 while another session held it and was rebasing the same branch; both did the work and one had to stand down. `board bind` accepted the second bind without a word.

It now refuses a card another live session holds, names the holder, its tree and branch and since when, and takes `--take` to hand the card over on purpose (a history line says whom it was taken from). A settled card, or the holder itself, binds as before.

Card #362.

**Verified**: `host-tests/bugflow`, 176 checks: the refusal names holder, tree and the `--take` remedy; the card stays put; the holder re-binds; `--take` hands over and leaves the takeover line; a done card re-binds freely.

**Not verified**: the same against the Supabase store (shared code above the store, as with `note`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Second commit, the worse problem Main found afterwards.** Two sessions were not working two copies of one card: they were writing into the *same worktree* (`wt/gcclist`) for an hour, with two `check.sh --committed` runs live against it at once, each verifying a tree the other was still changing. The identical resulting SHAs read as "independently converged" and meant "there was only ever one tree". "One card, one branch, one worktree" was a convention, the only rule here that was not a hook. Now the guard reads the cards: an Edit/Write under `wt/<name>`, or a Bash write from inside it (cwd) or naming it, is refused when a card binds that tree to another live session, naming the holder, the card and the remedy; the holder and the orchestrator pass, an unbound tree is anyone's. And `board bind --tree` refuses a tree another open card holds. Nine guard cases and two bind cases in bugflow; 188 checks.

**Third commit, Main's review.** The first two had no liveness: a session that ended without unbinding would have locked its tree to everyone but the orchestrator. Now the hook touches the session file on every tool call (its mtime is the last sign of life) and a `session_end` mode marks `ended_at`; a holder that ended or has been silent for 45 minutes is gone, so the guard lets the write through and `board bind` takes the card or tree over without a flag, saying why on the card. A live holder's refusal says how recently it was seen, that the idle rule lifts it by itself, and names `--take`. `SessionEnd` is already wired in the workspace `.claude/settings.json` to `guard.py session-end` (the live guard exits 0 on a mode it does not know, so it is a no-op until `firmware-next` carries this); idleness alone decides until then, which crashes and kills need anyway. 197 checks.

**Fourth commit, Main's edge.** A worker waiting on a backgrounded gate makes no tool calls for as long as the gate takes, so after 45 silent minutes its tree counted as free. #140's pid file already says which trees have a living gate; the guard and `board bind` now read it, and a tree with a living `check.sh` is held whatever its session is doing, the gate's pid in the refusal. The 45 minutes carries a comment saying what it was chosen against. 201 checks.
