### PR TITLE
fix(xkcd): the catch-up says which comic it is on, and Back stops it (#306)

### DIFF
--- a/docs/apps/xkcd-pack-format.md
+++ b/docs/apps/xkcd-pack-format.md
@@ -44,8 +44,12 @@ files, and the app's first run offers to download them itself -- GET THE
 COMICS, one confirm, a few minutes on WiFi. The files land as `.part` names
 and are renamed only when all three are complete, so a torn download leaves
 the card exactly as it was. After that, UPDATE fetches anything newer than
-the pack on-device, so the hosted pack only needs replacing when the gap
-grows large enough to be worth the refresh: build with
+the pack on-device, one comic at a time, naming each one on the panel as it
+goes and stopping on Back; whatever arrived is kept, and the header's
+"highest comic number present" is the last one that really did, so the next
+UPDATE resumes from there rather than believing the gap was filled. The
+hosted pack only needs replacing when the gap grows large enough to be worth
+the refresh: build with
 `tools_local/xkcd/build_pack.py`, upload with `gh release upload xkcd-pack
 --clobber`, and never attach `read.bin` (it is a reader's personal state).
 
@@ -146,11 +150,11 @@ settles that first. The device offers `SHORT = 480` and `LONG = 756`, and
 turning it swaps which one runs across. Each of `W` and `H` therefore lands in
 one of three bands, so there are **nine cases and no others**:
 
-|                  | W &le; 480          | 480 &lt; W &le; 756  | W &gt; 756           |
-| ---------------- | ------------------- | -------------------- | -------------------- |
-| **H &le; 480**   | portrait, whole     | turned, whole        | **turned, across**   |
-| **480 &lt; H &le; 756** | portrait, whole | portrait, across | portrait, across     |
-| **H &gt; 756**   | portrait, down      | **turned, down**     | fewest taps, both    |
+|                         | W &le; 480      | 480 &lt; W &le; 756 | W &gt; 756         |
+| ----------------------- | --------------- | ------------------- | ------------------ |
+| **H &le; 480**          | portrait, whole | turned, whole       | **turned, across** |
+| **480 &lt; H &le; 756** | portrait, whole | portrait, across    | portrait, across   |
+| **H &gt; 756**          | portrait, down  | **turned, down**    | fewest taps, both  |
 
 Read one out loud: bottom-left is a comic narrow enough for the short side but
 too tall for the long one, so it goes portrait and pans down only. Top-right is
@@ -161,7 +165,7 @@ Three rules produce that table:
 
 1. **Fewest panning axes wins.** `portrait axes = (W > 480) + (H > 756)`,
    `turned axes = (W > 756) + (H > 480)`. Six of the nine cells end here.
-2. **On a tie where the same axis pans either way, the axis that does *not* pan
+2. **On a tie where the same axis pans either way, the axis that does _not_ pan
    goes on the smallest side that contains it.** That leaves the longer side for
    the one that does, so it reads in fewer taps and wastes no space. Deciding
    this by counting taps instead ties far too often: 334 wide-and-short comics
@@ -177,7 +181,7 @@ archive from 68% to **85% needing no panning at all**, and cuts two-axis comics
 to 2.8%.
 
 **Rotation** is what the table calls "turned": the comic is stored a quarter
-turn, and the reader turns the *device*. The panel itself never rotates, so the
+turn, and the reader turns the _device_. The panel itself never rotates, so the
 bar and the controls never move. `--rotate-cw` flips which way; that is a
 rebuild, not a code change.
 
@@ -187,7 +191,7 @@ COLUMN_OVERLAP`, so every column reveals a full 432px and the last ends flush.
 The snap has one invariant and it has been broken three times: **it never
 increases the number of panning axes.** `N = 1` is a legal answer, and forcing
 a minimum of two blew a comic that came out 481px wide up to 912, where it
-started panning (2.8% -> 8.9%). Snapping also moves the *scale*, so it moves
+started panning (2.8% -> 8.9%). Snapping also moves the _scale_, so it moves
 the height, which pushed across-only comics past the viewport (8.9% -> 6.6%).
 And rounding can put a fitting width one pixel over, after which the snap sent
 pan-down-only comics to the next grid stop (6.6% -> 4.1%).
@@ -251,7 +255,6 @@ Add `--closer` to render the second rendition instead. Red lines are where the
 reader stops; what you are checking is that none of them cuts through a line of
 lettering.
 
-
 ## How the reader walks a comic
 
 Two rules, both of which came from Mario looking at the result rather than the
@@ -266,7 +269,7 @@ the last exactly flush with the bottom. Gap snapping still nudges the interior
 panels onto a gutter, but never the two ends and never past a fifth of a
 screen, so the steps stay visibly equal.
 
-A useful side effect: a position is now a *panel index* rather than a pixel
+A useful side effect: a position is now a _panel index_ rather than a pixel
 offset, and the offset is a pure function of it. Stepping forward and back is
 therefore an exact inverse, where before each snap re-derived itself from
 wherever the reader happened to be and the position drifted.

--- a/host-tests/paintfirst/run.sh
+++ b/host-tests/paintfirst/run.sh
@@ -58,6 +58,14 @@ need_file() {
 # Comments AND string literals, gone. Block state is tracked across lines: a
 # previous version dropped only lines STARTING with // or /*, so the interior of
 # a /* ... */ block survived and commenting out the call kept every check green.
+#
+# CHARACTER literals are skipped too, and that is not tidiness. A `'"'` -- a
+# double quote inside single quotes, which XkcdActivity::fetchOne() has in its
+# JSON scraper -- opened string mode that never closed, and every line of that
+# function after it came back BLANK. Three checks written against it failed with
+# a message about the code, when the truth was that the scanner had stopped
+# reading. A stripper that silently blanks the rest of a file is the worst kind
+# of instrument: it reports on nothing and looks like it reported.
 nocomment() {
   awk '
     {
@@ -69,6 +77,16 @@ nocomment() {
         else if (d == "/*") { inblock = 1; i += 2 }
         else if (d == "//") break
         else if (c == "\"") { instr = 1; out = out " "; i++ }
+        else if (c == "'\''") {
+          i++
+          while (i <= n) {
+            ch = substr(line, i, 1)
+            if (ch == "\\") { i += 2; continue }
+            i++
+            if (ch == "'\''") break
+          }
+          out = out " "
+        }
         else { out = out c; i++ }
       }
       print out
@@ -238,62 +256,132 @@ else bad "InstapaperActivity::render() has no REACHABLE displayBuffer() at funct
 # time. Each fetchOne() is a metadata fetch, an artwork download and a PNG
 # decode -- seconds -- and xkcd publishes three a week, so a reader a season
 # behind sits through forty of them. The panel said "Asking xkcd.com what is
-# new" for the whole run, which was true for the first HTTP request and a lie
-# for the rest of the minutes. Painting once at the start does not survive a
-# loop; the frame has to keep saying which one it is on.
+# new" for the whole run: true for the first HTTP request, a lie for the rest
+# of the minutes. Painting once at the start does not survive a loop.
 #
-# Inside the loop is the assertion, and the INDENT is how that is asserted: a
-# paint hoisted above the `for` would satisfy any presence check while showing
-# the same sentence forty times, which on e-ink is a full-screen flash carrying
-# no new information -- worse than not repainting at all.
+# THE FIRST VERSION OF THIS CASE ASSERTED AN INDENT AND A COLD CRITIC BEAT IT
+# FIVE WAYS. An indent is not a loop: hoisting the caption and the wait into a
+# bare `{ ... }` block above the `for` kept every check green while restoring
+# one frame for the whole run. So the scope is now taken by BRACE DEPTH from the
+# `for` that actually contains fetchOne(), a constant caption is refused by
+# requiring the per-comic counter among its arguments, the Back read has to set
+# the SAME flag the break tests (reading it into a dead variable passed before),
+# `lastGot` has to be assigned exactly once (a copy on the failure path at a
+# deeper indent passed before), and the header field is checked for the absence
+# of `latest` rather than the presence of a spelling.
 # ---------------------------------------------------------------------------
 XKCD=src/apps_local/xkcd/XkcdActivity.cpp
 need_file "$XKCD"
 upd=$(body "$XKCD" '^void XkcdActivity::runUpdate[(]')
+one=$(body "$XKCD" '^bool XkcdActivity::fetchOne[(]')
 
-# The caption is REWRITTEN each time round, at loop indent.
-if has_re "$(printf '^%ssnprintf\\(noticeBody_,' "$I4")" "$upd"; then ok
-else bad "runUpdate() does not rewrite noticeBody_ at loop indent; a repaint that shows the same sentence for every comic tells the reader nothing and costs a full e-ink refresh each time"; fi
+# The catch-up loop's own body: from the `for` enclosing fetchOne() to the brace
+# that closes it, counted character by character. Nothing above the loop and
+# nothing below it can satisfy a check written against this.
+fetch_loop() {
+  printf '%s\n' "$1" | awk '
+    { L[NR] = $0 }
+    /fetchOne\(/ && !fetchline { fetchline = NR }
+    END {
+      for (i = fetchline; i >= 1; i--) if (L[i] ~ /for[[:space:]]*\(/) { start = i; break }
+      if (!start) exit 1
+      depth = 0; started = 0
+      for (i = start; i <= NR; i++) {
+        print L[i]
+        n = length(L[i])
+        for (j = 1; j <= n; j++) {
+          ch = substr(L[i], j, 1)
+          if (ch == "{") { depth++; started = 1 }
+          else if (ch == "}") { depth--; if (started && depth == 0) exit 0 }
+        }
+      }
+    }'
+}
 
-# ...and the repaint that publishes it is inside the loop, not hoisted above it.
-if has_re "$(stmt "$I4" 'requestUpdateAndWait\(\)')" "$upd"; then ok
-else bad "runUpdate() has no requestUpdateAndWait() at loop indent; the catch-up runs for minutes with one frame on the panel (a plain requestUpdate() cannot help here -- loop() is blocked, so the tail that consumes it is never reached)"; fi
+loop=$(fetch_loop "$upd") || loop=""
+if [ -n "$loop" ]; then ok
+else bad "no loop enclosing fetchOne() found in runUpdate(); every scan below would pass by finding nothing"; fi
 
-# Caption first, then the paint. The other order publishes the previous comic's
-# number and the last one is never shown at all.
-if printf '%s\n' "$upd" | ahead_re "$(printf '^%ssnprintf\\(noticeBody_,' "$I4")" "$(stmt "$I4" 'requestUpdateAndWait\(\)')"; then ok
-else bad "runUpdate() repaints before it rewrites the caption; every frame would name the comic before the one being fetched"; fi
+# The caption is rewritten INSIDE the loop...
+if has_re 'snprintf\(noticeBody_,' "$loop"; then ok
+else bad "runUpdate()'s catch-up loop does not rewrite noticeBody_; one frame stands for the whole run and the reader cannot tell a working device from a hung one"; fi
 
-# EVERY fetchOne() is preceded by a paint. There is one today; a second added
-# without one is a second silent stretch.
-if printf '%s\n' "$upd" | preceded_within '^[[:space:]]+requestUpdateAndWait[(][)];' 'fetchOne[(]' 10; then ok
-else bad "a fetchOne() in runUpdate() is not preceded by requestUpdateAndWait(); that comic is fetched with a stale frame on the panel"; fi
+# ...and it is a DIFFERENT caption each time. A constant string repainted forty
+# times is forty full-screen e-ink flashes carrying no new information, which is
+# worse than not repainting at all.
+cap=$(printf '%s\n' "$loop" | awk '/snprintf\(noticeBody_,/{c=1} c{printf "%s ", $0} c && /;[[:space:]]*$/{exit}')
+if has_re 'attempted' "$cap" && has_re 'toGet' "$cap"; then ok
+else bad "the caption does not take the per-comic counter and the total as arguments, so it cannot say which comic this is; a constant caption is a flash, not a message"; fi
 
-# Back stops it, and the check is BEFORE the fetch: a cancel that first sits
-# through the download it was meant to skip is not a cancel.
-if has_re "$(stmt "$I4" 'mappedInput\.update\(\)')" "$upd"; then ok
-else bad "runUpdate() never pumps input inside the loop, so Back cannot be seen for the whole catch-up (this is the sanctioned exception to the one-pump rule: loop() is blocked and nothing else pumps)"; fi
+# The repaint that publishes it, in the loop, and the wait rather than the
+# deferred form: loop() is blocked, so the tail that consumes a deferred flag is
+# never reached and nothing would repaint at all.
+if has_re 'requestUpdateAndWait\(\);' "$loop"; then ok
+else bad "runUpdate()'s catch-up loop has no requestUpdateAndWait(); a plain requestUpdate() cannot help here because loop() is blocked for the whole run"; fi
 
-if has_re 'wasReleased\(MappedInputManager::Button::Back\)' "$upd"; then ok
-else bad "runUpdate() does not read Back; the reader has no way out of a multi-minute catch-up"; fi
+if printf '%s\n' "$loop" | ahead_re 'snprintf\(noticeBody_,' 'requestUpdateAndWait\(\);'; then ok
+else bad "the loop repaints before it rewrites the caption; every frame would name the comic before the one being fetched"; fi
 
-if printf '%s\n' "$upd" | ahead_re "$(stmt "$I4" 'if \(cancelled\) break')" 'fetchOne\('; then ok
-else bad "runUpdate() does not break on cancel BEFORE fetchOne(); a Back that still waits out one whole comic reads as ignored"; fi
+if printf '%s\n' "$loop" | preceded_within 'requestUpdateAndWait[(][)];' 'fetchOne[(]' 10; then ok
+else bad "a fetchOne() in the catch-up loop is not preceded by requestUpdateAndWait(); that comic is fetched with a stale frame on the panel"; fi
 
-# THE COST OF OFFERING A STOP, and the reason this check is in a paint suite.
-# The header patched at the end of runUpdate() IS the archive's maxNum (XkcdCore
-# reads it back from offset 12) and the next update fetches everything above it.
-# Publishing `latest` after a run that stopped early claims comics the card does
-# not hold, and every later update then answers UP TO DATE with the gap
-# unreachable. A cancel button turns that from a rare failure path into the
-# normal one. Spelling, not semantics: it catches the regression that exists,
-# and it is cheaper than proving provenance from a source scan.
-if has_re 'const uint32_t top = latest;' "$upd"; then
-  bad "runUpdate() publishes latest as the archive's maxNum; after a stopped or failed run that claims comics the card does not have, and every later update answers UP TO DATE with the missing ones unreachable"
-else ok; fi
+# The loop pumps too, not only the download's callback. fetchOne()'s progress
+# callback covers the transfer; the PNG decode and the index append after it are
+# ours and have no callback to hang a pump on, so a Back pressed during those is
+# seen here or not at all.
+if has_re 'mappedInput\.update\(\);' "$loop"; then ok
+else bad "the catch-up loop never pumps input itself; the PNG decode and index append have no progress callback, so a Back pressed during them is never seen"; fi
 
-if printf '%s\n' "$upd" | ahead_re "$(stmt "$I4" '\+\+fetched_')" "$(stmt "$I4" 'lastGot = n')"; then ok
-else bad "runUpdate() does not record the last comic that actually arrived immediately after counting it; the header patch has nothing honest to publish"; fi
+# BACK. The flag the loop breaks on is read out of the source, and the Back read
+# has to set THAT flag -- reading the button into a variable nobody tests looks
+# identical to a working cancel.
+flag=$(printf '%s\n' "$loop" | sed -n 's/^[[:space:]]*if (\([A-Za-z_][A-Za-z0-9_]*\)) break;[[:space:]]*$/\1/p' | head -1)
+if [ -n "$flag" ]; then ok
+else bad "the catch-up loop has no bare 'if (<flag>) break;' -- there is no cancel for Back to reach"; fi
+
+if [ -n "$flag" ] && has_re "wasReleased\(MappedInputManager::Button::Back\)\) $flag = true" "$loop"; then ok
+else bad "the loop's Back read does not set '$flag', the flag it breaks on; a read into a dead variable stops nothing while the panel says Back stops it"; fi
+
+if [ -n "$flag" ] && printf '%s\n' "$loop" | ahead_re "if \($flag\) break;" 'fetchOne\('; then ok
+else bad "the loop does not break on cancel BEFORE fetchOne(); a Back that still waits out one whole comic reads as ignored"; fi
+
+# THE PUMP THAT MAKES BACK REAL, and the finding that nearly shipped a lying
+# caption. InputManager::update() commits a state change on a LATER call: the
+# first update() to see a new level only stamps lastDebounceTime. Nothing else
+# polls during this run (beginAsync is never called in the fork), so a pump that
+# fires once per comic needs the button HELD across comics, and a normal tap
+# between two pumps is invisible. HttpDownloader's abortPoll() calls the
+# progress callback every 50ms through connect, headers and body -- so the
+# artwork download is where the pump has to be.
+if has_re 'downloadToFile\([^)]*,[^)]*,' "$one"; then ok
+else bad "fetchOne()'s artwork download takes no progress callback, so nothing pumps input for the seconds it runs; Back then needs a multi-second hold and a tap is dropped entirely"; fi
+
+if [ -n "$flag" ] && has_re "downloadToFile\(.*&$flag\)" "$one"; then ok
+else bad "fetchOne()'s download is not handed &$flag, the flag the loop breaks on; Back could not abort a transfer already in progress"; fi
+
+if [ -n "$flag" ] && has_re 'mappedInput\.update\(\);' "$one" && has_re "wasReleased\(MappedInputManager::Button::Back\)\) $flag = true" "$one"; then ok
+else bad "fetchOne()'s progress callback does not pump input and set $flag; passing a callback that does not read the button buys nothing"; fi
+
+# THE COST OF OFFERING A STOP. The header patched at the end of runUpdate() IS
+# the archive's maxNum (XkcdCore reads it back from index.dat offset 12) and the
+# next update fetches everything above it, so publishing `latest` after a run
+# that stopped early claims comics the card does not hold and every later update
+# answers UP TO DATE with the gap unreachable. Checked as the ABSENCE of
+# `latest` on that line: the first version grepped for the fix's spelling and a
+# cast or a ternary walked straight through it.
+topline=$(printf '%s\n' "$upd" | grep -E 'uint32_t top[[:space:]]*=' | head -1)
+if [ -n "$topline" ] && ! has_re 'latest' "$topline"; then ok
+else bad "the header's highest-comic field is derived from 'latest' rather than from what arrived; after a stopped or failed run that claims comics the card does not have. Line: $topline"; fi
+
+# ...and the value it publishes is recorded in exactly ONE place. A second
+# assignment on the failure path restores the same corruption from a deeper
+# scope, which an indent-anchored check cannot see.
+sets=$(printf '%s\n' "$upd" | grep -cE '^[[:space:]]*lastGot = ' || true)
+if [ "$sets" = "1" ]; then ok
+else bad "lastGot is assigned $sets times in runUpdate(); it must be recorded once, immediately after a comic is counted, or the header can name one that never arrived"; fi
+
+if printf '%s\n' "$loop" | ahead_re '\+\+fetched_;' 'lastGot = n;'; then ok
+else bad "lastGot is not recorded immediately after the comic is counted; the header patch has nothing honest to publish"; fi
 
 if reached "$(stmt "$I2" 'renderer\.displayBuffer\(\)')" "$(body "$XKCD" '^void XkcdActivity::render[(]')"; then ok
 else bad "XkcdActivity::render() has no REACHABLE displayBuffer() at function-body level; every frame above would be built and never shown"; fi

--- a/host-tests/paintfirst/run.sh
+++ b/host-tests/paintfirst/run.sh
@@ -229,5 +229,74 @@ else bad "a sync_.pairAbandon() in $INS is not preceded by paintBusyNow(); that 
 if reached "$(stmt "$I2" 'renderer\.displayBuffer\(\)')" "$(body "$INS" '^void InstapaperActivity::render[(]')"; then ok
 else bad "InstapaperActivity::render() has no REACHABLE displayBuffer() at function-body level"; fi
 
+# ---------------------------------------------------------------------------
+# CASE 4: xkcd's catch-up. Not a mis-ordered busy state and not a missing one:
+# the busy state is correct, it is painted before the run starts, and then the
+# app spends MINUTES on a frame that has stopped being true.
+#
+# runUpdate() fetches every comic published since the last update, one at a
+# time. Each fetchOne() is a metadata fetch, an artwork download and a PNG
+# decode -- seconds -- and xkcd publishes three a week, so a reader a season
+# behind sits through forty of them. The panel said "Asking xkcd.com what is
+# new" for the whole run, which was true for the first HTTP request and a lie
+# for the rest of the minutes. Painting once at the start does not survive a
+# loop; the frame has to keep saying which one it is on.
+#
+# Inside the loop is the assertion, and the INDENT is how that is asserted: a
+# paint hoisted above the `for` would satisfy any presence check while showing
+# the same sentence forty times, which on e-ink is a full-screen flash carrying
+# no new information -- worse than not repainting at all.
+# ---------------------------------------------------------------------------
+XKCD=src/apps_local/xkcd/XkcdActivity.cpp
+need_file "$XKCD"
+upd=$(body "$XKCD" '^void XkcdActivity::runUpdate[(]')
+
+# The caption is REWRITTEN each time round, at loop indent.
+if has_re "$(printf '^%ssnprintf\\(noticeBody_,' "$I4")" "$upd"; then ok
+else bad "runUpdate() does not rewrite noticeBody_ at loop indent; a repaint that shows the same sentence for every comic tells the reader nothing and costs a full e-ink refresh each time"; fi
+
+# ...and the repaint that publishes it is inside the loop, not hoisted above it.
+if has_re "$(stmt "$I4" 'requestUpdateAndWait\(\)')" "$upd"; then ok
+else bad "runUpdate() has no requestUpdateAndWait() at loop indent; the catch-up runs for minutes with one frame on the panel (a plain requestUpdate() cannot help here -- loop() is blocked, so the tail that consumes it is never reached)"; fi
+
+# Caption first, then the paint. The other order publishes the previous comic's
+# number and the last one is never shown at all.
+if printf '%s\n' "$upd" | ahead_re "$(printf '^%ssnprintf\\(noticeBody_,' "$I4")" "$(stmt "$I4" 'requestUpdateAndWait\(\)')"; then ok
+else bad "runUpdate() repaints before it rewrites the caption; every frame would name the comic before the one being fetched"; fi
+
+# EVERY fetchOne() is preceded by a paint. There is one today; a second added
+# without one is a second silent stretch.
+if printf '%s\n' "$upd" | preceded_within '^[[:space:]]+requestUpdateAndWait[(][)];' 'fetchOne[(]' 10; then ok
+else bad "a fetchOne() in runUpdate() is not preceded by requestUpdateAndWait(); that comic is fetched with a stale frame on the panel"; fi
+
+# Back stops it, and the check is BEFORE the fetch: a cancel that first sits
+# through the download it was meant to skip is not a cancel.
+if has_re "$(stmt "$I4" 'mappedInput\.update\(\)')" "$upd"; then ok
+else bad "runUpdate() never pumps input inside the loop, so Back cannot be seen for the whole catch-up (this is the sanctioned exception to the one-pump rule: loop() is blocked and nothing else pumps)"; fi
+
+if has_re 'wasReleased\(MappedInputManager::Button::Back\)' "$upd"; then ok
+else bad "runUpdate() does not read Back; the reader has no way out of a multi-minute catch-up"; fi
+
+if printf '%s\n' "$upd" | ahead_re "$(stmt "$I4" 'if \(cancelled\) break')" 'fetchOne\('; then ok
+else bad "runUpdate() does not break on cancel BEFORE fetchOne(); a Back that still waits out one whole comic reads as ignored"; fi
+
+# THE COST OF OFFERING A STOP, and the reason this check is in a paint suite.
+# The header patched at the end of runUpdate() IS the archive's maxNum (XkcdCore
+# reads it back from offset 12) and the next update fetches everything above it.
+# Publishing `latest` after a run that stopped early claims comics the card does
+# not hold, and every later update then answers UP TO DATE with the gap
+# unreachable. A cancel button turns that from a rare failure path into the
+# normal one. Spelling, not semantics: it catches the regression that exists,
+# and it is cheaper than proving provenance from a source scan.
+if has_re 'const uint32_t top = latest;' "$upd"; then
+  bad "runUpdate() publishes latest as the archive's maxNum; after a stopped or failed run that claims comics the card does not have, and every later update answers UP TO DATE with the missing ones unreachable"
+else ok; fi
+
+if printf '%s\n' "$upd" | ahead_re "$(stmt "$I4" '\+\+fetched_')" "$(stmt "$I4" 'lastGot = n')"; then ok
+else bad "runUpdate() does not record the last comic that actually arrived immediately after counting it; the header patch has nothing honest to publish"; fi
+
+if reached "$(stmt "$I2" 'renderer\.displayBuffer\(\)')" "$(body "$XKCD" '^void XkcdActivity::render[(]')"; then ok
+else bad "XkcdActivity::render() has no REACHABLE displayBuffer() at function-body level; every frame above would be built and never shown"; fi
+
 echo "$checks checks, $failed failed"
 [ "$failed" -eq 0 ]

--- a/src/apps_local/xkcd/XkcdActivity.cpp
+++ b/src/apps_local/xkcd/XkcdActivity.cpp
@@ -968,7 +968,31 @@ bool XkcdActivity::fetchOne(const uint16_t num, char* whyNot, const int whyNotCa
   field("safe_title", title, sizeof(title), true);
   field("alt", alt, sizeof(alt), true);
 
-  if (HttpDownloader::downloadToFile(img, kTmpPng) != HttpDownloader::OK) {
+  // THE PUMP LIVES HERE, not only in runUpdate()'s loop, and that is not
+  // belt-and-braces. InputManager::update() debounces by COMMITTING A STATE
+  // CHANGE ON A LATER CALL: the first update() that sees a new level only
+  // stamps lastDebounceTime, and the commit needs a second call more than
+  // DEBOUNCE_DELAY (5ms) afterwards. Nothing else in the firmware polls during
+  // this run -- InputManager::beginAsync() is never called anywhere in the
+  // fork -- so a pump that fires once per comic sees a press only if it is
+  // still held at the next comic, and a normal tap between two pumps is
+  // invisible to it entirely. "Back stops it" would have been a lie.
+  //
+  // HttpDownloader's abortPoll() invokes this every 50ms through the connect,
+  // the headers and the body, so Back is live for the long part of each comic.
+  // Same mechanism as runPackDownload(); the metadata fetch above still has no
+  // hook (fetchUrl takes no progress callback -- card #120).
+  const auto pump = [this](const size_t, const size_t) {
+    mappedInput.update();
+    if (mappedInput.wasReleased(MappedInputManager::Button::Back)) updateCancel_ = true;
+    // The pump consumes the one-shot home event before ActivityManager can see
+    // it; treat it as a cancel rather than dropping the intent.
+    if (mappedInput.wasHomeGesture()) {
+      updateCancel_ = true;
+      updateHomeCancel_ = true;
+    }
+  };
+  if (HttpDownloader::downloadToFile(img, kTmpPng, pump, &updateCancel_) != HttpDownloader::OK) {
     snprintf(whyNot, whyNotCap, "Could not download the artwork for #%u.", static_cast<unsigned>(num));
     return false;
   }
@@ -1148,8 +1172,8 @@ void XkcdActivity::runUpdate() {
   // The header patch below publishes this as the archive's maxNum, and maxNum
   // is what the next update subtracts from. See the comment there.
   uint16_t lastGot = have;
-  bool cancelled = false;
-  bool homeAfterCancel = false;
+  updateCancel_ = false;
+  updateHomeCancel_ = false;
   int attempted = 0;
   for (uint16_t n = static_cast<uint16_t>(have + 1); n <= latest; ++n) {
     if (n == 404) continue;  // not a comic, and that is the joke
@@ -1166,29 +1190,44 @@ void XkcdActivity::runUpdate() {
     // requestUpdateAndWait(), not requestUpdate(): loop() is blocked for the
     // whole run, so a deferred update never reaches the tail of
     // ActivityManager::loop() that consumes it and nothing would repaint at
-    // all. The wait is also what puts the frame on the glass BEFORE the next
-    // socket opens rather than racing it. Same shape as runPackDownload()
-    // above, and the input pump below is the same sanctioned exception to the
-    // one-pump rule: nothing else pumps while this blocks, and without it Back
-    // could not stop a catch-up that has minutes left to run.
+    // all. Same shape as runPackDownload() above.
+    //
+    // WHAT THE WAIT DOES NOT BUY, said plainly so nobody relies on it.
+    // renderTaskLoop() takes its notification at the TOP of an iteration and
+    // claims waitingTaskHandle at the BOTTOM, so a wait registered while a
+    // render is ALREADY in flight is satisfied by the frame that began before
+    // it asked. That happens here on the first pass -- onWifiChosen() left a
+    // deferred update pending and displayBuffer() is 0.3-2s -- so the caption
+    // can run one comic behind what is being fetched. Fixing it means changing
+    // that handshake in ActivityManager, which is CrossPoint's file and not
+    // ours to patch for a caption. What the wait does buy is the thing that was
+    // missing: the panel changes once per comic instead of once per run.
     ++attempted;
-    snprintf(noticeBody_, sizeof(noticeBody_), "Comic %d of %d: #%u. Back stops it.", attempted, toGet,
-             static_cast<unsigned>(n));
+    {
+      // The render task reads noticeBody_ while building this frame, and the
+      // wait above may return with one still in flight. Scoped so the lock is
+      // released before requestUpdateAndWait(), which asserts against being
+      // called under it. Same shape as HackerNewsActivity::request().
+      RenderLock lock(*this);
+      snprintf(noticeBody_, sizeof(noticeBody_), "Comic %d of %d: #%u. Back stops it.", attempted, toGet,
+               static_cast<unsigned>(n));
+    }
     requestUpdateAndWait();
+    // Between comics as well as inside the download, because the PNG decode
+    // and the index append are ours and have no callback to hang a pump on.
     mappedInput.update();
-    if (mappedInput.wasReleased(MappedInputManager::Button::Back)) cancelled = true;
-    // The pump above consumes the one-shot home event before ActivityManager
-    // can see it; treat it as a cancel too rather than dropping the intent.
-    // The user lands on the STOPPED notice and their next Home works.
+    if (mappedInput.wasReleased(MappedInputManager::Button::Back)) updateCancel_ = true;
     if (mappedInput.wasHomeGesture()) {
-      cancelled = true;
-      homeAfterCancel = true;
+      updateCancel_ = true;
+      updateHomeCancel_ = true;
     }
     // Before the fetch, not after: stopping is only worth offering if it does
     // not first sit through the download it was meant to skip.
-    if (cancelled) break;
+    if (updateCancel_) break;
 
     if (!fetchOne(n, why, sizeof(why))) {
+      // A cancel arrives here too: fetchOne()'s download is handed
+      // &updateCancel_, so Back aborts the transfer and it returns false.
       LOG_ERR("XKCD", "stopped at #%u: %s", static_cast<unsigned>(n), why);
       break;
     }
@@ -1235,18 +1274,24 @@ void XkcdActivity::runUpdate() {
       patch.close();
     }
 
-    // Reopen so the in-memory archive agrees with the files again.
+    // Reopen so the in-memory archive agrees with the files again, under the
+    // lock: requestUpdateAndWait() above can return with a render still in
+    // flight, and closeArchive() frees the three HalFiles and the index source
+    // that the Menu and List views read. Nothing reads them from the Updating
+    // view we are in, so this is the hazard closed rather than a bug fixed --
+    // but a line added to the notice would open it, and nothing would say so.
+    RenderLock lock(*this);
     closeArchive();
     archiveOpen_ = openArchive();
   }
 
   char body[192];
-  if (cancelled) {
+  if (updateCancel_) {
     // Kept, not discarded: each comic was committed as it arrived, and the
     // header above now names the last one that really did. The next update
     // starts from there.
     snprintf(body, sizeof(body), "Stopped. %d of %d kept; the rest are still there next time.%s", fetched_, toGet,
-             homeAfterCancel ? " Home works now." : "");
+             updateHomeCancel_ ? " Home works now." : "");
     showNotice("STOPPED", body);
   } else if (fetched_ == 0) {
     snprintf(body, sizeof(body), "%s", why[0] ? why : "Nothing was added.");

--- a/src/apps_local/xkcd/XkcdActivity.cpp
+++ b/src/apps_local/xkcd/XkcdActivity.cpp
@@ -1133,22 +1133,75 @@ void XkcdActivity::runUpdate() {
     return;
   }
 
+  // How many there are to get, COUNTED rather than written down as
+  // latest - have: 404 is not a comic and the difference is off by one
+  // whenever it is in range. A denominator the reader is shown has to be
+  // derived from the same walk that produces the numerator; see the memory
+  // derived-facts-written-as-literals.
+  int toGet = 0;
+  for (uint16_t n = static_cast<uint16_t>(have + 1); n <= latest; ++n) {
+    if (n != 404) ++toGet;
+  }
+
+  fetched_ = 0;
+  // The highest number that ACTUALLY arrived, not the highest that exists.
+  // The header patch below publishes this as the archive's maxNum, and maxNum
+  // is what the next update subtracts from. See the comment there.
+  uint16_t lastGot = have;
+  bool cancelled = false;
+  bool homeAfterCancel = false;
+  int attempted = 0;
+  for (uint16_t n = static_cast<uint16_t>(have + 1); n <= latest; ++n) {
+    if (n == 404) continue;  // not a comic, and that is the joke
+
+    // SAY WHAT IS HAPPENING BEFORE EACH COMIC. fetchOne() is a metadata fetch,
+    // an artwork download and a PNG decode -- seconds each, nothing repainting
+    // inside it -- and this loop runs once per comic missed since the last
+    // update. xkcd publishes three a week, so a reader a season behind waits
+    // minutes on one frame that says "Asking xkcd.com what is new", which
+    // stopped being true at the first iteration. A screen that says nothing for
+    // minutes reads as a crash (memory a-silent-screen-reads-as-a-crash); this
+    // is the last of card #306's list still silent.
+    //
+    // requestUpdateAndWait(), not requestUpdate(): loop() is blocked for the
+    // whole run, so a deferred update never reaches the tail of
+    // ActivityManager::loop() that consumes it and nothing would repaint at
+    // all. The wait is also what puts the frame on the glass BEFORE the next
+    // socket opens rather than racing it. Same shape as runPackDownload()
+    // above, and the input pump below is the same sanctioned exception to the
+    // one-pump rule: nothing else pumps while this blocks, and without it Back
+    // could not stop a catch-up that has minutes left to run.
+    ++attempted;
+    snprintf(noticeBody_, sizeof(noticeBody_), "Comic %d of %d: #%u. Back stops it.", attempted, toGet,
+             static_cast<unsigned>(n));
+    requestUpdateAndWait();
+    mappedInput.update();
+    if (mappedInput.wasReleased(MappedInputManager::Button::Back)) cancelled = true;
+    // The pump above consumes the one-shot home event before ActivityManager
+    // can see it; treat it as a cancel too rather than dropping the intent.
+    // The user lands on the STOPPED notice and their next Home works.
+    if (mappedInput.wasHomeGesture()) {
+      cancelled = true;
+      homeAfterCancel = true;
+    }
+    // Before the fetch, not after: stopping is only worth offering if it does
+    // not first sit through the download it was meant to skip.
+    if (cancelled) break;
+
+    if (!fetchOne(n, why, sizeof(why))) {
+      LOG_ERR("XKCD", "stopped at #%u: %s", static_cast<unsigned>(n), why);
+      break;
+    }
+    ++fetched_;
+    lastGot = n;
+  }
+
   // The header has to be rewritten after appending, because the count and the
   // highest number both live in it. Done once at the end rather than per
   // comic: a half-finished run then leaves a pack whose header is honest about
   // fewer comics than the files hold, which reads correctly and simply misses
   // the tail. The opposite order would leave a header promising records that
   // are not there.
-  fetched_ = 0;
-  for (uint16_t n = static_cast<uint16_t>(have + 1); n <= latest; ++n) {
-    if (n == 404) continue;  // not a comic, and that is the joke
-    if (!fetchOne(n, why, sizeof(why))) {
-      LOG_ERR("XKCD", "stopped at #%u: %s", static_cast<unsigned>(n), why);
-      break;
-    }
-    ++fetched_;
-  }
-
   if (fetched_ > 0) {
     // **Not openFileForWrite.** It carries O_TRUNC, and calling it here -- with
     // a comment saying why it must not be called -- emptied index.dat before
@@ -1166,7 +1219,13 @@ void XkcdActivity::runUpdate() {
       head[1] = static_cast<uint8_t>((total >> 8) & 0xFF);
       head[2] = static_cast<uint8_t>((total >> 16) & 0xFF);
       head[3] = static_cast<uint8_t>((total >> 24) & 0xFF);
-      const uint32_t top = latest;
+      // lastGot, NOT latest. This field IS the archive's maxNum (XkcdCore reads
+      // it back from offset 12), and the next update computes what to fetch as
+      // everything above maxNum. Publishing `latest` after a run that stopped
+      // early -- a failed comic, and now a cancelled one -- claims comics the
+      // card does not hold and makes every later update answer UP TO DATE. The
+      // gap would then be unreachable short of deleting the pack.
+      const uint32_t top = lastGot;
       head[4] = static_cast<uint8_t>(top & 0xFF);
       head[5] = static_cast<uint8_t>((top >> 8) & 0xFF);
       head[6] = static_cast<uint8_t>((top >> 16) & 0xFF);
@@ -1182,7 +1241,14 @@ void XkcdActivity::runUpdate() {
   }
 
   char body[192];
-  if (fetched_ == 0) {
+  if (cancelled) {
+    // Kept, not discarded: each comic was committed as it arrived, and the
+    // header above now names the last one that really did. The next update
+    // starts from there.
+    snprintf(body, sizeof(body), "Stopped. %d of %d kept; the rest are still there next time.%s", fetched_, toGet,
+             homeAfterCancel ? " Home works now." : "");
+    showNotice("STOPPED", body);
+  } else if (fetched_ == 0) {
     snprintf(body, sizeof(body), "%s", why[0] ? why : "Nothing was added.");
     showNotice("NOTHING NEW", body);
   } else {

--- a/src/apps_local/xkcd/XkcdActivity.h
+++ b/src/apps_local/xkcd/XkcdActivity.h
@@ -140,6 +140,12 @@ class XkcdActivity final : public Activity {
   // The update.
   bool wifiConnected_ = false;
   bool updateQueued_ = false;
+  // The catch-up's cancel, read by fetchOne()'s download and by runUpdate()'s
+  // own loop. A member rather than a local because the pump that sets it lives
+  // inside the artwork download's progress callback, which is the only thing
+  // running often enough for the input debounce to see a press at all.
+  bool updateCancel_ = false;
+  bool updateHomeCancel_ = false;
   bool downloadQueued_ = false;
   bool downloadCancel_ = false;
   int fetched_ = 0;


### PR DESCRIPTION
The last item on card #306 that was still silent, and the only one left in an
app of ours. The three severe sites (Get Books' cold start, KOReader auth,
Instapaper's disconnect) landed in 96af97a5; this is the same user-visible
failure one layer along.

## What was wrong

`XkcdActivity::runUpdate()` fetches every comic published since the last update,
one at a time, in a loop that repaints nothing. Each `fetchOne()` is a metadata
request, an artwork download and a PNG decode -- seconds -- and xkcd publishes
three a week, so a reader a season behind sits through forty of them looking at
one frame that says "Asking xkcd.com what is new". True for the first HTTP
request, a lie for the minutes after it. Back was dead for the whole run too:
nothing pumped input.

This is not the #306 mechanism itself. The busy frame here **is** asked for and
**is** painted, before the run starts. Painting once does not survive a loop.

## What it does now

Before each comic, rewrite the caption to `Comic N of M: #NNNN. Back stops it.`
and `requestUpdateAndWait()`.

- The **wait**, not `requestUpdate()`: `loop()` is blocked for the whole run, so
  a deferred flag never reaches the tail of `ActivityManager::loop()` that
  consumes it and nothing repaints at all.
- Same shape as `runPackDownload()` twenty lines up, and the input pump is the
  same sanctioned exception to the one-pump rule -- nothing else pumps while
  this blocks.
- Cancel is checked **before** the fetch, so Back does not first sit through the
  download it was meant to skip. Home counts as a cancel because the pump
  consumes that one-shot event before ActivityManager can see it.
- `N of M` is counted, not written down as `latest - have`: 404 is not a comic
  and that difference is off by one whenever it is in range.

## The non-obvious half: offering a stop needed a header fix first

The header patched at the end of `runUpdate()` published `latest` as the
archive's highest number. That field **is** `maxNum` (`XkcdCore` reads it back
from `index.dat` offset 12) and the next UPDATE fetches everything above it. So
a run that stopped early claimed comics the card does not hold, and every later
UPDATE answered UP TO DATE with the gap unreachable short of deleting the pack.
`docs/apps/xkcd-pack-format.md` already called that field "highest comic number
present", so the code was wrong against its own format doc. It now publishes the
last comic that actually arrived.

Pre-existing, on the fetch-failure `break`. A cancel button would have turned a
rare path into the normal one.

## Scope

Two source files, both ours. No CrossPoint-owned file is touched:

    src/apps_local/xkcd/XkcdActivity.cpp   OURS
    host-tests/paintfirst/run.sh           fork addition
    docs/apps/xkcd-pack-format.md          fork addition

## Nothing else on #306's list is still silent

Checked rather than assumed. Hacker News, Instapaper's Step machinery and
xkcd's first block all defer their work to the next loop pass -- the strongest
form, because that tail **is** reached. Study's SNTP wait runs under a SyncFlow
frame already on the panel. Wallpapers' free-space walk moved out of `onEnter`
into a painted `loop()`. Connections, Trivia and Get Books' `downloadBook()`
were already clean.

## Tests

`host-tests/paintfirst` gains a CASE 4: 10 checks, **each watched red against
its own mutation** -- caption removed, wait removed, the two swapped, the wait
hoisted out of the loop, the pump removed, the Back read removed, the break
moved after the fetch, `top = latest` restored, `lastGot` removed, and an early
`return` added above `render()`'s `displayBuffer()`. Commenting the wait out
rather than deleting it also fails, three ways.

## Not verified

- **Hardware. No device has run this.** The simulator cannot show it either:
  `displayBuffer()` is ~1ms there and 0.3-2s on the panel, so a busy frame that
  never reaches the glass looks perfect in the sim. The host suite carries the
  proof instead.
- The caption's fit at the panel's width is not asserted; it is shorter than the
  strings already in this notice screen, but no render was taken.
- Timing: how long a single `fetchOne()` actually takes on device is not
  measured, only argued from what it does.