### PR TITLE
ci: the emulator is rebuilt once per quiet window, not once per merge

### DIFF
--- a/.github/workflows/crossplay-emulator.yml
+++ b/.github/workflows/crossplay-emulator.yml
@@ -72,6 +72,40 @@ jobs:
     # going an hour is stuck, not slow.
     timeout-minutes: 60
     steps:
+      # One rebuild per quiet window, not one per merge. Trunk landed a commit
+      # every fourteen minutes on 2026-09-05 and this job rebuilt after each:
+      # twenty-one "chore: emulator rebuilt" commits in a day, each moving the
+      # tip under whatever --committed gate was in flight, each a Vercel deploy
+      # of site/emulator until the free plan's daily budget was gone. So the
+      # job first waits for xteink to hold still for QUIET_SECONDS (a push
+      # restarts the clock, CAP_SECONDS ends the wait regardless), then checks
+      # out the tip AS IT IS THEN. With cancel-in-progress false a run that is
+      # waiting keeps waiting while arrivals replace the one pending run behind
+      # it, so a stream of merges yields one rebuild of the last of them.
+      # host-tests/ci runs this step's own text against a fake gh.
+      - name: Wait for xteink to hold still
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          quiet="${QUIET_SECONDS:-600}"; poll="${POLL_SECONDS:-60}"; cap="${CAP_SECONDS:-2400}"
+          tip() { gh api "repos/$GITHUB_REPOSITORY/commits/xteink" --jq .sha; }
+          last="$(tip)"; still=0; waited=0
+          while [ "$still" -lt "$quiet" ] && [ "$waited" -lt "$cap" ]; do
+            sleep "$poll"; waited=$((waited + poll))
+            now="$(tip)"
+            if [ "$now" = "$last" ]; then
+              still=$((still + poll))
+            else
+              echo "xteink moved to ${now:0:8} after ${waited}s; the quiet clock restarts"
+              last="$now"; still=0
+            fi
+          done
+          if [ "$still" -lt "$quiet" ]; then
+            echo "xteink never held still for ${quiet}s in ${cap}s; building ${last:0:8} anyway"
+          else
+            echo "xteink held still at ${last:0:8} for ${still}s; building it"
+          fi
+
       - uses: actions/checkout@v4
         with:
           ref: xteink

--- a/host-tests/freshness/run.sh
+++ b/host-tests/freshness/run.sh
@@ -78,6 +78,26 @@ if [ "$rc" -eq 0 ] && [ -z "$out" ]; then ok; else
 fi
 
 # 2. Behind by a FIRMWARE commit: exit 4.
+# CI's emulator rebuild commits touch site/emulator/ only; a tree behind by
+# those alone is not behind on anything a gate verifies (twenty-one of them
+# withheld verdicts in one day).
+seed_clone
+advance_remote site/emulator/crossplay.wasm rebuilt
+out="$("$PROBE" "$WORK/clone" 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ]; then ok; else
+  bad "behind only by an emulator rebuild reported rc=$rc, expected 0: $out"
+fi
+case "$out" in
+  *"emulator rebuild"*) ok ;;
+  *) bad "the emulator-only case does not say so: $out" ;;
+esac
+seed_clone
+advance_remote site/emulator/crossplay.wasm rebuilt
+advance_remote docs/readme.md changed
+out="$("$PROBE" "$WORK/clone" 2>&1)"; rc=$?
+if [ "$rc" -eq 3 ]; then ok; else
+  bad "behind by a rebuild AND a docs commit reported rc=$rc, expected 3: $out"
+fi
 seed_clone
 advance_remote src/main.cpp changed
 out="$("$PROBE" "$WORK/clone" 2>&1)"; rc=$?

--- a/scripts_local/tree_freshness.sh
+++ b/scripts_local/tree_freshness.sh
@@ -98,6 +98,22 @@ if [ "$behind" -eq 0 ]; then
   exit 0
 fi
 
+# CI's own emulator rebuilds ("chore: emulator rebuilt for <sha>") touch
+# site/emulator/ and nothing else, and nothing a gate verifies reads that
+# directory. Twenty-one of them landed in one day and each moved the tip under
+# whatever --committed run was in flight, withholding a verdict about code the
+# commit could not have changed. Commits that touch only site/emulator/ do not
+# count as being behind.
+rebuilds=0
+for c in $(git -C "$repo" rev-list "HEAD..$REF" 2>/dev/null); do
+  if ! git -C "$repo" diff-tree --no-commit-id --name-only -r "$c" | grep -qv '^site/emulator/'; then
+    rebuilds=$((rebuilds + 1))
+  fi
+done
+if [ "$rebuilds" -eq "$behind" ]; then
+  echo "this tree is $behind commit(s) behind $REF, all of them CI's own emulator rebuilds (site/emulator/ only); nothing a gate verifies changed."
+  exit 0
+fi
 base="$(git -C "$repo" merge-base HEAD "$REF" 2>/dev/null || true)"
 newest="$(git -C "$repo" log --format='%h %s' -1 "$REF" 2>/dev/null || true)"
 


### PR DESCRIPTION
Trunk landed a commit every fourteen minutes yesterday and the emulator workflow rebuilt after each: twenty-one `chore: emulator rebuilt` commits in a day against sixty-one merges. Each moved the tip under whatever `--committed` gate was in flight, and each touched `site/emulator`, a Vercel deploy, until the free plan's daily budget was gone (Main's report: one loop, two currencies).

**Debounced at the source.** The rebuild job first waits for xteink to hold still for `QUIET_SECONDS` (600; a push restarts the clock, `CAP_SECONDS` 2400 ends the wait regardless), then checks out the tip as it is then. With `cancel-in-progress: false` a waiting run keeps waiting while arrivals replace the one pending run behind it, so a stream of merges yields one rebuild of the last of them, and the emulator lags trunk by at most the window.

**And the gate's side of the loop.** `tree_freshness.sh` no longer counts a commit that touches only `site/emulator/` as being behind; nothing a gate verifies reads that directory, so a tree behind by rebuilds alone is fresh, while a rebuild plus any other commit is still behind.

Card #363.

**Verified**: `host-tests/ci` (80 checks) lifts the step's own text and runs it against a fake `gh` handing out shas with the seconds shrunk: a still trunk builds after the window, a push restarts the clock and the last tip is built, a trunk that never settles is built at the cap. `host-tests/freshness` (14 checks): behind by an emulator rebuild only is rc 0 and says so; a rebuild plus a docs commit is rc 3 as before.

**Not verified**: the step on a real runner; the next firmware merge is the proof (one rebuild commit after the window, not one per merge), and the Vercel deploy count over the next day is the counter-proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)