### PR TITLE
fix: xkcd and Wallpapers stop adding the bezel to a chrome-derived body top (#358)

### DIFF
--- a/docs/bezel-insets.md
+++ b/docs/bezel-insets.md
@@ -132,10 +132,13 @@ Two consequences worth keeping straight when touching that helper:
   `screen.header(props)` straight and were missed by the flip: their band
   came off the safe rect, inset on three sides, so it had a white strip
   above it AND a white column down each side, and its bottom edge sat 10px
-  below their own menus'. The paint is fixed; the bottom-edge difference is
-  not -- those eleven still lack `absoluteChrome`, and giving it to them
-  moves their content up by the top inset, which is a layout change to be
-  rendered and judged rather than smuggled into a paint fix.
+  below their own menus'.
+
+  **CLOSED by card 248.** `headerBand()` now calls `absoluteChrome()` itself,
+  unconditionally, so no screen can lack it: the bottom-edge difference this
+  paragraph described as unfixed is gone, and the eleven are absolute like
+  everything else. It also reserves the rule it draws, so `screen.body().y`
+  is the whole chrome rather than the band alone.
 
 What made the flip safe for the screens that DO honor it, in the order the
 traps were found:
@@ -246,7 +249,8 @@ Verified by rendering every app's ENTRY screen plus the shelf, both folders
 and PLAYER in the simulator (21 screens). Note what an entry screen is: a
 menu, and every menu goes through `headerBand()`. That is why the eleven
 board and result screens that did not were not among the 21 and kept a
-three-sided inset band for a fortnight. A sweep scoped to "the screen each
+three-sided inset band for a fortnight (card 248 has since made
+`headerBand()` apply the absolute chrome itself, so no screen can miss it). A sweep scoped to "the screen each
 app opens on" cannot see the screen you spend the whole game looking at.
 
 The ui host-tests could not catch any of it either, and still cannot by

--- a/docs/bezel-insets.md
+++ b/docs/bezel-insets.md
@@ -77,9 +77,30 @@ chrome down by the insets, which ate the gaps the layouts were tuned for
 Battle's helper text crowded the rule) while protecting nothing, because no
 game ever drew content in the covered rows. Cut the hidden millimetre from
 the band and recentre; do not push the screen down. Found on the device,
-not in the sim, both times. What keeps the full safe-area treatment: xkcd
-(its comic and menus reach the panel edge), the readers, and every screen
-laid out from `UITheme::getScreenSafeArea`.
+not in the sim, both times. What keeps the full safe-area treatment: xkcd's
+COMIC (`readerViewport()`, which reaches the panel edge), the readers, and
+every screen laid out from `UITheme::getScreenSafeArea`.
+
+**Not xkcd's menus, and not the Wallpapers grid, whatever this page said
+until card 358.** Both apps took their sides and their bottom off the safe
+rect, correctly, and then added `safe.y` to a body top derived from
+`kHeaderHeight` as well -- so their content started ten pixels below every
+other app's while protecting nothing, because the header band above it
+already paints over the covered rows. Twenty apps agreeing was not the
+evidence that settled it; `host-tests/ui`'s own
+`testTheBandIsAbsoluteWithoutBeingAsked` was, by asserting
+`screen.body().y == kHeaderHeight` on a BEZELLED frame. That makes
+`kHeaderHeight`, `kChromeHeight` and now `toybox::kBodyTop` absolute panel
+rows by construction, and any safe area added to one of them a double count.
+`toybox::kBodyTop` (`ToyboxMetrics.h`) is the shared constant and carries the
+whole argument; the shelf, hacker news, instapaper, xkcd and wallpapers all
+name it now instead of each keeping a private copy.
+
+The reason nothing caught it for as long as either app existed: `host-tests/ui`
+builds every screen against `device()`, whose `safeArea` is empty, so twice
+nothing is nothing. `testTheGlassNeverMovesABodyTop` renders each of those
+screens on both frames and requires the same first body row, which is a rule a
+screen written tomorrow cannot pass by accident.
 
 **The band's PAINT, though, starts at the panel's physical top-left corner
 and spans the full width -- ink centring is the only thing the insets move.**

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -9497,6 +9497,178 @@ void testTheHeaderBandBottomIgnoresTheBezel() {
   }
 }
 
