### PR TITLE
gate: two gates on one tree verify nothing, so the second refuses to start

### DIFF
--- a/host-tests/checksh/run.sh
+++ b/host-tests/checksh/run.sh
@@ -2110,5 +2110,42 @@ unrun_case "every test file named is clean"            'python3 test_a.py && g++
 unrun_case "a file run.sh never names is reported"     'python3 test_a.py' " test_b.cpp"
 unrun_case "a run.sh that globs test_* runs everything" 'for f in test_*.py; do python3 "$f"; done; for c in test_*.cpp; do g++ "$c"; done' ""
 
+
+# --- one gate per tree -------------------------------------------------------
+#
+# Lifted between its markers and run with TAG and TMPDIR of this harness: no
+# lock proceeds and leaves this pid; a lock held by a living check.sh refuses
+# and names the pid; a lock left by a dead pid is taken over.
+python3 - "$CHECK" >"$WORK/onegate.sh" <<'PY'
+import sys
+lines = open(sys.argv[1]).read().splitlines()
+a = next(i for i, l in enumerate(lines) if 'one gate per tree begin' in l)
+b = next(i for i, l in enumerate(lines) if 'one gate per tree end' in l)
+print('\n'.join(lines[a + 1:b]))
+PY
+[ -s "$WORK/onegate.sh" ] || { echo "FAIL checksh  could not lift the one-gate block out of check.sh"; failed=$((failed + 1)); }
+onegate_run() {  # echoes refused|proceeded and leaves $WORK/onegate.out
+  rm -f "$WORK/onegate.refused"
+  ( cd "$WORK" && unset CHECK_OUTER_LOGS && TAG=onegate TMPDIR="$WORK" && die() { echo "$*" >"$WORK/onegate.refused"; exit 0; } && . "$WORK/onegate.sh" >"$WORK/onegate.out" 2>&1; echo "$$" >"$WORK/onegate.pid" )
+  [ -e "$WORK/onegate.refused" ] && echo refused || echo proceeded
+}
+rm -f "$WORK/xteink-check-onegate.running"
+checks=$((checks + 1)); [ "$(onegate_run)" = proceeded ] || { failed=$((failed + 1)); echo "FAIL checksh  one gate: a free tree was refused: $(cat "$WORK/onegate.refused" 2>/dev/null)"; }
+# the holder is a living check.sh: a sleeper wearing the name
+bash -c 'exec -a check.sh sleep 30' & SLEEPER=$!
+sleep 0.2
+echo "$SLEEPER" >"$WORK/xteink-check-onegate.running"
+checks=$((checks + 1)); [ "$(onegate_run)" = refused ] || { failed=$((failed + 1)); echo "FAIL checksh  one gate: a tree with a living gate was not refused"; }
+checks=$((checks + 1)); grep -q "pid $SLEEPER" "$WORK/onegate.refused" 2>/dev/null || { failed=$((failed + 1)); echo "FAIL checksh  one gate: the refusal does not name the holder's pid"; }
+kill "$SLEEPER" 2>/dev/null; wait "$SLEEPER" 2>/dev/null
+# a dead holder: the sleeper's pid, now gone
+echo "$SLEEPER" >"$WORK/xteink-check-onegate.running"
+checks=$((checks + 1)); [ "$(onegate_run)" = proceeded ] || { failed=$((failed + 1)); echo "FAIL checksh  one gate: a dead holder's lock was not taken over"; }
+# a living pid that is not a check.sh (reused pid) is taken over too
+sleep 30 & OTHER=$!
+echo "$OTHER" >"$WORK/xteink-check-onegate.running"
+checks=$((checks + 1)); [ "$(onegate_run)" = proceeded ] || { failed=$((failed + 1)); echo "FAIL checksh  one gate: a living pid that is not a gate was refused"; }
+kill "$OTHER" 2>/dev/null; wait "$OTHER" 2>/dev/null
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -140,6 +140,30 @@ die() {  # message...
 }
 TREE_STALE=""
 
+# --- one gate per tree begin ---
+# Two gates on one tree verify nothing. Two sessions once shared wt/gcclist
+# for an hour and two --committed runs (pids 61511 and 44575) were live
+# against it at once, each verifying a tree the other was still changing;
+# neither said so, and any verdict from that window was meaningless
+# (2026-09-05). One run per tree at a time: a pid file, refused while its
+# holder is a living check.sh, taken over when it is not. The --committed
+# trial run is the outer run's own (CHECK_OUTER_LOGS is set) and is not a
+# second gate. Later `trap ... EXIT` lines in this file replace the cleanup,
+# so a finished run may leave its pid behind; a dead or reused pid that is
+# not a check.sh is taken over, never refused.
+RUNLOCK="${TMPDIR:-/tmp}/xteink-check-$TAG.running"
+if [ -z "${CHECK_OUTER_LOGS:-}" ]; then
+  holder="$(cat "$RUNLOCK" 2>/dev/null || true)"
+  if [ -n "$holder" ] && [ "$holder" != "$$" ] && kill -0 "$holder" 2>/dev/null \
+     && ps -o command= -p "$holder" 2>/dev/null | grep -q 'check\.sh'; then
+    die "another check.sh (pid $holder) is already verifying this tree; two gates on one tree verify nothing." \
+        " Wait for it (ps -p $holder -o etime,command), and if that run is not yours, the tree is not either."
+  fi
+  echo "$$" > "$RUNLOCK"
+  trap 'rm -f "$RUNLOCK"' EXIT
+fi
+# --- one gate per tree end ---
+
 # --ignore-submodules=untracked: the icon tools drop a __pycache__/ inside
 # freeink-sdk, which is untracked content in a submodule and not your work.
 dirty_count() {


### PR DESCRIPTION
Two `check.sh --committed` runs were live against one worktree at once (pids 61511 and 44575 on `wt/gcclist`), each verifying a tree the other session was still changing; any verdict from that window was meaningless and neither said so (Main's post-mortem). Together with #138's tree rules this makes "one card, one branch, one worktree" a hook rather than a convention: the guard refuses writes into another session's tree, `board bind` refuses a held tree, and the gate refuses to run beside another gate on the same tree.

One run per tree at a time: a pid file per tree, refused while its holder is a living `check.sh` (the pid named, with how to look at it), taken over when the holder is dead or a reused pid that is not a gate. The `--committed` trial run is the outer run's own and is not a second gate.

Card #364. Touches `check.sh` and `host-tests/checksh` like #134; different regions.

**Verified**: `host-tests/checksh` (149 checks) lifts the block and drives it: a free tree proceeds and leaves this pid; a living `check.sh` holder (a sleeper wearing the name) refuses and is named; a dead holder is taken over; a living pid that is not a gate is taken over.

**Not verified**: later `trap ... EXIT` lines in check.sh replace this block's cleanup, so a finished run can leave its pid file behind; by construction that is taken over on the next run, never refused, and the file is one line under TMPDIR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)