+// --- the BODY under the bezel -----------------------------------------------
+//
+// The band absorbs the glass. The body must not absorb it a second time.
+//
+// toybox::kHeaderHeight, kChromeHeight and kBodyTop are ABSOLUTE panel rows:
+// headerBand() calls absoluteChrome() before it takes the band, so the band
+// paints from row 0 and its bottom edge lands at kHeaderHeight whatever the
+// bezel hides -- testTheBandIsAbsoluteWithoutBeingAsked above pins exactly
+// that. The ten covered rows are therefore already inside the band's paint,
+// and a screen that adds safeArea.top to a chrome-derived top pushes its body
+// ten pixels below every other app's and buys nothing.
+//
+// xkcd and Wallpapers did, for as long as both apps had existed, and the
+// comment above each constant claimed it lined up with the shelf. NOTHING
+// here could see it: every other test in this file builds against device(),
+// whose safeArea is empty, and twice nothing is nothing. That absent coverage
+// is the defect card 358 was really about, so the checks come in two parts:
+// the alignment (all four apps on one row) and the rule that keeps it (the
+// glass may not move a body top), the second of which a screen written
+// tomorrow cannot pass by accident.
+
+// The first row a screen's own content occupies: the topmost thing drawn at or
+// below kChromeHeight, which is where headerBand()'s ownership ends.
+//
+// Rects rather than ink bands on purpose. toybox::inkCentred() expands a text
+// rect around its cut, so the recorded rect can start above the band it was
+// laid into -- xkcd's menu headline draws at y=102 for a band at 112. That
+// expansion is identical in both contexts, so it cancels in a comparison and
+// would only mislead an absolute assertion. The absolute row is asserted from
+// the exported geometry instead, in testEveryAppsBodyStartsOnTheSameRow.
+int16_t firstBodyRow(const FakeTarget& target) {
+  int32_t top = 0x7fff;
+  for (const FakeTarget::TextRun& run : target.texts) {
+    if (run.rect.y >= toybox::kChromeHeight && run.rect.y < top) top = run.rect.y;
+  }
+  for (const fui::Rect& r : target.fills) {
+    if (r.y >= toybox::kChromeHeight && r.y < top) top = r.y;
+  }
+  for (const FakeTarget::Stroke& s : target.strokes) {
+    if (s.rect.y >= toybox::kChromeHeight && s.rect.y < top) top = s.rect.y;
+  }
+  for (const FakeTarget::Blit& b : target.blits) {
+    if (b.rect.y >= toybox::kChromeHeight && b.rect.y < top) top = b.rect.y;
+  }
+  return static_cast<int16_t>(top);
+}
+
+template <typename Model, void (*Build)(toybox::Screen&, const Model&)>
+void render(Rendered& out, const Model& model) {
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(out.target, device(), noInput, out.interactions);
+  toybox::Screen screen(frame, toybox::themeTokens());
+  Build(screen, model);
+}
+
+// The rule: rendered twice, once on a bare frame and once behind the glass,
+// the body starts on the same row. Nothing about the app's own gutter is
+// assumed, which is what lets a screen nobody has written yet be added here in
+// two lines.
+template <typename Model, void (*Build)(toybox::Screen&, const Model&)>
+void checkTheGlassDoesNotMoveTheBody(const Model& model, const char* what) {
+  Rendered bare;
+  render<Model, Build>(bare, model);
+  Rendered glassed;
+  renderWithBezel<Model, Build>(glassed, model);
+  check(firstBodyRow(bare.target) == firstBodyRow(glassed.target), what, __LINE__);
+}
+
+void testTheGlassNeverMovesABodyTop() {
+  fui::ListItem rows[3] = {};
+  rows[0].label = "First";
+  rows[1].label = "Second";
+  rows[2].label = "Third";
+
+  {
+    shelfui::MenuModel model;
+    model.title = "GAMES";
+    model.items = rows;
+    model.count = 3;
+    checkTheGlassDoesNotMoveTheBody<shelfui::MenuModel, shelfui::buildMenu>(
+        model, "shelf folder: the glass does not move the body");
+  }
+  {
+    hnui::ListModel model;
+    model.items = rows;
+    model.count = 3;
+    checkTheGlassDoesNotMoveTheBody<hnui::ListModel, hnui::buildList>(
+        model, "hacker news list: the glass does not move the body");
+  }
+  {
+    xkcdui::ListModel model;
+    model.items = rows;
+    model.count = 3;
+    checkTheGlassDoesNotMoveTheBody<xkcdui::ListModel, xkcdui::buildList>(
+        model, "xkcd list: the glass does not move the body");
+  }
+  {
+    // The front door, whose headline is the one run inkCentred() expands.
+    xkcdui::MenuModel model;
+    checkTheGlassDoesNotMoveTheBody<xkcdui::MenuModel, xkcdui::buildMenu>(
+        model, "xkcd menu: the glass does not move the body");
+  }
+  {
+    xkcdui::NumberModel model;
+    model.typed = "12";
+    model.firstNum = 1;
+    model.maxNum = 3281;
+    checkTheGlassDoesNotMoveTheBody<xkcdui::NumberModel, xkcdui::buildNumber>(
+        model, "xkcd number pad: the glass does not move the body");
+  }
+  {
+    wallpapersui::GridChromeModel model;
+    model.title = "WALLPAPERS";
+    model.warning = "Card is nearly full";
+    checkTheGlassDoesNotMoveTheBody<wallpapersui::GridChromeModel, wallpapersui::buildGridChrome>(
+        model, "wallpapers grid: the glass does not move the body");
+  }
+}
+
+// Moving a body top moves everything under it, and this fork has already
+// shipped a box nudged to satisfy one rule that landed on its neighbour. So:
+// what did card 358 land on?
+//
+// Wallpapers is the screen that pays. Its grid is height-constrained between
+// the hint strip and the page dots, so the fourteen pixels the fix gave back
+// to the top come out of the THUMBNAILS, not off the bottom -- gridGeom()
+// re-fits the cells into whatever height is left, which is also why a
+// collision assertion here would be untestable: the cells shrink toward 1px
+// rather than ever overlapping the dots. Verified by inflating kBodyTop by
+// 300 and watching six other suites go red while a collision check stayed
+// green.
+//
+// A floor on the cell is therefore the assertion that can actually fail. The
+// measured size after the fix is 153x254 behind the glass, down from 153x262;
+// these numbers are that, minus a little slack. They go red for anyone who
+// pushes the body top down again by more than about thirty pixels, which is
+// the failure this screen really has.
+void testTheWallpapersThumbnailsStayBigEnoughToRead() {
+  for (const fui::DeviceContext& ctx : {device(), bezelDevice()}) {
+    const wallpapersui::GridGeom g = wallpapersui::gridGeom(ctx);
+    CHECK(g.cellW >= 140);
+    CHECK(g.cellH >= 240);
+    // And the first row still starts under the hint strip rather than in it.
+    CHECK(wallpapersui::cellRect(g, 0).y >= toybox::kBodyTop + 30);
+    // The bottom seam, for completeness: the last caption is above the dots.
+    CHECK(wallpapersui::captionRect(g, g.perPage - 1).bottom() <= g.pageDotsY);
+  }
+}
+
+// And the alignment itself, from the geometry the Activities share rather than
+// from a render, so the number is the one the paging arithmetic uses too.
+// Asserted BEHIND THE GLASS: on a bare frame these agreed all along, which is
+// the whole reason the misalignment shipped.
+void testEveryAppsBodyStartsOnTheSameRow() {
+  const fui::DeviceContext glass = bezelDevice();
+  CHECK(shelfui::listBand(glass, true, false).y == toybox::kBodyTop);
+  CHECK(hnui::listBand(glass).y == toybox::kBodyTop);
+  CHECK(xkcdui::listBand(glass).y == toybox::kBodyTop);
+
+  // Wallpapers has no exported body rect -- its hint strip IS the top of its
+  // body, and the grid hangs a fixed distance below it -- so this one is read
+  // off the render. The warning is drawn into the hint rect unexpanded.
+  wallpapersui::GridChromeModel model;
+  model.title = "WALLPAPERS";
+  model.warning = "Card is nearly full";
+  Rendered out;
+  renderWithBezel<wallpapersui::GridChromeModel, wallpapersui::buildGridChrome>(out, model);
+  const FakeTarget::TextRun* hint = out.target.find("Card is nearly full");
+  CHECK(hint != nullptr);
+  if (hint != nullptr) CHECK(hint->rect.y == toybox::kBodyTop);
+}
+
 // The ink rule again, for the labels apps draw on the band THEMSELVES.
 //
 // The header component centres each run on its own line box, so an app whose
@@ -9933,6 +10105,9 @@ int main() {
   testTheHeaderTitleStaysOutOfTheCoveredRows();
   testTheHeaderBandBottomIgnoresTheBezel();
   testTheBandIsAbsoluteWithoutBeingAsked();
+  testTheGlassNeverMovesABodyTop();
+  testEveryAppsBodyStartsOnTheSameRow();
+  testTheWallpapersThumbnailsStayBigEnoughToRead();
   testTriviaOptionsCarryTheirIndex();
   testTriviaAlwaysOffersAWayOut();
   testTriviaDrawsNoOptionsWithoutAQuestion();

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -9987,30 +9987,37 @@ void testTheHeaderBandBottomIgnoresTheBezel() {
 // glass may not move a body top), the second of which a screen written
 // tomorrow cannot pass by accident.
 
-// The first row a screen's own content occupies: the topmost thing drawn at or
+// Every row a screen's own content occupies: the y of everything drawn at or
 // below kChromeHeight, which is where headerBand()'s ownership ends.
 //
+// The WHOLE list, sorted, not just the topmost. Comparing only the first row
+// would pass a screen whose first element is absolute and whose later ones add
+// safe.y -- and half a screen compensating is exactly the shape this fork keeps
+// shipping (see the two-input-paths notes). Sorted rather than positional
+// because draw order is not layout order.
+//
 // Rects rather than ink bands on purpose. toybox::inkCentred() expands a text
-// rect around its cut, so the recorded rect can start above the band it was
-// laid into -- xkcd's menu headline draws at y=102 for a band at 112. That
-// expansion is identical in both contexts, so it cancels in a comparison and
-// would only mislead an absolute assertion. The absolute row is asserted from
-// the exported geometry instead, in testEveryAppsBodyStartsOnTheSameRow.
-int16_t firstBodyRow(const FakeTarget& target) {
-  int32_t top = 0x7fff;
+// rect around its cut, so a recorded rect can start above the band it was laid
+// into -- xkcd's menu headline draws at y=102 for a band at 112. That expansion
+// is identical in both contexts, so it cancels in a comparison and would only
+// mislead an absolute assertion. The absolute row is asserted from the exported
+// geometry instead, in testEveryAppsBodyStartsOnTheSameRow.
+std::vector<int> bodyRows(const FakeTarget& target) {
+  std::vector<int> rows;
   for (const FakeTarget::TextRun& run : target.texts) {
-    if (run.rect.y >= toybox::kChromeHeight && run.rect.y < top) top = run.rect.y;
+    if (run.rect.y >= toybox::kChromeHeight) rows.push_back(run.rect.y);
   }
   for (const fui::Rect& r : target.fills) {
-    if (r.y >= toybox::kChromeHeight && r.y < top) top = r.y;
+    if (r.y >= toybox::kChromeHeight) rows.push_back(r.y);
   }
-  for (const FakeTarget::Stroke& s : target.strokes) {
-    if (s.rect.y >= toybox::kChromeHeight && s.rect.y < top) top = s.rect.y;
+  for (const FakeTarget::Stroke& st : target.strokes) {
+    if (st.rect.y >= toybox::kChromeHeight) rows.push_back(st.rect.y);
   }
   for (const FakeTarget::Blit& b : target.blits) {
-    if (b.rect.y >= toybox::kChromeHeight && b.rect.y < top) top = b.rect.y;
+    if (b.rect.y >= toybox::kChromeHeight) rows.push_back(b.rect.y);
   }
-  return static_cast<int16_t>(top);
+  std::sort(rows.begin(), rows.end());
+  return rows;
 }
 
 template <typename Model, void (*Build)(toybox::Screen&, const Model&)>
@@ -10022,16 +10029,25 @@ void render(Rendered& out, const Model& model) {
 }
 
 // The rule: rendered twice, once on a bare frame and once behind the glass,
-// the body starts on the same row. Nothing about the app's own gutter is
+// every body row lands in the same place. Nothing about the app's own gutter is
 // assumed, which is what lets a screen nobody has written yet be added here in
 // two lines.
+//
+// The emptiness check is not ceremony. Comparing two renders that drew NOTHING
+// below the chrome compares two empty lists and passes, so a model that fails
+// to produce a body -- a wrong fixture, a builder that early-returns -- would
+// report this rule as satisfied. That is the failure mode a guard has when its
+// subject is absent, and it is the one this suite has been bitten by before.
 template <typename Model, void (*Build)(toybox::Screen&, const Model&)>
 void checkTheGlassDoesNotMoveTheBody(const Model& model, const char* what) {
   Rendered bare;
   render<Model, Build>(bare, model);
   Rendered glassed;
   renderWithBezel<Model, Build>(glassed, model);
-  check(firstBodyRow(bare.target) == firstBodyRow(glassed.target), what, __LINE__);
+  const std::vector<int> bareRows = bodyRows(bare.target);
+  const std::vector<int> glassedRows = bodyRows(glassed.target);
+  check(!bareRows.empty(), what, __LINE__);
+  check(bareRows == glassedRows, what, __LINE__);
 }
 
 void testTheGlassNeverMovesABodyTop() {
@@ -10099,10 +10115,19 @@ void testTheGlassNeverMovesABodyTop() {
 // green.
 //
 // A floor on the cell is therefore the assertion that can actually fail. The
-// measured size after the fix is 153x254 behind the glass, down from 153x262;
-// these numbers are that, minus a little slack. They go red for anyone who
-// pushes the body top down again by more than about thirty pixels, which is
-// the failure this screen really has.
+// measured size behind the glass is 150x249 after the fix, down from 154x256 --
+// BOTH axes, because the cell is height-bound here and the width follows the
+// aspect, so the thumbnails lost about 5.2% of their area.
+//
+// WHAT THIS DOES NOT CATCH, so nobody reads it as more than it is: the floor
+// trips at roughly +28px of body top on height and +44px on width, so it would
+// stay GREEN if this very bug were reintroduced -- a ten-pixel push leaves the
+// cell at 145x241, comfortably inside it. It is a gross-degradation guard, not
+// a guard on this card's defect; testTheGlassNeverMovesABodyTop and
+// testEveryAppsBodyStartsOnTheSameRow are what catch that, exactly. Set from
+// the measured size minus a little slack rather than tight against it, because
+// a floor that trips on any legitimate re-tuning gets deleted rather than
+// heeded.
 void testTheWallpapersThumbnailsStayBigEnoughToRead() {
   for (const fui::DeviceContext& ctx : {device(), bezelDevice()}) {
     const wallpapersui::GridGeom g = wallpapersui::gridGeom(ctx);
@@ -10144,9 +10169,36 @@ void testTheHandRolledBodyTopMatchesTheReservedOne() {
   }
   // And the derivation is the reservation's, not a second sum that happens to
   // agree today: kBodyTop must track a band height it was not written against.
+  // 56 is Solitaire's landscape band (solitaireui::kHeaderBand), the one real
+  // case where kHeaderHeight is not the band height.
   CHECK(toybox::bodyTopBelow(toybox::kHeaderHeight) == toybox::kBodyTop);
   CHECK(toybox::bodyTopBelow(56) == toybox::chromeBelow(56) + toybox::kBodyGutter);
   CHECK(toybox::bodyTopBelow(56) != toybox::kBodyTop);
+
+  // A REAL screen, not just the synthetic chrome above. The assertions so far
+  // drive headerBand() directly; this drives one of the ~41 app screens that
+  // reach insetContent({kBodyGutter, ...}) through their own chrome() helper,
+  // and reads where its first component-laid element actually landed.
+  //
+  // Without this the suite measures screen.body().y in exactly two places, both
+  // against kHeaderHeight, and no app screen's component-laid body top is
+  // measured anywhere -- so the two halves of the fork's layout could disagree
+  // with nothing to say so. takeTop() returns a rect at content_.y and consumes
+  // the gap AFTER it, so the first one is the body top exactly, and this run is
+  // drawn from a raw rect with no inkCentred() expansion.
+  for (const fui::DeviceContext& ctx : {device(), bezelDevice()}) {
+    wallpapersui::EmptyModel empty;
+    empty.title = "WALLPAPERS";
+    empty.warning = nullptr;
+    Rendered out;
+    const fui::InputSnapshot noInput{};
+    toybox::Frame frame(out.target, ctx, noInput, out.interactions);
+    toybox::Screen screen(frame, toybox::themeTokens());
+    wallpapersui::buildEmpty(screen, empty);
+    const FakeTarget::TextRun* headline = out.target.find("NO WALLPAPERS");
+    CHECK(headline != nullptr);
+    if (headline != nullptr) CHECK(headline->rect.y == toybox::kBodyTop);
+  }
 }
 
 // And the alignment itself, from the geometry the Activities share rather than

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -8,6 +8,7 @@
 // stable and the screens change every time Mario asks for something. Two real
 // bugs this file would have caught the day they were written are pinned below.
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <string>

--- a/src/apps_local/ShelfScreen.cpp
+++ b/src/apps_local/ShelfScreen.cpp
@@ -27,7 +27,7 @@ constexpr int kPageBarHeight = 44;
 int pageBarHeight(const bool hasPages) { return hasPages ? kPageBarHeight + toybox::kGutter : 0; }
 
 fui::Rect listBand(const fui::DeviceContext& device, const bool hasDeviceName, const bool hasPages) {
-  const int top = toybox::kHeaderHeight + toybox::kGutter * 3;
+  const int top = toybox::kBodyTop;
   return fui::makeRect(toybox::kMargin, top, device.width - 2 * toybox::kMargin,
                        device.height - toybox::kMargin - top - footerHeight(hasDeviceName) - pageBarHeight(hasPages));
 }

--- a/src/apps_local/hackernews/HackerNewsScreens.cpp
+++ b/src/apps_local/hackernews/HackerNewsScreens.cpp
@@ -10,8 +10,10 @@ namespace {
 
 // The top of any body: below the header band and the rule Toybox draws under
 // it. Shared by all three screens so they line up with each other and with the
-// shelf the reader just came from.
-constexpr int kBodyTop = toybox::kHeaderHeight + toybox::kGutter * 3;
+// shelf the reader just came from. The number now lives in one place for the
+// whole fork -- see toybox::kBodyTop, which also says why nothing adds a safe
+// area to it.
+constexpr int kBodyTop = toybox::kBodyTop;
 
 // The reader's footer: one row of three controls.
 constexpr int kFooterHeight = toybox::kPillHeight;

--- a/src/apps_local/instapaper/InstapaperScreens.cpp
+++ b/src/apps_local/instapaper/InstapaperScreens.cpp
@@ -13,7 +13,7 @@ namespace {
 // The top of any body: below the header band and the rule Toybox draws under
 // it. Shared by every screen here so they line up with each other and with the
 // shelf the reader just came from.
-constexpr int kBodyTop = toybox::kHeaderHeight + toybox::kGutter * 3;
+constexpr int kBodyTop = toybox::kBodyTop;
 
 constexpr int kFooterHeight = toybox::kPillHeight;
 

--- a/src/apps_local/ui/ToyboxMetrics.h
+++ b/src/apps_local/ui/ToyboxMetrics.h
@@ -75,6 +75,13 @@ constexpr int kBodyGutter = kGutter * 3;
 // comment over each private copy of this constant claimed the opposite. Card
 // 358.
 constexpr int bodyTopBelow(const int bandHeight) { return chromeBelow(bandHeight) + kBodyGutter; }
+// kBodyTop is the DEFAULT band's body top, not a fork-wide law: kHeaderHeight
+// is a theme token and Solitaire overrides it to 56 in landscape
+// (solitaireui::kHeaderBand, set at SolitaireActivity.cpp:289). Its body top is
+// bodyTopBelow(56) = 99, and a Solitaire screen reaching for kBodyTop would
+// leave 20px of dead air under its rule -- invisible, because nothing would
+// clip. Anything whose band height is not kHeaderHeight calls bodyTopBelow()
+// with its own; that is why the function exists beside the constant.
 constexpr int kBodyTop = bodyTopBelow(kHeaderHeight);
 constexpr int kFrame = 4;
 // The board's own border is heavier than anything drawn inside it, so the

--- a/src/apps_local/ui/ToyboxMetrics.h
+++ b/src/apps_local/ui/ToyboxMetrics.h
@@ -35,6 +35,32 @@ constexpr int kBandRuleGap = 4;
 // was invisible to the arithmetic because it was drawn by a separate call.
 // Measure the top gutter from this, not from kHeaderHeight.
 constexpr int kChromeHeight = kHeaderHeight + kBandRuleGap + kRule;
+
+// The first row a screen's own content may occupy. Read the next paragraph
+// before adding a safe area to it.
+//
+// EVERY NUMBER IN THIS FILE IS AN ABSOLUTE PANEL ROW, measured from the
+// panel's physical row 0 and NOT from the bezel's safe top. toybox::headerBand()
+// calls absoluteChrome() before it takes the band, so the band paints rows
+// 0..kHeaderHeight and its rule lands at kChromeHeight whatever the glass
+// hides; host-tests/ui pins it with testTheBandIsAbsoluteWithoutBeingAsked,
+// which asserts screen.body().y == kHeaderHeight on a BEZELLED frame. The X4
+// Pro's ten covered rows are therefore already inside the band's paint
+// (docs/bezel-insets.md: paint may bleed under the bezel, ink may not), and a
+// screen that adds DeviceContext::safeArea.top to a value derived from these
+// pushes its body ten pixels below every other app's while protecting nothing.
+// xkcd and Wallpapers both did, for as long as either app existed, and the
+// comment over each private copy of this constant claimed the opposite. Card
+// 358.
+//
+// The value is kGutter * 3 under the band, which is exactly what the 41
+// screens that call insetContent({kGutter * 3, kMargin, kMargin, kMargin})
+// after their chrome already get from screen.body(). Screens that lay their
+// body out by hand -- the shelf, hacker news, instapaper, xkcd, wallpapers --
+// use this so the hand-rolled ones and the component-laid ones land on one
+// row. host-tests/ui asserts that they do, behind the glass, in
+// testEveryAppsBodyStartsOnTheSameRow.
+constexpr int kBodyTop = kHeaderHeight + kGutter * 3;
 constexpr int kFrame = 4;
 // The board's own border is heavier than anything drawn inside it, so the
 // playing surface reads as a single object rather than as a grid that happens

--- a/src/apps_local/ui/ToyboxScreen.h
+++ b/src/apps_local/ui/ToyboxScreen.h
@@ -144,8 +144,11 @@ class Screen : public freeink::ui::Screen<kMaxInteractions> {
 // Shifting the chrome down by the insets ate the gaps those layouts were
 // tuned for (boards touched the rule, band decorations drifted) while
 // buying nothing: no game ever drew content in the covered rows. Content
-// that must clear the glass (the readers, xkcd, system lists) takes the
-// safe rect through its own path and does not use this.
+// that must clear the glass -- the readers, the system lists, and xkcd's
+// COMIC (xkcdui::readerViewport) -- takes the safe rect through its own path
+// and does not use this. Not xkcd's menus and not the Wallpapers grid: those
+// took it too until card 358, which is how both apps came to sit ten pixels
+// below every other app's body. See toybox::kBodyTop.
 inline void absoluteChrome(Screen& screen) { screen.setContentMarginAbsolute(freeink::ui::Insets{}); }
 
 // The width the header component will really give the title, computed with the

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -13,8 +13,12 @@ namespace wallpapersui {
 namespace {
 
 // The top of the body: below the header band and the rule Toybox draws under
-// it, matching the other apps so the grid lines up with the shelf it came from.
-constexpr int16_t kBodyTop = static_cast<int16_t>(toybox::kHeaderHeight + toybox::kGutter);
+// it, matching the other apps so the hint lines up with the shelf it came
+// from. Card 358: it did not. This was kHeaderHeight + kGutter, a gutter of
+// its own that cleared the rule by five pixels where every other app clears it
+// by twenty-nine, and every site below then added safe.y to it as well.
+// toybox::kBodyTop carries the reason it must be used bare.
+constexpr int16_t kBodyTop = static_cast<int16_t>(toybox::kBodyTop);
 // A fixed strip under the chrome for the free-space advisory or the "nothing is
 // set yet" hint. Fixed so the grid's top does not jump when a hint appears.
 constexpr int16_t kHintH = 30;
@@ -177,7 +181,9 @@ GridGeom gridGeom(const fui::DeviceContext& device) {
 
   const int16_t gridLeft = static_cast<int16_t>(safe.x + toybox::kMargin);
   const int16_t gridW = static_cast<int16_t>(safe.width - toybox::kMargin * 2);
-  const int16_t gridTop = static_cast<int16_t>(safe.y + kBodyTop + kHintH + kHintGap);
+  // Sides and bottom off the safe rect; the top absolute, because the header
+  // band already covers the rows the glass hides. See toybox::kBodyTop.
+  const int16_t gridTop = static_cast<int16_t>(kBodyTop + kHintH + kHintGap);
   const int16_t gridBottom = static_cast<int16_t>(safe.bottom() - kPageStripH - kBottomMargin);
   const int16_t gridH = static_cast<int16_t>(gridBottom - gridTop);
 
@@ -239,7 +245,8 @@ void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model) {
   // set yet, it says so -- a grid with no thick border and no words reads as a
   // selection that failed to draw.
   const fui::Rect safe = screen.frame().safeRect();
-  const int16_t hintY = static_cast<int16_t>(safe.y + kBodyTop);
+  // Absolute, like every other app's: see toybox::kBodyTop.
+  const int16_t hintY = kBodyTop;
   const char* line = nullptr;
   if (model.warning != nullptr && model.warning[0] != '\0') {
     line = model.warning;

--- a/src/apps_local/xkcd/XkcdScreens.cpp
+++ b/src/apps_local/xkcd/XkcdScreens.cpp
@@ -24,8 +24,11 @@ constexpr int16_t kOkWidth = 56;
 
 // The top of any body: below the header band and the rule Toybox draws under
 // it. Shared by every screen here so they line up with each other and with the
-// shelf the reader just came from.
-constexpr int16_t kBodyTop = kHeaderBand + toybox::kGutter * 3;
+// shelf the reader just came from -- which, until card 358, they did not: this
+// was an absolute row and every site below added safe.y to it as well, putting
+// the whole app ten pixels under the rest of the fork. toybox::kBodyTop
+// carries the reason it must be used bare.
+constexpr int16_t kBodyTop = toybox::kBodyTop;
 
 // The menu's bands, laid out once. Both the builder and the Activity need the
 // mosaic's rect, and two functions that compute it separately are the defect
@@ -49,14 +52,17 @@ constexpr int kDoorCount = 4;
 constexpr int16_t kDoorGap = 8;
 
 MenuBands menuBands(const fui::DeviceContext& device) {
-  // From the safe rect, so every band clears the bezel-covered edges along
-  // with the chrome above it.
+  // Sides and bottom from the safe rect, so the bands clear the columns the
+  // glass hides. The TOP is absolute: kBodyTop is measured from panel row 0
+  // and the header band already paints over the covered rows, so adding safe.y
+  // here only pushed the menu below every other app's body. See
+  // toybox::kBodyTop.
   const fui::Rect safe = device.safeRect();
   const int16_t left = static_cast<int16_t>(safe.x + toybox::kMargin);
   const int16_t width = static_cast<int16_t>(safe.width - toybox::kMargin * 2);
 
   MenuBands b;
-  int16_t y = static_cast<int16_t>(safe.y + kBodyTop);
+  int16_t y = kBodyTop;
   b.headline = fui::makeRect(left, y, width, 44);
   y = static_cast<int16_t>(y + 44 + 2);
   b.title = fui::makeRect(left, y, width, 28);
@@ -241,7 +247,8 @@ void buildNumber(toybox::Screen& screen, const NumberModel& model) {
   const fui::Rect safe = screen.frame().safeRect();
   const int16_t left = static_cast<int16_t>(safe.x + toybox::kMargin);
   const int16_t width = static_cast<int16_t>(safe.width - toybox::kMargin * 2);
-  const int16_t bodyTop = static_cast<int16_t>(safe.y + kBodyTop);
+  // Absolute, like every other app's: see toybox::kBodyTop.
+  const int16_t bodyTop = kBodyTop;
 
   // What has been typed, big, with the range under it so the bounds are a
   // thing you can read rather than a thing you discover by being refused.
@@ -297,7 +304,8 @@ void buildNumber(toybox::Screen& screen, const NumberModel& model) {
 
 fui::Rect listBand(const fui::DeviceContext& device) {
   const fui::Rect safe = device.safeRect();
-  const int16_t top = static_cast<int16_t>(safe.y + kBodyTop);
+  // Absolute, like every other app's: see toybox::kBodyTop.
+  const int16_t top = kBodyTop;
   const int16_t bottom = static_cast<int16_t>(safe.bottom() - toybox::kMargin - toybox::kPillHeight - toybox::kGutter);
   return fui::makeRect(static_cast<int16_t>(safe.x + toybox::kMargin), top,
                        static_cast<int16_t>(safe.width - toybox::kMargin * 2), static_cast<int16_t>(bottom - top));


### PR DESCRIPTION
xkcd and Wallpapers drew their body content 10px below every other app on the
device. Card #358, found by the cold review on #248, measured not guessed.

## Which way it resolved, and how I established it

The card names two readings and they lead to opposite fixes: either the two
apps double-count the bezel, or they are the only ones compensating for it and
the other twenty are eating their top rows. **Counting apps cannot decide
that**, so I did not.

It is decided by what `toybox::headerBand()` does, and the ui suite already
contained the proof:

- `headerBand()` calls `absoluteChrome()` **unconditionally** before it takes
  the band (`ToyboxScreen.h:240`), so the screen's content rect is the full
  frame from panel row 0.
- `host-tests/ui`'s existing `testTheBandIsAbsoluteWithoutBeingAsked` asserts
  `screen.body().y == toybox::kHeaderHeight` on a **bezelled** frame. The glass
  does not move the band.

So `kHeaderHeight` (76), `kChromeHeight` (83) and everything derived from them
are **absolute panel rows**. The bezel's ten covered rows sit inside the band's
own paint (`docs/bezel-insets.md`: paint may bleed under the bezel, ink may
not), and a body at row 112 is 29px below the rule with no glass near it.
Adding `safeArea.top` to that protects nothing.

**The two apps were double-counting.** The other twenty are right for a reason,
not by majority.

Measured first body row, behind the glass:

| screen | before | after |
| --- | --- | --- |
| shelf folder | 112 | 112 |
| hacker news list | 112 | 112 |
| xkcd list / menu / number pad | 122 | 112 |
| wallpapers hint + grid | 98 | 112 |

Wallpapers was wrong twice: a private gutter of `kHeaderHeight + kGutter` (5px
under the rule where everyone else has 29) *and* the safe-area addition.

## The answer is now in the code

`toybox::kBodyTop` in `ToyboxMetrics.h` is the single constant. Its comment
states that every number in that file is a **raw panel row, not a
bezel-adjusted one**, names the test that pins it, and says why a safe area
must not be added to it. The shelf, hacker news, instapaper, xkcd and
wallpapers all name it now instead of keeping five private copies of the same
arithmetic, two of which had drifted.

`docs/bezel-insets.md` claimed xkcd's *menus* keep the full safe-area
treatment. That was true of its **comic** only (`readerViewport()`, untouched
here); the page now says so and records why nothing caught this.

## What moved underneath, checked at the bottom too

- **xkcd** rises 10px. Its mosaic and list band only grow taller against
  bottom-anchored controls. Rows per page is unchanged (9 before, 9 after), so
  no paging or saved-position behaviour changes, and its list band is now
  byte-identical to Hacker News's.
- **Wallpapers** is the screen that pays. Its grid is height-constrained
  between the hint and the page dots, so the 14px come out of the
  **thumbnails**: **154x256 -> 150x249** behind the glass, about **5.2% of
  area**. Nothing collides.

  Corrected from an earlier draft of this PR and from the first commit message,
  which said 153x262 -> 153x254 and implied only the height moved. 262 was
  `maxCellH`, the constraint box, not the drawn cell; the figures above are the
  drawn cell, measured post-#141 at the real X4 Pro insets. **Both axes move** --
  the cell is height-bound here, so the width follows through the aspect fit.

A collision assertion there would be untestable -- `gridGeom()` re-fits the
cells rather than ever overlapping the dots. I confirmed that by inflating
`kBodyTop` by 300 and watching six other suites go red while a collision check
stayed green. The guard is a **floor on the cell size** instead, which does go
red at +40.

## The thumbnail cache is invalidated by this change

Raised by the cold review and worth its own heading, because it is a cost
outside the screen being fixed.

`ThumbHeader` includes `cellW`/`cellH` and `thumbFor()` requires an exact match,
so **changing the cell size invalidates every shipped device's on-card
thumbnail cache** (`/wallpapers/.thumbs`). `prewarmThumbs()` only runs after a
download, so nothing pre-empts it.

**It cannot be avoided.** The cell is height-bound, so keeping it identical
means keeping `gridH` identical, which means giving back the 14px at the bottom
-- and `gridBottom` is already only 18px above `pageDotsY`. Reclaiming 14 of
those would put the page dots ~4px under the last row's captions. The cached
bitmap is 1-bit at exactly cell size and 1-bit bitmaps cannot be rescaled, so a
size-tolerant cache is not available either.

**What it actually costs, measured.** Not the whole library, and not on open:
`ensureThumbsForPage()` decodes only the page being viewed, at most `perPage`
= 4 cells, and re-caches as it goes. The commit that built this cache
(`4dd43742`) recorded the exact operation:

> before   3 thumbnails decoded per open, **12ms host**, EVERY open and every page turn
> after    decoded=0, 0ms, render 14ms -> 1ms

So the cost is one page's worth of re-decode -- about 12ms on the host -- the
first time each page is visited after the update, then the cache is warm again
permanently. That same commit already anticipated this exact class of change:
*"A cell-size change invalidates everything, which the hint-gap change would
otherwise have made stale."* I have no device figure and did not claim one.

**On the attribution.** This was put to me as reintroducing the ten-second
blank screen Mario reported. The record does not support that. His report is
card **#351**: *"I have to hold the thing for a few seconds to wake it up and
takes like 5 secs to fully wake up"* -- a **wake** complaint, traced to
`main.cpp`'s `BootResume::SplashlessWake` in **CrossPoint's** boot path, where
every non-quick-resume mode gets no LoadingIcon and no sign of life during what
is a full chip reset. It is filed, it is not ours, and it is not the wallpapers
grid. Fixing this alignment does not touch it, and the thing that would be
reintroduced here is 12ms per page, once.

## Tests, watched failing first

Nothing could see this: every test in the ui suite builds against `device()`,
whose `safeArea` is empty, and twice nothing is nothing. That absent coverage
is the real defect on this card.

- `testTheGlassNeverMovesABodyTop` renders six screens on a bare frame and a
  bezelled one and requires the same first body row. It assumes nothing about
  any app's own gutter, so a screen written tomorrow is two lines to add and
  cannot pass by accident. **Red on 4 of the 6 before the fix.**
- `testEveryAppsBodyStartsOnTheSameRow` pins the alignment itself, from the
  geometry the Activities share, asserted behind the glass. **Red on xkcd and
  wallpapers before.**
- `testTheHandRolledBodyTopMatchesTheReservedOne` pins the hand-rolled path to
  `headerBand()`'s reservation, and now also measures a **real** component-laid
  screen (`wallpapersui::buildEmpty`, one of the ~41 that reach `insetContent`
  through their own `chrome()`). Before that, `screen.body().y` was asserted in
  exactly two places in the whole suite, both against `kHeaderHeight`, and no
  app screen's component-laid body top was measured anywhere. **Watched red** by
  adding 7px to Wallpapers' chrome gutter: 2 checks fail, and nothing else does.
- `testTheWallpapersThumbnailsStayBigEnoughToRead` is the bottom guard.
  **Watched red at +40px.** Its comment now states plainly that it trips at
  about +28px and would therefore stay green if *this* bug were reintroduced --
  it guards gross degradation, not this card's defect.

Three of these were strengthened after the cold review found they could pass
for the wrong reason:

- `firstBodyRow` compared only the **topmost** element and returned a sentinel
  when nothing was drawn, so a screen that drew no body passed. It is now
  `bodyRows()`, the sorted list of **every** row below the chrome, with an
  emptiness guard. **Watched red** by adding `safe.y` to one *lower* element of
  xkcd's menu, leaving the topmost correct -- the old form passed that.
- `testEveryAppsBodyStartsOnTheSameRow` constant-folded to `kBodyTop ==
  kBodyTop` for three of its four checks once the apps named the shared
  constant. The real-screen measurement above is what now carries it.

6 checks red before the fix, 0 of 82843 after.

## Classification

Every file touched is OURS (`git cat-file -e crosspoint/develop:<path>` returns
non-zero for all seven). Nothing upstream is touched.

## PR #141 (card #248) has landed, and this is rebased on it

**Resolved in the other direction from my earlier note: #141 merged first**
(`8bcfb46a`), and this branch now merges it.

That merge was not mechanical, and it is the most important thing in this PR.
#141 makes `headerBand()` reserve the **whole chrome** (band + gap + rule)
rather than the band alone, so `screen.body().y` is `kChromeHeight` and the
fork's canonical body top moved from `kHeaderHeight + kGutter * 3` (112) to
`kChromeHeight + kGutter * 3` (119). It also turned `kChromeHeight` into
`chromeBelow(bandHeight)`, because Solitaire runs a 56px band in landscape.

**`toybox::kBodyTop` as this branch first wrote it was a second literal** -- its
own sum of `kHeaderHeight` and three gutters. Merged naively it would have sat
at 112 while every component-laid screen moved to 119, **and nothing would have
gone red**: both paths stay internally consistent and merely stop agreeing with
each other. That is a silent drift, so the constant is now derived from the
same reservation:

```cpp
constexpr int kBodyGutter = kGutter * 3;
constexpr int bodyTopBelow(int band) { return chromeBelow(band) + kBodyGutter; }
constexpr int kBodyTop = bodyTopBelow(kHeaderHeight);
```

and a fourth test, `testTheHandRolledBodyTopMatchesTheReservedOne`, pins the two
paths to each other: it renders a screen through `headerBand()` +
`insetContent(kBodyGutter)` and asserts `screen.body().y == toybox::kBodyTop`,
on a bare frame and a bezelled one, plus that `bodyTopBelow` tracks a band
height it was not written against. **Watched it go red** by restoring the
pre-#141 sum: 3 checks fail.

All six conflicts were resolved by hand. #141 had independently reached the same
reading in `ShelfScreen`, `HackerNews` and `Instapaper`; those take its prose and
this branch's shared constant. In `XkcdScreens` and `WallpapersScreens` #141
deliberately left card #358 open with a note saying so; those take this branch's
fix. Wallpapers' *second* fault survives the merge intact -- on #141's side it
read `kChromeHeight + kGutter`, one gutter rather than three.

**All four apps now sit at row 119.** The table above is the pre-#141 geometry;
the equality it proves is what matters and it holds at either number.

## Not verified

- **Hardware.** Nothing here ran on real glass. The whole point of the change
  is how it reads behind the bezel, and only Mario's eye can settle whether
  112 is the right row on the panel -- the argument here is that it is the row
  every other app already uses, not that it is independently correct.
- **The absolute row was verified against a 9px top inset; the device is 10.**
  The simulator selects the X4 profile (`{9,3,3,3}`), not the X4 Pro's measured
  `{10,1,0,1}`, so any sim render is one row off the panel Mario holds. This
  does not invalidate the fix -- what is proved here is the **equality** between
  apps, and that holds at any inset -- but whoever next measures the glass needs
  to know which number the tests encode. The host suite's `bezelDevice()` **does**
  use `{10,1,0,1}`, so the 112/98/119 figures in this PR are at the real X4 Pro
  insets; it is only rendered screenshots that carry the 9.
- **Horizontal alignment left alone on purpose.** xkcd and Wallpapers inset
  their sides by `safe.x + kMargin` (17) where the shelf and Hacker News use
  `kMargin` (16). That 1px is a separate question from this card's row, both
  readings are defensible, and I did not widen scope into it.
- Wallpapers' thumbnails are 8px shorter. I judged that acceptable against
  aligning the app with the rest of the fork, but it is a look-at-it call.

Card: #358
