### PR TITLE
Wallpapers: the chosen wallpaper survives an idle-timeout sleep, and the picker stops claiming one that cannot

### DIFF
--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -346,11 +346,18 @@ int main() {
 
   // 5. The hint strip's sentences, measured in the real face (#354).
   //
-  //    The strip is ONE fixed 30px line drawn at FONT_SLOT_SMALL. fittedTitle
-  //    steps DOWN through the font slots and small is the bottom rung, so the
-  //    only move left to it is an ellipsis -- and a cut sentence in the strip
-  //    that exists to explain why a wallpaper is not showing is worse than no
-  //    sentence at all. Every string that can land there is measured here.
+  //    The strip is ONE fixed line, kHintH tall, and buildGridChrome pins its
+  //    style to FONT_SLOT_SMALL. In the chrome's face set that is the bottom
+  //    rung, so fittedTitle -- which only steps DOWN -- has nothing left and
+  //    its only move is an ellipsis. A cut sentence in the strip that exists to
+  //    explain why a wallpaper is not showing is worse than no sentence at all,
+  //    so every string that can land there is measured here.
+  //
+  //    The pin matters as much as the width. Without it the style carries
+  //    themeTokens().smallText.font, which is FONT_SLOT_BODY -- toybox_20 here,
+  //    whose line box is TALLER than the strip. fittedTitle would then step a
+  //    long sentence down to 14 and leave a short one at 20, so which sentences
+  //    overflowed the strip vertically depended on how long they were.
   //
   //    Measured against the panel inset by the X4 Pro's bezel (T10 R1 B0 L1,
   //    the bezel-insets memory), which is narrower than a bare 480 -- so the
@@ -359,6 +366,18 @@ int main() {
     const ChromeFontTarget chrome;
     const fui::Rect bezelSafe = fui::makeRect(1, 10, 478, 790);
     const int16_t stripWidth = wallpapersui::hintTextWidth(bezelSafe);
+
+    // The strip's line box has to FIT the strip, which is the half a width
+    // measurement cannot see. buildGridChrome pins the style to
+    // FONT_SLOT_SMALL; the two checks below are why, and they are what a
+    // future session deleting that pin has to argue with.
+    check(chrome.lineHeight(fui::FONT_SLOT_SMALL) <= wallpapersui::hintStripHeight(),
+          "the strip's own face does not fit the strip: lineHeight " +
+              std::to_string(chrome.lineHeight(fui::FONT_SLOT_SMALL)) + " in a " +
+              std::to_string(wallpapersui::hintStripHeight()) + "px box");
+    check(chrome.lineHeight(fui::FONT_SLOT_BODY) > wallpapersui::hintStripHeight(),
+          "FONT_SLOT_BODY now fits the strip, so buildGridChrome's pin to the SMALL slot no longer needs to "
+          "be there -- re-read the comment before deleting it");
     fui::TextStyle hintStyle;
     hintStyle.font = fui::FONT_SLOT_SMALL;
     hintStyle.align = fui::TextAlign::Left;
@@ -372,11 +391,13 @@ int main() {
         if (hint != nullptr) lines.emplace_back(hint);
       }
     }
-    // Every takeoverNote sentence, the same way.
+    // Every post-selection sentence, the same way.
     for (uint8_t mode = 0; mode < wallpapers::kSleepModeCount; ++mode) {
       for (int qr = 0; qr < 2; ++qr) {
-        const char* note = wallpapers::takeoverNote(wallpapers::choiceForSetWallpaper(mode, qr != 0));
-        if (note != nullptr) lines.emplace_back(note);
+        const wallpapers::SleepChoice choice = wallpapers::choiceForSetWallpaper(mode, qr != 0);
+        const wallpapers::StripLine note = wallpapers::stripLineAfterSelection(
+            choice, wallpapers::reachOfPinnedSleep(choice.sleepScreenMode, choice.quickResumeAfterTimeout));
+        if (note.text != nullptr) lines.emplace_back(note.text);
       }
     }
     // And the two the strip already carried, so this check covers the strip

--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -261,6 +261,63 @@ int main() {
     }
   }
 
+  // 5. The hint strip's sentences, measured in the real face (#354).
+  //
+  //    The strip is ONE fixed 30px line drawn at FONT_SLOT_SMALL. fittedTitle
+  //    steps DOWN through the font slots and small is the bottom rung, so the
+  //    only move left to it is an ellipsis -- and a cut sentence in the strip
+  //    that exists to explain why a wallpaper is not showing is worse than no
+  //    sentence at all. Every string that can land there is measured here.
+  //
+  //    Measured against the panel inset by the X4 Pro's bezel (T10 R1 B0 L1,
+  //    the bezel-insets memory), which is narrower than a bare 480 -- so the
+  //    number here is the device's, not the emulator's.
+  {
+    const fui::Rect bezelSafe = fui::makeRect(1, 10, 478, 790);
+    const int16_t stripWidth = wallpapersui::hintTextWidth(bezelSafe);
+    fui::TextStyle hintStyle;
+    hintStyle.font = fui::FONT_SLOT_SMALL;
+    hintStyle.align = fui::TextAlign::Left;
+    hintStyle.maxLines = 1;
+
+    std::vector<std::string> lines;
+    // Every reachHint sentence, walked off the enum rather than typed out.
+    for (uint8_t mode = 0; mode < wallpapers::kSleepModeCount; ++mode) {
+      for (int qr = 0; qr < 2; ++qr) {
+        const char* hint = wallpapers::reachHint(wallpapers::reachOfPinnedSleep(mode, qr != 0));
+        if (hint != nullptr) lines.emplace_back(hint);
+      }
+    }
+    // Every takeoverNote sentence, the same way.
+    for (uint8_t mode = 0; mode < wallpapers::kSleepModeCount; ++mode) {
+      for (int qr = 0; qr < 2; ++qr) {
+        const char* note = wallpapers::takeoverNote(wallpapers::choiceForSetWallpaper(mode, qr != 0));
+        if (note != nullptr) lines.emplace_back(note);
+      }
+    }
+    // And the two the strip already carried, so this check covers the strip
+    // rather than only the new arrivals.
+    lines.emplace_back("Tap one to set your sleep screen.");
+    lines.emplace_back("Card is low on space. Saves may fail.");
+    lines.emplace_back("Could not check card space.");
+
+    int widestHint = 0;
+    std::string widestHintText;
+    for (const std::string& line : lines) {
+      fui::TextStyle style = hintStyle;
+      const std::string fitted = toybox::fittedTitle(target, line.c_str(), stripWidth, style);
+      const int w = target.widthOf(fui::FONT_SLOT_SMALL, line);
+      if (w > widestHint) {
+        widestHint = w;
+        widestHintText = line;
+      }
+      check(fitted == line, "hint strip sentence was cut: \"" + line + "\" -> \"" + fitted + "\"");
+      check(line.find('\n') == std::string::npos, "hint strip sentence carries a newline: \"" + line + "\"");
+    }
+    std::printf("wallcaption: widest hint \"%s\" = %dpx in a %dpx strip (%dpx spare)\n", widestHintText.c_str(),
+                widestHint, stripWidth, stripWidth - widestHint);
+  }
+
   std::printf("wallcaption: widest caption \"%s\" = %dpx in a %dpx box (%dpx spare)\n", widestName.c_str(), widest,
               wallpapersui::captionRect(g, 0).width, wallpapersui::captionRect(g, 0).width - widest);
   std::printf("wallcaption: %d checks, %d failed\n", checks, failed);

--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -25,6 +25,7 @@
 
 #include "../../src/apps_local/ui/ToyboxText.h"
 #include "../../src/apps_local/ui/fonts/toybox_10.h"
+#include "../../src/apps_local/ui/fonts/toybox_14.h"
 #include "../../src/apps_local/ui/fonts/toybox_20.h"
 #include "../../src/apps_local/ui/fonts/toybox_30.h"
 #include "../../src/apps_local/wallpapers/WallpapersCore.h"
@@ -47,9 +48,11 @@ void check(const bool ok, const std::string& what) {
 // The faces the picker really binds: the caption asks for FONT_SLOT_SMALL and
 // the Toybox theme answers with toybox_10 (WallpapersActivity::drawGrid).
 EpdFont small10(&toybox_10);
+EpdFont button14(&toybox_14);
 EpdFont ui20(&toybox_20);
 EpdFont display30(&toybox_30);
 EpdFontFamily smallFamily(&small10);
+EpdFontFamily buttonFamily(&button14);
 EpdFontFamily uiFamily(&ui20);
 EpdFontFamily displayFamily(&display30);
 
@@ -57,6 +60,50 @@ class FontTarget final : public fui::DrawTarget {
  public:
   const EpdFontFamily* familyFor(const fui::FontId font) const {
     if (font == fui::FONT_SLOT_SMALL) return &smallFamily;
+    if (font == fui::FONT_SLOT_BODY) return &uiFamily;
+    return &displayFamily;
+  }
+  int widthOf(const fui::FontId font, const std::string& text) const {
+    if (text.empty()) return 0;
+    int w = 0;
+    int h = 0;
+    familyFor(font)->getTextDimensions(text.c_str(), &w, &h);
+    return w;
+  }
+  fui::Size measureText(const fui::FontId font, const char* text, const fui::TextStyle) const override {
+    return fui::Size{static_cast<int16_t>(widthOf(font, text == nullptr ? "" : text)), lineHeight(font)};
+  }
+  int16_t lineHeight(const fui::FontId font) const override {
+    return static_cast<int16_t>(familyFor(font)->getData(EpdFontFamily::REGULAR)->advanceY);
+  }
+  void fill(fui::Rect, fui::Paint, uint8_t = 0, uint8_t = 0xFF) override {}
+  void stroke(fui::Rect, fui::Paint, uint8_t, uint8_t = 0, uint8_t = 0xFF) override {}
+  void line(fui::Point, fui::Point, uint8_t, fui::Paint) override {}
+  void triangle(fui::Point, fui::Point, fui::Point, fui::Paint) override {}
+  void text(fui::Rect, const char*, const fui::TextStyle) override {}
+  void bitmap(fui::Rect, fui::BitmapRef, fui::BitmapMode, fui::Paint = {},
+              fui::Rotation = fui::Rotation::None) override {}
+};
+
+// The grid CHROME is a different face set from the grid's captions, and the
+// difference is the whole reason this block exists.
+//
+// drawGrid() builds its caption target with toybox::makeTarget(renderer) and
+// the DEFAULT Faces, so FONT_SLOT_SMALL is kTileFontId = toybox_10 -- what
+// FontTarget above models. render() builds the CHROME's target with
+// toybox::proseMenuFaces(), where the same slot is kButtonFontId = toybox_14.
+// So the hint strip draws ~40% wider than the captions do, and measuring it in
+// toybox_10 said every sentence fitted while the panel cut one mid-word. The
+// simulator screenshot is what caught it; this target is what stops it coming
+// back ("drawn size is a claim").
+//
+// fittedTitle can rescue nothing here: it steps DOWN through the bound slots,
+// and in this face set TITLE (30) and BODY (20) are both taller than SMALL
+// (14), so there is no rung below and the only move left is the ellipsis.
+class ChromeFontTarget final : public fui::DrawTarget {
+ public:
+  const EpdFontFamily* familyFor(const fui::FontId font) const {
+    if (font == fui::FONT_SLOT_SMALL) return &buttonFamily;
     if (font == fui::FONT_SLOT_BODY) return &uiFamily;
     return &displayFamily;
   }
@@ -309,6 +356,7 @@ int main() {
   //    the bezel-insets memory), which is narrower than a bare 480 -- so the
   //    number here is the device's, not the emulator's.
   {
+    const ChromeFontTarget chrome;
     const fui::Rect bezelSafe = fui::makeRect(1, 10, 478, 790);
     const int16_t stripWidth = wallpapersui::hintTextWidth(bezelSafe);
     fui::TextStyle hintStyle;
@@ -341,8 +389,8 @@ int main() {
     std::string widestHintText;
     for (const std::string& line : lines) {
       fui::TextStyle style = hintStyle;
-      const std::string fitted = toybox::fittedTitle(target, line.c_str(), stripWidth, style);
-      const int w = target.widthOf(fui::FONT_SLOT_SMALL, line);
+      const std::string fitted = toybox::fittedTitle(chrome, line.c_str(), stripWidth, style);
+      const int w = chrome.widthOf(fui::FONT_SLOT_SMALL, line);
       if (w > widestHint) {
         widestHint = w;
         widestHintText = line;

--- a/host-tests/wallpapers/test_wallpapers.cpp
+++ b/host-tests/wallpapers/test_wallpapers.cpp
@@ -255,33 +255,14 @@ void testChoiceKeepsWhatItCan() {
   const SleepChoice cover = choiceForSetWallpaper(kSleepCoverCustom, false);
   CHECK(cover.sleepScreenMode == kSleepCoverCustom);
   CHECK(!cover.tookOverMode);
-  CHECK(takeoverNote(cover) == nullptr);
 
   // Already Custom with nothing in the way: nothing changes, nothing is said.
   const SleepChoice plain = choiceForSetWallpaper(kSleepCustom, false);
   CHECK(plain.sleepScreenMode == kSleepCustom);
   CHECK(!plain.tookOverMode);
   CHECK(!plain.clearedQuickResume);
-  CHECK(takeoverNote(plain) == nullptr);
-
-  // Every combination that DOES change a setting the user chose elsewhere has
-  // to hand the picker a sentence. This is criterion 3, stated as a loop rather
-  // than as three examples, so a new mode cannot be added silently.
-  for (uint8_t mode = 0; mode < kSleepModeCount; ++mode) {
-    for (int qr = 0; qr < 2; ++qr) {
-      const SleepChoice choice = choiceForSetWallpaper(mode, qr != 0);
-      const bool changedSomething = choice.tookOverMode || choice.clearedQuickResume;
-      const char* note = takeoverNote(choice);
-      if (changedSomething) {
-        check(note != nullptr && note[0] != '\0', "a selection that changed a Settings choice must say so", __LINE__);
-      } else {
-        check(note == nullptr, "a selection that changed nothing must not invent a notice", __LINE__);
-      }
-      // Whatever it did, it must have preserved the previous mode for the
-      // sentence -- a note that cannot name what it replaced is not a report.
-      check(choice.previousMode == mode, "the choice lost the mode it replaced", __LINE__);
-    }
-  }
+  CHECK(stripLineAfterSelection(plain, reachOfPinnedSleep(plain.sleepScreenMode, plain.quickResumeAfterTimeout)).text ==
+        nullptr);
 
   // Quick Resume as the mode cannot survive: it is the one mode that means "do
   // not show a sleep image at all". So it is replaced, and reported.
@@ -289,20 +270,66 @@ void testChoiceKeepsWhatItCan() {
   CHECK(fromQuickResume.sleepScreenMode == kSleepCustom);
   CHECK(fromQuickResume.tookOverMode);
   CHECK(fromQuickResume.clearedQuickResume);
-  CHECK(takeoverNote(fromQuickResume) != nullptr);
 
-  // Two settings can move at once, and the three cases must be three different
-  // sentences. A note that read the same whether one or both had changed would
-  // be reporting the branch it happened to check first.
-  const SleepChoice both = choiceForSetWallpaper(kSleepDark, true);  // mode + flag
-  const SleepChoice modeOnly = choiceForSetWallpaper(kSleepDark, false);
-  const SleepChoice flagOnly = choiceForSetWallpaper(kSleepCustom, true);
-  CHECK(both.tookOverMode && both.clearedQuickResume);
-  CHECK(modeOnly.tookOverMode && !modeOnly.clearedQuickResume);
-  CHECK(!flagOnly.tookOverMode && flagOnly.clearedQuickResume);
-  CHECK(std::string(takeoverNote(both)) != std::string(takeoverNote(modeOnly)));
-  CHECK(std::string(takeoverNote(both)) != std::string(takeoverNote(flagOnly)));
-  CHECK(std::string(takeoverNote(modeOnly)) != std::string(takeoverNote(flagOnly)));
+  for (uint8_t mode = 0; mode < kSleepModeCount; ++mode) {
+    for (int qr = 0; qr < 2; ++qr) {
+      const SleepChoice choice = choiceForSetWallpaper(mode, qr != 0);
+      check(choice.previousMode == mode, "the choice lost the mode it replaced", __LINE__);
+    }
+  }
+}
+
+// THE COVERAGE PROOF, and the reason StripLine is a struct rather than a
+// string.
+//
+// The first version of this fix returned the "what your tap changed" sentence
+// and fell through to the standing caveat only when there was none. So a user
+// on Cover + Custom with Quick Resume on Timeout who tapped a wallpaper got
+// "Quick Resume on Timeout turned off." -- and the caveat that a book cover
+// still wins inside a book was suppressed for the rest of the app session.
+// That is card #354's own shape (a confident screen, a silent caveat) recurring
+// inside its fix, and it is "a warning that can vanish".
+//
+// So the assertion is not that a sentence exists, and not that it CONTAINS some
+// word -- a text check is satisfied by a mention (see "a detector that matches
+// the description"). It is that the facts the line declares it covers are
+// exactly the facts present, for every reachable combination.
+void testStripLineCoversEveryFact() {
+  using namespace wallpapers;
+
+  int withCaveat = 0;
+  int withBoth = 0;
+  for (uint8_t mode = 0; mode < kSleepModeCount; ++mode) {
+    for (int qr = 0; qr < 2; ++qr) {
+      const SleepChoice choice = choiceForSetWallpaper(mode, qr != 0);
+      const Reach reach = reachOfPinnedSleep(choice.sleepScreenMode, choice.quickResumeAfterTimeout);
+      const StripLine line = stripLineAfterSelection(choice, reach);
+      const bool caveat = reach != Reach::Always;
+      const std::string at = " (mode " + std::to_string(static_cast<int>(mode)) + ", qr " + std::to_string(qr) + ")";
+
+      check(line.saysModeChanged == choice.tookOverMode, ("the line does not report the mode takeover" + at).c_str(),
+            __LINE__);
+      check(line.saysQuickResumeCleared == choice.clearedQuickResume,
+            ("the line does not report quick resume being cleared" + at).c_str(), __LINE__);
+      check(line.saysCaveat == caveat, ("the line drops a standing caveat" + at).c_str(), __LINE__);
+
+      const bool anything = choice.tookOverMode || choice.clearedQuickResume || caveat;
+      check((line.text != nullptr && line.text[0] != '\0') == anything,
+            ("a line that has something to say must say it, and one that has nothing must stay quiet" + at).c_str(),
+            __LINE__);
+      if (caveat) ++withCaveat;
+      if (caveat && choice.clearedQuickResume) ++withBoth;
+    }
+  }
+  // The loop must actually REACH the case that was broken, or it proves
+  // nothing: a caveat surviving a selection, and one doing so alongside a
+  // cleared quick-resume flag ("a test not seen fail").
+  CHECK(withCaveat > 0);
+  CHECK(withBoth > 0);
+
+  // And with no selection at all the strip still carries the caveat.
+  CHECK(reachHint(reachOfPinnedSleep(kSleepCoverCustom, false)) != nullptr);
+  CHECK(reachHint(reachOfPinnedSleep(kSleepCustom, false)) == nullptr);
 }
 
 }  // namespace
@@ -315,6 +342,7 @@ int main() {
   testReach();
   testChoiceReachesTheGlassOnTimeout();
   testChoiceKeepsWhatItCan();
+  testStripLineCoversEveryFact();
 
   // Uploads first, then built-ins, each alphabetical. Mario's ask, and the
   // ordering the picker's captions are indexed by -- get it wrong and every

--- a/host-tests/wallpapers/test_wallpapers.cpp
+++ b/host-tests/wallpapers/test_wallpapers.cpp
@@ -124,12 +124,184 @@ void testDisplayNames() {
   CHECK(displayName("noextension").full == "noextension");
 }
 
+// ---------------------------------------------------------------------------
+// Card #354: a wallpaper the picker marked never reached the glass.
+//
+// The picker writes /sleep.bmp and then draws a confident marker, but TWO
+// settings decide whether SleepActivity ever draws that file, and the app was
+// leaving them in a combination that guaranteed it would not -- on the IDLE
+// TIMEOUT sleep, which is the ordinary way this device sleeps. The tests below
+// are about that path specifically: a button-held sleep already worked and
+// proves nothing.
+
+// The mirror of SleepActivity::onEnter. If this drifts from upstream the picker
+// starts lying again, so the shape of the rule is asserted, not just one case.
+void testDrawsPinnedSleep() {
+  using namespace wallpapers;
+
+  // The whole bug in one line: mode is CUSTOM, the file is there, the user
+  // chose it -- and the idle sleep shows something else.
+  CHECK(!drawsPinnedSleep(kSleepCustom, /*qr=*/true, /*fromTimeout=*/true, /*fromReader=*/false));
+  // Same settings, a button-held sleep. This is why a screenshot of a manual
+  // sleep was never evidence.
+  CHECK(drawsPinnedSleep(kSleepCustom, /*qr=*/true, /*fromTimeout=*/false, /*fromReader=*/false));
+
+  // With the timeout flag off, CUSTOM shows on every sleep.
+  CHECK(drawsPinnedSleep(kSleepCustom, false, true, false));
+  CHECK(drawsPinnedSleep(kSleepCustom, false, false, false));
+  CHECK(drawsPinnedSleep(kSleepCustom, false, true, true));
+
+  // COVER_CUSTOM shows it outside the reader only.
+  CHECK(drawsPinnedSleep(kSleepCoverCustom, false, true, false));
+  CHECK(!drawsPinnedSleep(kSleepCoverCustom, false, true, true));
+
+  // Exactly two of the eight modes ever put this file on the glass. The count
+  // is walked rather than asserted mode by mode, so a ninth mode arriving from
+  // upstream cannot slip past a hand-written list.
+  int everDraws = 0;
+  for (uint8_t mode = 0; mode < kSleepModeCount; ++mode) {
+    bool any = false;
+    for (int qr = 0; qr < 2; ++qr) {
+      for (int t = 0; t < 2; ++t) {
+        for (int r = 0; r < 2; ++r) {
+          if (drawsPinnedSleep(mode, qr != 0, t != 0, r != 0)) any = true;
+        }
+      }
+    }
+    if (any) ++everDraws;
+  }
+  CHECK(everDraws == 2);
+
+  // Quick Resume as the MODE beats the file on every path, timeout or not.
+  for (int t = 0; t < 2; ++t) {
+    for (int r = 0; r < 2; ++r) {
+      CHECK(!drawsPinnedSleep(kSleepQuickResume, false, t != 0, r != 0));
+    }
+  }
+  // And the transparent mode has its own art, so a wallpaper is ignored there.
+  CHECK(!drawsPinnedSleep(kSleepTransparentCustom, false, false, false));
+}
+
+// Reach is what the picker SAYS. Blocked must be distinguishable from "shows,
+// but not inside a book": one is a settings problem the user can fix, the other
+// is normal.
+void testReach() {
+  using namespace wallpapers;
+
+  CHECK(reachOfPinnedSleep(kSleepCustom, false) == Reach::Always);
+  CHECK(reachOfPinnedSleep(kSleepCustom, true) == Reach::BlockedByQuickResume);
+  CHECK(reachOfPinnedSleep(kSleepCoverCustom, false) == Reach::OutsideReaderOnly);
+  CHECK(reachOfPinnedSleep(kSleepCoverCustom, true) == Reach::BlockedByQuickResume);
+  CHECK(reachOfPinnedSleep(kSleepQuickResume, false) == Reach::BlockedByMode);
+  CHECK(reachOfPinnedSleep(kSleepQuickResume, true) == Reach::BlockedByMode);
+  CHECK(reachOfPinnedSleep(kSleepDark, false) == Reach::BlockedByMode);
+  CHECK(reachOfPinnedSleep(kSleepLight, false) == Reach::BlockedByMode);
+  CHECK(reachOfPinnedSleep(kSleepCover, false) == Reach::BlockedByMode);
+  CHECK(reachOfPinnedSleep(kSleepBlank, false) == Reach::BlockedByMode);
+  CHECK(reachOfPinnedSleep(kSleepTransparentCustom, false) == Reach::BlockedByMode);
+
+  // Every blocked state must produce a sentence, and Always must produce none:
+  // a hint strip that stays blank while the marker lies is the whole defect.
+  for (uint8_t mode = 0; mode < kSleepModeCount; ++mode) {
+    for (int qr = 0; qr < 2; ++qr) {
+      const Reach reach = reachOfPinnedSleep(mode, qr != 0);
+      const char* hint = reachHint(reach);
+      if (reach == Reach::Always) {
+        CHECK(hint == nullptr);
+      } else {
+        CHECK(hint != nullptr && hint[0] != '\0');
+      }
+    }
+  }
+}
+
+// The acceptance criterion, as arithmetic: after tapping a wallpaper, from ANY
+// starting combination of the two settings, the wallpaper shows on an IDLE
+// TIMEOUT sleep.
+//
+// This is the test that goes red on the shipped rule. Shipped, setWallpaper
+// turned the timeout quick-resume flag ON whenever the previous mode was Quick
+// Resume, to keep wake fast -- which made the timeout sleep, the ordinary one,
+// the single path the chosen wallpaper could never appear on.
+void testChoiceReachesTheGlassOnTimeout() {
+  using namespace wallpapers;
+
+  for (uint8_t mode = 0; mode < kSleepModeCount; ++mode) {
+    for (int qr = 0; qr < 2; ++qr) {
+      const SleepChoice choice = choiceForSetWallpaper(mode, qr != 0);
+      check(drawsPinnedSleep(choice.sleepScreenMode, choice.quickResumeAfterTimeout, /*fromTimeout=*/true,
+                             /*fromReader=*/false),
+            "after selecting a wallpaper the idle-timeout sleep must show it", __LINE__);
+      // And it must not merely work by accident on the manual path.
+      check(drawsPinnedSleep(choice.sleepScreenMode, choice.quickResumeAfterTimeout, /*fromTimeout=*/false,
+                             /*fromReader=*/false),
+            "after selecting a wallpaper a button-held sleep must show it too", __LINE__);
+      check(
+          reachOfPinnedSleep(choice.sleepScreenMode, choice.quickResumeAfterTimeout) != Reach::BlockedByMode &&
+              reachOfPinnedSleep(choice.sleepScreenMode, choice.quickResumeAfterTimeout) != Reach::BlockedByQuickResume,
+          "selecting a wallpaper must not leave the picker in a blocked state", __LINE__);
+    }
+  }
+}
+
+// A deliberate choice made in Settings is either kept or reported. Never
+// overwritten in silence.
+void testChoiceKeepsWhatItCan() {
+  using namespace wallpapers;
+
+  // COVER_CUSTOM already draws /sleep.bmp outside the reader. Handing it a new
+  // wallpaper must leave the mode alone -- the user asked for book covers in
+  // books and this picture everywhere else, and both still happen.
+  const SleepChoice cover = choiceForSetWallpaper(kSleepCoverCustom, false);
+  CHECK(cover.sleepScreenMode == kSleepCoverCustom);
+  CHECK(!cover.tookOverMode);
+  CHECK(takeoverNote(cover) == nullptr);
+
+  // Already Custom with nothing in the way: nothing changes, nothing is said.
+  const SleepChoice plain = choiceForSetWallpaper(kSleepCustom, false);
+  CHECK(plain.sleepScreenMode == kSleepCustom);
+  CHECK(!plain.tookOverMode);
+  CHECK(!plain.clearedQuickResume);
+  CHECK(takeoverNote(plain) == nullptr);
+
+  // Every combination that DOES change a setting the user chose elsewhere has
+  // to hand the picker a sentence. This is criterion 3, stated as a loop rather
+  // than as three examples, so a new mode cannot be added silently.
+  for (uint8_t mode = 0; mode < kSleepModeCount; ++mode) {
+    for (int qr = 0; qr < 2; ++qr) {
+      const SleepChoice choice = choiceForSetWallpaper(mode, qr != 0);
+      const bool changedSomething = choice.tookOverMode || choice.clearedQuickResume;
+      const char* note = takeoverNote(choice);
+      if (changedSomething) {
+        check(note != nullptr && note[0] != '\0', "a selection that changed a Settings choice must say so", __LINE__);
+      } else {
+        check(note == nullptr, "a selection that changed nothing must not invent a notice", __LINE__);
+      }
+      // Whatever it did, it must have preserved the previous mode for the
+      // sentence -- a note that cannot name what it replaced is not a report.
+      check(choice.previousMode == mode, "the choice lost the mode it replaced", __LINE__);
+    }
+  }
+
+  // Quick Resume as the mode cannot survive: it is the one mode that means "do
+  // not show a sleep image at all". So it is replaced, and reported.
+  const SleepChoice fromQuickResume = choiceForSetWallpaper(kSleepQuickResume, true);
+  CHECK(fromQuickResume.sleepScreenMode == kSleepCustom);
+  CHECK(fromQuickResume.tookOverMode);
+  CHECK(fromQuickResume.clearedQuickResume);
+  CHECK(takeoverNote(fromQuickResume) != nullptr);
+}
+
 }  // namespace
 
 int main() {
   testFileNameFilter();
   testDisplayNames();
   testRoomFor();
+  testDrawsPinnedSleep();
+  testReach();
+  testChoiceReachesTheGlassOnTimeout();
+  testChoiceKeepsWhatItCan();
 
   // Uploads first, then built-ins, each alphabetical. Mario's ask, and the
   // ordering the picker's captions are indexed by -- get it wrong and every

--- a/host-tests/wallpapers/test_wallpapers.cpp
+++ b/host-tests/wallpapers/test_wallpapers.cpp
@@ -290,6 +290,19 @@ void testChoiceKeepsWhatItCan() {
   CHECK(fromQuickResume.tookOverMode);
   CHECK(fromQuickResume.clearedQuickResume);
   CHECK(takeoverNote(fromQuickResume) != nullptr);
+
+  // Two settings can move at once, and the three cases must be three different
+  // sentences. A note that read the same whether one or both had changed would
+  // be reporting the branch it happened to check first.
+  const SleepChoice both = choiceForSetWallpaper(kSleepDark, true);  // mode + flag
+  const SleepChoice modeOnly = choiceForSetWallpaper(kSleepDark, false);
+  const SleepChoice flagOnly = choiceForSetWallpaper(kSleepCustom, true);
+  CHECK(both.tookOverMode && both.clearedQuickResume);
+  CHECK(modeOnly.tookOverMode && !modeOnly.clearedQuickResume);
+  CHECK(!flagOnly.tookOverMode && flagOnly.clearedQuickResume);
+  CHECK(std::string(takeoverNote(both)) != std::string(takeoverNote(modeOnly)));
+  CHECK(std::string(takeoverNote(both)) != std::string(takeoverNote(flagOnly)));
+  CHECK(std::string(takeoverNote(modeOnly)) != std::string(takeoverNote(flagOnly)));
 }
 
 }  // namespace

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -23,6 +23,24 @@
 namespace fui = freeink::ui;
 
 namespace {
+// WallpapersCore mirrors CrossPointSettings::SLEEP_SCREEN_MODE so the sleep-
+// reachability rules are freestanding and host-testable. This is the seam where
+// the mirror is checked: a value that moves upstream fails the build here
+// rather than silently teaching the picker to say the wrong sentence.
+static_assert(wallpapers::kSleepDark == CrossPointSettings::SLEEP_SCREEN_MODE::DARK, "sleep mode mirror drifted");
+static_assert(wallpapers::kSleepLight == CrossPointSettings::SLEEP_SCREEN_MODE::LIGHT, "sleep mode mirror drifted");
+static_assert(wallpapers::kSleepCustom == CrossPointSettings::SLEEP_SCREEN_MODE::CUSTOM, "sleep mode mirror drifted");
+static_assert(wallpapers::kSleepCover == CrossPointSettings::SLEEP_SCREEN_MODE::COVER, "sleep mode mirror drifted");
+static_assert(wallpapers::kSleepCoverCustom == CrossPointSettings::SLEEP_SCREEN_MODE::COVER_CUSTOM,
+              "sleep mode mirror drifted");
+static_assert(wallpapers::kSleepBlank == CrossPointSettings::SLEEP_SCREEN_MODE::BLANK, "sleep mode mirror drifted");
+static_assert(wallpapers::kSleepQuickResume == CrossPointSettings::SLEEP_SCREEN_MODE::QUICK_RESUME,
+              "sleep mode mirror drifted");
+static_assert(wallpapers::kSleepTransparentCustom == CrossPointSettings::SLEEP_SCREEN_MODE::TRANSPARENT_CUSTOM,
+              "sleep mode mirror drifted");
+static_assert(wallpapers::kSleepModeCount == CrossPointSettings::SLEEP_SCREEN_MODE::SLEEP_SCREEN_MODE_COUNT,
+              "a sleep screen mode was added upstream; WallpapersCore's mirror and its rules must be updated");
+
 constexpr int kMaxLibrary = 256;
 constexpr size_t kNameMax = 128;
 constexpr size_t kCopyChunk = 4096;
@@ -122,6 +140,7 @@ void WallpapersActivity::onEnter() {
   // before-block work, so the screen is painted first and the walk happens
   // after, in loop(), with content already on the glass.
   warning_.clear();
+  takeover_.clear();
   warningPending_ = true;
   LOG_INF("WALL", "onEnter %ums: fonts=%u sweep=%u scan=%u active=%u (free-space deferred)", tActive - tEnter,
           tFonts - tEnter, tSweep - tFonts, tScan - tSweep, tActive - tScan);
@@ -165,7 +184,12 @@ void WallpapersActivity::scanLibrary() {
 
 void WallpapersActivity::loadActive() {
   activeIndex_ = -1;
-  if (SETTINGS.sleepScreen != CrossPointSettings::CUSTOM) return;
+  // Deliberately NOT gated on sleepScreen == CUSTOM any more (#354). That gate
+  // was wrong in both directions: it hid the marker under COVER_CUSTOM, where
+  // the wallpaper genuinely does show, and it drew the marker at full
+  // confidence under CUSTOM-plus-quick-resume, where it never does. What is
+  // pinned is a fact about the card; whether it reaches the glass is a fact
+  // about two settings, and the hint strip says that in words instead.
   if (!Storage.exists(wallpapers::kPinnedSleep)) return;
   char marker[kNameMax] = {};
   if (Storage.readFileToBuffer(wallpapers::kActiveMarker, marker, sizeof(marker)) == 0) return;
@@ -183,6 +207,29 @@ void WallpapersActivity::loadActive() {
   }
 }
 
+wallpapers::Reach WallpapersActivity::sleepReach() const {
+  const bool quickResumeOnTimeout =
+      SETTINGS.quickResumeSleepScreen == CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT;
+  return wallpapers::reachOfPinnedSleep(SETTINGS.sleepScreen, quickResumeOnTimeout);
+}
+
+bool WallpapersActivity::sleepBlocked() const {
+  const wallpapers::Reach reach = sleepReach();
+  return reach == wallpapers::Reach::BlockedByMode || reach == wallpapers::Reach::BlockedByQuickResume;
+}
+
+std::string WallpapersActivity::currentSleepNote() const {
+  // What a selection changed comes first: it reports something that has already
+  // happened to the device, and the user did not ask for it.
+  if (!takeover_.empty()) return takeover_;
+  // Otherwise, only when there is a marker to contradict. With nothing pinned
+  // the strip already carries "Tap one to set your sleep screen.", and telling
+  // someone their non-existent wallpaper is blocked would be noise.
+  if (activeIndex_ < 0) return std::string();
+  const char* hint = wallpapers::reachHint(sleepReach());
+  return hint == nullptr ? std::string() : std::string(hint);
+}
+
 void WallpapersActivity::computeWarning() {
   warning_.clear();
   uint64_t free = 0;
@@ -191,7 +238,11 @@ void WallpapersActivity::computeWarning() {
     case wallpapers::Room::Ok:
       break;
     case wallpapers::Room::TooFull:
-      warning_ = "Card is low on space. New wallpapers or books may not save.";
+      // Short enough to survive the 30px hint strip in the real face. The
+      // longer form ("... New wallpapers or books may not save.") measured
+      // 498px in a 446px strip and was cut mid-phrase on the device -- found by
+      // measuring rather than by looking, see host-tests/wallcaption.
+      warning_ = "Card is low on space. Saves may fail.";
       break;
     case wallpapers::Room::Unknown:
       warning_ = "Could not check card space.";
@@ -284,30 +335,31 @@ bool WallpapersActivity::setWallpaper(int index) {
     return false;
   }
 
-  // Taking a QUICK_RESUME user off that mode is the ONE thing this app does
-  // that changes the whole device rather than its own screen, and it is the only
-  // wallpaper code anywhere near the boot path -- nothing of ours executes at
-  // wake at all.
+  // The two settings that decide whether /sleep.bmp is ever drawn, set together
+  // (#354). Keeping the timeout quick-resume flag ON used to be this app's way
+  // of not making wake slower, and the price was the whole feature: while that
+  // flag is on, the IDLE sleep -- the ordinary one -- short-circuits above the
+  // sleep-screen switch and no wallpaper can appear. The user tapped a picture;
+  // the picture wins, and the picker says what that cost.
   //
-  // main.cpp::enterDeepSleep saves a retained frame ONLY when the sleep is a
-  // quick-resume sleep, and the wake branch that restores it is also the branch
-  // that draws the LoadingIcon. Flipping the mode to CUSTOM therefore cost two
-  // things at once: the fast frame restore, and the only sign of life the user
-  // gets while the device boots (wake is a chip reset). A decorative feature
-  // must not buy itself a slower wake for the whole device.
-  //
-  // quickResumeSleepScreen is left ON so timeout sleeps -- the common case, and
-  // the one Mario was waiting on -- keep the fast path and the icon. The
-  // combination is supported: SettingsActivity::syncQuickResumeTimeoutForSleepScreen
-  // preserves an explicitly-enabled timeout flag across a sleep-screen change.
-  // The trade is that the wallpaper then shows on manual sleeps rather than on
-  // timeout ones.
-  if (SETTINGS.sleepScreen == CrossPointSettings::QUICK_RESUME) {
-    SETTINGS.quickResumeSleepScreen = CrossPointSettings::QUICK_RESUME_AFTER_TIMEOUT;
-    LOG_INF("WALL", "was QUICK_RESUME; keeping quick wake on timeout sleeps so wake does not get slower");
-  }
-  SETTINGS.sleepScreen = CrossPointSettings::CUSTOM;
+  // The rule and its consequences are proved in host-tests/wallpapers, which is
+  // where they can be walked over all eight modes rather than reasoned about.
+  const bool quickResumeOnTimeout =
+      SETTINGS.quickResumeSleepScreen == CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT;
+  const wallpapers::SleepChoice choice = wallpapers::choiceForSetWallpaper(SETTINGS.sleepScreen, quickResumeOnTimeout);
+  SETTINGS.sleepScreen = choice.sleepScreenMode;
+  SETTINGS.quickResumeSleepScreen = choice.quickResumeAfterTimeout
+                                        ? CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT
+                                        : CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_NEVER;
   SETTINGS.saveToFile();
+  const char* note = wallpapers::takeoverNote(choice);
+  takeover_ = note == nullptr ? std::string() : std::string(note);
+  if (choice.tookOverMode || choice.clearedQuickResume) {
+    LOG_INF("WALL", "sleep settings changed by a selection: mode %s -> %s, quick resume on timeout %d -> %d",
+            wallpapers::sleepScreenModeName(choice.previousMode),
+            wallpapers::sleepScreenModeName(choice.sleepScreenMode), quickResumeOnTimeout ? 1 : 0,
+            choice.quickResumeAfterTimeout ? 1 : 0);
+  }
 
   HalFile marker;
   if (Storage.openFileForWrite("WALL", wallpapers::kActiveMarker, marker)) {
@@ -1090,7 +1142,11 @@ void WallpapersActivity::loop() {
     return;
   }
   const int idx = combined - specials;
-  if (idx == activeIndex_) return;  // already the sleep screen
+  // "Already the sleep screen" is only true when it can actually BE the sleep
+  // screen. When the settings block it, tapping the marked wallpaper again is
+  // exactly what a person does after nothing happened, and it now repairs the
+  // settings instead of being swallowed (#354).
+  if (idx == activeIndex_ && !sleepBlocked()) return;
   if (setWallpaper(idx)) requestUpdate();
 }
 
@@ -1148,10 +1204,16 @@ void WallpapersActivity::render(RenderLock&&) {
       snprintf(label, sizeof(label), "%d SAVED", static_cast<int>(names_.size()));
       rightLabel_ = label;
     }
+    sleepNote_ = currentSleepNote();
     wallpapersui::GridChromeModel model;
     model.rightLabel = rightLabel_.c_str();
     model.warning = warning_.empty() ? nullptr : warning_.c_str();
     model.hasActive = activeIndex_ >= 0;
+    // Read from SETTINGS at paint time, not remembered from the selection: the
+    // user can leave for Settings, turn quick resume back on and come back, and
+    // the marker would otherwise go on claiming a wallpaper that no longer
+    // shows.
+    model.note = sleepNote_.empty() ? nullptr : sleepNote_.c_str();
     wallpapersui::buildGridChrome(surface, model);
 
     // The chrome is a screen tree; the grid is the app's own surface, drawn

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -140,7 +140,7 @@ void WallpapersActivity::onEnter() {
   // before-block work, so the screen is painted first and the walk happens
   // after, in loop(), with content already on the glass.
   warning_.clear();
-  takeover_.clear();
+  selectedThisSession_ = false;
   warningPending_ = true;
   LOG_INF("WALL", "onEnter %ums: fonts=%u sweep=%u scan=%u active=%u (free-space deferred)", tActive - tEnter,
           tFonts - tEnter, tSweep - tFonts, tScan - tSweep, tActive - tScan);
@@ -218,16 +218,17 @@ bool WallpapersActivity::sleepBlocked() const {
   return reach == wallpapers::Reach::BlockedByMode || reach == wallpapers::Reach::BlockedByQuickResume;
 }
 
-std::string WallpapersActivity::currentSleepNote() const {
-  // What a selection changed comes first: it reports something that has already
-  // happened to the device, and the user did not ask for it.
-  if (!takeover_.empty()) return takeover_;
-  // Otherwise, only when there is a marker to contradict. With nothing pinned
-  // the strip already carries "Tap one to set your sleep screen.", and telling
-  // someone their non-existent wallpaper is blocked would be noise.
-  if (activeIndex_ < 0) return std::string();
-  const char* hint = wallpapers::reachHint(sleepReach());
-  return hint == nullptr ? std::string() : std::string(hint);
+const char* WallpapersActivity::currentSleepNote() const {
+  // Nothing pinned: the strip already carries "Tap one to set your sleep
+  // screen.", and telling someone their non-existent wallpaper is blocked
+  // would be noise.
+  if (activeIndex_ < 0) return nullptr;
+  const wallpapers::Reach reach = sleepReach();
+  // After a selection the line must carry BOTH what the tap changed and any
+  // caveat that still applies -- one cannot be allowed to hide the other, which
+  // is what stripLineAfterSelection exists to guarantee.
+  if (selectedThisSession_) return wallpapers::stripLineAfterSelection(lastChoice_, reach).text;
+  return wallpapers::reachHint(reach);
 }
 
 void WallpapersActivity::computeWarning() {
@@ -238,10 +239,11 @@ void WallpapersActivity::computeWarning() {
     case wallpapers::Room::Ok:
       break;
     case wallpapers::Room::TooFull:
-      // Short enough to survive the 30px hint strip in the real face. The
-      // longer form ("... New wallpapers or books may not save.") measured
-      // 498px in a 446px strip and was cut mid-phrase on the device -- found by
-      // measuring rather than by looking, see host-tests/wallcaption.
+      // Short enough to survive the hint strip. The longer form
+      // ("... New wallpapers or books may not save.") did not: it overflowed
+      // the 446px line in the face the strip resolves and was cut mid-phrase.
+      // host-tests/wallcaption measures this string with the rest of them --
+      // found by measuring rather than by looking.
       warning_ = "Card is low on space. Saves may fail.";
       break;
     case wallpapers::Room::Unknown:
@@ -353,8 +355,8 @@ bool WallpapersActivity::setWallpaper(int index) {
                                         ? CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT
                                         : CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_NEVER;
   SETTINGS.saveToFile();
-  const char* note = wallpapers::takeoverNote(choice);
-  takeover_ = note == nullptr ? std::string() : std::string(note);
+  lastChoice_ = choice;
+  selectedThisSession_ = true;
   if (choice.tookOverMode || choice.clearedQuickResume) {
     LOG_INF("WALL", "sleep settings changed by a selection: mode %s -> %s, quick resume on timeout %d -> %d",
             wallpapers::sleepScreenModeName(choice.previousMode),
@@ -1156,7 +1158,24 @@ void WallpapersActivity::loop() {
   // exactly what a person does after nothing happened, and it now repairs the
   // settings instead of being swallowed (#354).
   if (idx == activeIndex_ && !sleepBlocked()) return;
-  if (setWallpaper(idx)) requestUpdate();
+  if (setWallpaper(idx)) {
+    requestUpdate();
+    return;
+  }
+  // A failed pin used to do NOTHING: no notice, no repaint, nothing on the
+  // panel at all, while the reasons (card full, unreadable file, a card that
+  // refused the rename) went only to the log. setWallpaper leaves /sleep.bmp
+  // untouched on every one of those paths, so the honest report is that the
+  // sleep screen did not change.
+  //
+  // The free-space walk is re-armed rather than run here: it can take seconds
+  // on a large card and this is the input path (rendering-is-notification-
+  // driven). loop() runs it after the notice is on the glass.
+  warningPending_ = true;
+  showNotice("COULD NOT SET IT",
+             "The wallpaper was not saved and your sleep screen is unchanged. The card may be full, or the file may be "
+             "damaged.",
+             "OK", wallpapersui::ActionDismiss);
 }
 
 void WallpapersActivity::render(RenderLock&&) {
@@ -1213,16 +1232,15 @@ void WallpapersActivity::render(RenderLock&&) {
       snprintf(label, sizeof(label), "%d SAVED", static_cast<int>(names_.size()));
       rightLabel_ = label;
     }
-    sleepNote_ = currentSleepNote();
     wallpapersui::GridChromeModel model;
     model.rightLabel = rightLabel_.c_str();
     model.warning = warning_.empty() ? nullptr : warning_.c_str();
     model.hasActive = activeIndex_ >= 0;
-    // Read from SETTINGS at paint time, not remembered from the selection: the
-    // user can leave for Settings, turn quick resume back on and come back, and
-    // the marker would otherwise go on claiming a wallpaper that no longer
-    // shows.
-    model.note = sleepNote_.empty() ? nullptr : sleepNote_.c_str();
+    // Rebuilt from SETTINGS every paint rather than cached at selection time.
+    // The reach half is only knowable from the live settings, and the pointer
+    // is always a string literal out of WallpapersCore, so nothing here
+    // outlives the paint or allocates on it.
+    model.note = currentSleepNote();
     wallpapersui::buildGridChrome(surface, model);
 
     // The chrome is a screen tree; the grid is the app's own surface, drawn

--- a/src/apps_local/wallpapers/WallpapersActivity.h
+++ b/src/apps_local/wallpapers/WallpapersActivity.h
@@ -19,6 +19,7 @@
 
 #include "../../activities/Activity.h"
 #include "../ui/ToyboxScreen.h"
+#include "WallpapersCore.h"
 #include "WallpapersScreens.h"
 
 class WallpapersActivity final : public Activity {
@@ -64,6 +65,13 @@ class WallpapersActivity final : public Activity {
   void showNotice(const char* headline, const char* body, const char* actionLabel, freeink::ui::ActionId action);
   void loadActive();
   void computeWarning();
+  // Whether the pinned wallpaper can reach the sleep screen under the settings
+  // as they are RIGHT NOW, and the one line that says so. Both read SETTINGS
+  // live, because the two settings involved are changed elsewhere (Settings,
+  // and the web settings page) while this app is not looking. See #354.
+  wallpapers::Reach sleepReach() const;
+  bool sleepBlocked() const;
+  std::string currentSleepNote() const;
   bool setWallpaper(int index);  // copy /wallpapers/<index> -> /sleep.bmp
   int pageCount() const;         // over the whole library
   void clampPage();
@@ -95,6 +103,12 @@ class WallpapersActivity final : public Activity {
   freeink::ui::ActionId noticeActionId_ = 0;
   std::string rightLabel_;
   std::string warning_;
+  // What the last selection changed behind the user's back, if anything: a
+  // sleep-screen mode or the quick-resume-on-timeout flag they had chosen in
+  // Settings. Held until the app is left, so the change is reported rather than
+  // made in silence.
+  std::string takeover_;
+  std::string sleepNote_;  // the hint strip's line, rebuilt every paint
 
   // The current page's thumbnails, one per on-page slot (perPage entries;
   // trailing empty slots have ok = false).

--- a/src/apps_local/wallpapers/WallpapersActivity.h
+++ b/src/apps_local/wallpapers/WallpapersActivity.h
@@ -71,7 +71,7 @@ class WallpapersActivity final : public Activity {
   // and the web settings page) while this app is not looking. See #354.
   wallpapers::Reach sleepReach() const;
   bool sleepBlocked() const;
-  std::string currentSleepNote() const;
+  const char* currentSleepNote() const;
   bool setWallpaper(int index);  // copy /wallpapers/<index> -> /sleep.bmp
   int pageCount() const;         // over the whole library
   void clampPage();
@@ -103,12 +103,13 @@ class WallpapersActivity final : public Activity {
   freeink::ui::ActionId noticeActionId_ = 0;
   std::string rightLabel_;
   std::string warning_;
-  // What the last selection changed behind the user's back, if anything: a
-  // sleep-screen mode or the quick-resume-on-timeout flag they had chosen in
-  // Settings. Held until the app is left, so the change is reported rather than
-  // made in silence.
-  std::string takeover_;
-  std::string sleepNote_;  // the hint strip's line, rebuilt every paint
+  // The last selection's outcome, kept so the strip can report what it changed
+  // behind the user's back. The CHOICE, not a rendered sentence: the sentence
+  // also has to carry any standing caveat, and a caveat is only knowable from
+  // SETTINGS at paint time. Holding a string here is what let the first version
+  // suppress a caveat for a whole app session (#354, twice over).
+  bool selectedThisSession_ = false;
+  wallpapers::SleepChoice lastChoice_;
 
   // The current page's thumbnails, one per on-page slot (perPage entries;
   // trailing empty slots have ok = false).

--- a/src/apps_local/wallpapers/WallpapersCore.cpp
+++ b/src/apps_local/wallpapers/WallpapersCore.cpp
@@ -136,7 +136,7 @@ const char* reachHint(const Reach reach) {
     case Reach::Always:
       return nullptr;
     case Reach::OutsideReaderOnly:
-      return "Book covers win when you sleep in a book.";
+      return "Book covers win inside a book.";
     case Reach::BlockedByQuickResume:
       return "Quick Resume on Timeout hides this.";
     case Reach::BlockedByMode:
@@ -195,24 +195,30 @@ const char* takeoverNote(const SleepChoice& choice) {
   // Both settings can move at once, and a note that reported only one of them
   // would quietly drop the other ("a warning that can vanish"). So all three
   // branches exist and every one of them is a sentence.
+  //
+  // Terse on purpose. The strip draws in the CHROME face set (toybox_14 in the
+  // small slot, not the captions' toybox_10), which is ~40% wider per character
+  // and leaves 446px for one line. The longer forms measured 504-519px and the
+  // panel cut them mid-word. host-tests/wallcaption measures every one of these
+  // in that face.
   if (choice.tookOverMode && choice.clearedQuickResume) {
-    return "Sleep Screen now Custom, Quick Resume off.";
+    return "Now Custom, Quick Resume off.";
   }
   if (choice.clearedQuickResume) return "Quick Resume on Timeout turned off.";
   if (!choice.tookOverMode) return nullptr;
   switch (choice.previousMode) {
     case kSleepDark:
-      return "Sleep Screen was Dark, now Custom.";
+      return "Was Dark, now Custom.";
     case kSleepLight:
-      return "Sleep Screen was Light, now Custom.";
+      return "Was Light, now Custom.";
     case kSleepCover:
-      return "Sleep Screen was Cover, now Custom.";
+      return "Was Cover, now Custom.";
     case kSleepBlank:
-      return "Sleep Screen was Blank, now Custom.";
+      return "Was Blank, now Custom.";
     case kSleepQuickResume:
-      return "Sleep Screen was Quick Resume, now Custom.";
+      return "Was Quick Resume, now Custom.";
     case kSleepTransparentCustom:
-      return "Sleep Screen was Transparent, now Custom.";
+      return "Was Transparent, now Custom.";
     default:
       return nullptr;
   }

--- a/src/apps_local/wallpapers/WallpapersCore.cpp
+++ b/src/apps_local/wallpapers/WallpapersCore.cpp
@@ -103,6 +103,112 @@ DisplayName displayName(std::string_view fileName) {
   return DisplayName{own, own};
 }
 
+bool drawsPinnedSleep(const uint8_t sleepScreenMode, const bool quickResumeAfterTimeout, const bool fromTimeout,
+                      const bool fromReader) {
+  // 1. Quick resume short-circuits every mode, including the custom ones.
+  if (sleepScreenMode == kSleepQuickResume) return false;
+  if (fromTimeout && quickResumeAfterTimeout) return false;
+  // 2. The transparent mode has its own art (/sleep-overlay.*), not this file.
+  if (sleepScreenMode == kSleepTransparentCustom) return false;
+  // 3. and 4.
+  if (sleepScreenMode == kSleepCustom) return true;
+  if (sleepScreenMode == kSleepCoverCustom) return !fromReader;
+  // 5. DARK, LIGHT, COVER, BLANK.
+  return false;
+}
+
+Reach reachOfPinnedSleep(const uint8_t sleepScreenMode, const bool quickResumeAfterTimeout) {
+  // Every answer below is asked of drawsPinnedSleep rather than restated, so
+  // the classification cannot disagree with the predicate it describes.
+  const bool onTimeout = drawsPinnedSleep(sleepScreenMode, quickResumeAfterTimeout, true, false);
+  const bool onManual = drawsPinnedSleep(sleepScreenMode, quickResumeAfterTimeout, false, false);
+  if (!onTimeout && !onManual) return Reach::BlockedByMode;
+  if (!onTimeout) return Reach::BlockedByQuickResume;
+  return drawsPinnedSleep(sleepScreenMode, quickResumeAfterTimeout, true, true) ? Reach::Always
+                                                                                : Reach::OutsideReaderOnly;
+}
+
+const char* reachHint(const Reach reach) {
+  switch (reach) {
+    case Reach::Always:
+      return nullptr;
+    case Reach::OutsideReaderOnly:
+      return "Book covers win when sleeping in a book.";
+    case Reach::BlockedByQuickResume:
+      return "Quick Resume hides this on idle sleep.";
+    case Reach::BlockedByMode:
+      return "Settings: sleep screen is not Custom.";
+  }
+  return nullptr;
+}
+
+const char* sleepScreenModeName(const uint8_t sleepScreenMode) {
+  switch (sleepScreenMode) {
+    case kSleepDark:
+      return "Dark";
+    case kSleepLight:
+      return "Light";
+    case kSleepCustom:
+      return "Custom";
+    case kSleepCover:
+      return "Cover";
+    case kSleepCoverCustom:
+      return "Cover + Custom";
+    case kSleepBlank:
+      return "Blank";
+    case kSleepQuickResume:
+      return "Quick Resume";
+    case kSleepTransparentCustom:
+      return "Transparent";
+    default:
+      return "Unknown";
+  }
+}
+
+SleepChoice choiceForSetWallpaper(const uint8_t sleepScreenMode, const bool quickResumeAfterTimeout) {
+  SleepChoice choice;
+  choice.previousMode = sleepScreenMode;
+
+  // A mode that already draws /sleep.bmp on a non-reader sleep is kept, so a
+  // deliberate COVER_CUSTOM is handed a new picture rather than replaced by
+  // one. Asked of the predicate rather than listed, so a mode upstream adds is
+  // classified by the rules and not by this function's memory of them.
+  const bool modeAlreadyShowsIt = drawsPinnedSleep(sleepScreenMode, /*quickResumeAfterTimeout=*/false,
+                                                   /*fromTimeout=*/true, /*fromReader=*/false);
+  choice.sleepScreenMode = modeAlreadyShowsIt ? sleepScreenMode : kSleepCustom;
+  choice.tookOverMode = !modeAlreadyShowsIt && sleepScreenMode != kSleepCustom;
+
+  // The timeout flag always comes off. It is not a preference about sleep
+  // screens, it is a short-circuit ABOVE them: while it is on, the idle sleep
+  // -- the ordinary one -- shows the last screen and no wallpaper of any kind
+  // can appear. Leaving it on to keep wake fast is the trade the app used to
+  // make, and it cost the user the one thing they had just asked for.
+  choice.quickResumeAfterTimeout = false;
+  choice.clearedQuickResume = quickResumeAfterTimeout;
+  return choice;
+}
+
+const char* takeoverNote(const SleepChoice& choice) {
+  if (choice.clearedQuickResume) return "Quick Resume off, so this can show.";
+  if (!choice.tookOverMode) return nullptr;
+  switch (choice.previousMode) {
+    case kSleepDark:
+      return "Sleep screen was Dark. Now this.";
+    case kSleepLight:
+      return "Sleep screen was Light. Now this.";
+    case kSleepCover:
+      return "Sleep screen was Cover. Now this.";
+    case kSleepBlank:
+      return "Sleep screen was Blank. Now this.";
+    case kSleepQuickResume:
+      return "Sleep screen was Quick Resume. Now this.";
+    case kSleepTransparentCustom:
+      return "Sleep screen was Transparent. Now this.";
+    default:
+      return nullptr;
+  }
+}
+
 Room roomFor(bool queryOk, uint64_t freeBytes, uint64_t floorBytes) {
   if (!queryOk) return Room::Unknown;
   return freeBytes >= floorBytes ? Room::Ok : Room::TooFull;

--- a/src/apps_local/wallpapers/WallpapersCore.cpp
+++ b/src/apps_local/wallpapers/WallpapersCore.cpp
@@ -129,15 +129,18 @@ Reach reachOfPinnedSleep(const uint8_t sleepScreenMode, const bool quickResumeAf
 }
 
 const char* reachHint(const Reach reach) {
+  // Every sentence names the setting the way SETTINGS names it ("Sleep Screen",
+  // "Quick Resume on Timeout", english.yaml), because a hint that describes a
+  // setting the user then cannot find is not a hint.
   switch (reach) {
     case Reach::Always:
       return nullptr;
     case Reach::OutsideReaderOnly:
-      return "Book covers win when sleeping in a book.";
+      return "Book covers win when you sleep in a book.";
     case Reach::BlockedByQuickResume:
-      return "Quick Resume hides this on idle sleep.";
+      return "Quick Resume on Timeout hides this.";
     case Reach::BlockedByMode:
-      return "Settings: sleep screen is not Custom.";
+      return "Sleep Screen is not set to Custom.";
   }
   return nullptr;
 }
@@ -189,21 +192,27 @@ SleepChoice choiceForSetWallpaper(const uint8_t sleepScreenMode, const bool quic
 }
 
 const char* takeoverNote(const SleepChoice& choice) {
-  if (choice.clearedQuickResume) return "Quick Resume off, so this can show.";
+  // Both settings can move at once, and a note that reported only one of them
+  // would quietly drop the other ("a warning that can vanish"). So all three
+  // branches exist and every one of them is a sentence.
+  if (choice.tookOverMode && choice.clearedQuickResume) {
+    return "Sleep Screen now Custom, Quick Resume off.";
+  }
+  if (choice.clearedQuickResume) return "Quick Resume on Timeout turned off.";
   if (!choice.tookOverMode) return nullptr;
   switch (choice.previousMode) {
     case kSleepDark:
-      return "Sleep screen was Dark. Now this.";
+      return "Sleep Screen was Dark, now Custom.";
     case kSleepLight:
-      return "Sleep screen was Light. Now this.";
+      return "Sleep Screen was Light, now Custom.";
     case kSleepCover:
-      return "Sleep screen was Cover. Now this.";
+      return "Sleep Screen was Cover, now Custom.";
     case kSleepBlank:
-      return "Sleep screen was Blank. Now this.";
+      return "Sleep Screen was Blank, now Custom.";
     case kSleepQuickResume:
-      return "Sleep screen was Quick Resume. Now this.";
+      return "Sleep Screen was Quick Resume, now Custom.";
     case kSleepTransparentCustom:
-      return "Sleep screen was Transparent. Now this.";
+      return "Sleep Screen was Transparent, now Custom.";
     default:
       return nullptr;
   }

--- a/src/apps_local/wallpapers/WallpapersCore.cpp
+++ b/src/apps_local/wallpapers/WallpapersCore.cpp
@@ -158,7 +158,10 @@ const char* sleepScreenModeName(const uint8_t sleepScreenMode) {
     case kSleepCoverCustom:
       return "Cover + Custom";
     case kSleepBlank:
-      return "Blank";
+      // What Settings calls it: SettingsList.h maps BLANK to STR_NONE_OPT.
+      // Naming it "Blank" would send the user hunting for a value the menu
+      // does not have.
+      return "None";
     case kSleepQuickResume:
       return "Quick Resume";
     case kSleepTransparentCustom:
@@ -194,22 +197,15 @@ SleepChoice choiceForSetWallpaper(const uint8_t sleepScreenMode, const bool quic
   return choice;
 }
 
-const char* takeoverNote(const SleepChoice& choice) {
-  // Both settings can move at once, and a note that reported only one of them
-  // would quietly drop the other ("a warning that can vanish"). So all three
-  // branches exist and every one of them is a sentence.
-  //
-  // Terse on purpose. The strip draws in the CHROME face set (toybox_14 in the
-  // small slot, not the captions' toybox_10), which is ~40% wider per character
-  // and leaves 446px for one line. The longer forms measured 504-519px and the
-  // panel cut them mid-word. host-tests/wallcaption measures every one of these
-  // in that face.
-  if (choice.tookOverMode && choice.clearedQuickResume) {
-    return "Now Custom, Quick Resume off.";
-  }
-  if (choice.clearedQuickResume) return "Quick Resume on Timeout turned off.";
-  if (!choice.tookOverMode) return nullptr;
-  switch (choice.previousMode) {
+namespace {
+// The mode-takeover half of the sentence. File-local: it is one branch of
+// stripLineAfterSelection, not an API.
+//
+// Terse on purpose. The strip resolves to toybox_14 (buildGridChrome pins
+// FONT_SLOT_SMALL) and leaves 446px for one line at the X4 Pro's bezel inset;
+// host-tests/wallcaption measures every sentence here against that.
+const char* modeTakeoverNote(const uint8_t previousMode) {
+  switch (previousMode) {
     case kSleepDark:
       return "Was Dark, now Custom.";
     case kSleepLight:
@@ -217,7 +213,7 @@ const char* takeoverNote(const SleepChoice& choice) {
     case kSleepCover:
       return "Was Cover, now Custom.";
     case kSleepBlank:
-      return "Was Blank, now Custom.";
+      return "Was None, now Custom.";
     case kSleepQuickResume:
       return "Was Quick Resume, now Custom.";
     case kSleepTransparentCustom:
@@ -225,6 +221,55 @@ const char* takeoverNote(const SleepChoice& choice) {
     default:
       return nullptr;
   }
+}
+}  // namespace
+
+StripLine stripLineAfterSelection(const SleepChoice& choice, const Reach reach) {
+  StripLine line;
+  const bool caveat = reach != Reach::Always;
+
+  // The four states a tap can leave behind, each with a sentence that names
+  // EVERY fact present. There is no fall-through: a combination with no
+  // sentence would silently drop one of them, which is the defect this shape
+  // exists to make impossible.
+  //
+  // Taking over the mode always ends at CUSTOM, which has no caveat, so
+  // "mode changed" and "caveat" cannot co-occur; the loop in
+  // host-tests/wallpapers is what establishes that rather than this comment.
+  if (choice.tookOverMode) {
+    if (choice.clearedQuickResume) {
+      line.text = "Now Custom, Quick Resume off.";
+      line.saysModeChanged = true;
+      line.saysQuickResumeCleared = true;
+      return line;
+    }
+    line.text = modeTakeoverNote(choice.previousMode);
+    line.saysModeChanged = line.text != nullptr;
+    return line;
+  }
+
+  if (choice.clearedQuickResume) {
+    if (caveat) {
+      // The case the first version lost: the mode was kept because it already
+      // draws the wallpaper (COVER_CUSTOM), the quick-resume flag came off, and
+      // the caveat that a book cover still wins inside a book STILL APPLIES.
+      // Both go in the line.
+      line.text = "Quick Resume off. Book covers win.";
+      line.saysQuickResumeCleared = true;
+      line.saysCaveat = true;
+      return line;
+    }
+    line.text = "Quick Resume on Timeout turned off.";
+    line.saysQuickResumeCleared = true;
+    return line;
+  }
+
+  if (caveat) {
+    line.text = reachHint(reach);
+    line.saysCaveat = line.text != nullptr;
+    return line;
+  }
+  return line;
 }
 
 Room roomFor(bool queryOk, uint64_t freeBytes, uint64_t floorBytes) {

--- a/src/apps_local/wallpapers/WallpapersCore.cpp
+++ b/src/apps_local/wallpapers/WallpapersCore.cpp
@@ -178,7 +178,10 @@ SleepChoice choiceForSetWallpaper(const uint8_t sleepScreenMode, const bool quic
   // classified by the rules and not by this function's memory of them.
   const bool modeAlreadyShowsIt = drawsPinnedSleep(sleepScreenMode, /*quickResumeAfterTimeout=*/false,
                                                    /*fromTimeout=*/true, /*fromReader=*/false);
-  choice.sleepScreenMode = modeAlreadyShowsIt ? sleepScreenMode : kSleepCustom;
+  // The cast is load-bearing under g++ -Wextra: `cond ? uint8_t : SleepScreenMode`
+  // is "enumerated and non-enumerated type in conditional expression", which is
+  // an error in CI and silent under clang (see the ci-gcc-clang-gap memory).
+  choice.sleepScreenMode = modeAlreadyShowsIt ? sleepScreenMode : static_cast<uint8_t>(kSleepCustom);
   choice.tookOverMode = !modeAlreadyShowsIt && sleepScreenMode != kSleepCustom;
 
   // The timeout flag always comes off. It is not a preference about sleep

--- a/src/apps_local/wallpapers/WallpapersCore.h
+++ b/src/apps_local/wallpapers/WallpapersCore.h
@@ -136,10 +136,10 @@ enum class Reach : uint8_t {
 };
 Reach reachOfPinnedSleep(uint8_t sleepScreenMode, bool quickResumeAfterTimeout);
 
-// The sentence for the picker's hint strip, or nullptr when there is nothing to
-// say. Short on purpose: the strip is one fixed 30px line and a cut sentence is
-// the defect it exists to avoid (host-tests/wallcaption measures these in the
-// real face).
+// The sentence for the picker's hint strip when NOTHING was selected this
+// session, or nullptr when there is nothing to say. Short on purpose: the strip
+// is one fixed 30px line and a cut sentence is the defect it exists to avoid
+// (host-tests/wallcaption measures these in the face the strip resolves).
 const char* reachHint(Reach reach);
 
 // The mode's name in a sentence, for saying what a selection replaced.
@@ -164,11 +164,24 @@ struct SleepChoice {
 };
 SleepChoice choiceForSetWallpaper(uint8_t sleepScreenMode, bool quickResumeAfterTimeout);
 
-// The one-line note the picker shows after a selection changed something the
-// user had chosen elsewhere. nullptr when the selection changed nothing but the
-// picture. Criterion: a settings change the user did not ask for is never
-// silent.
-const char* takeoverNote(const SleepChoice& choice);
+// The strip's line after a selection: what the tap changed, PLUS any standing
+// caveat that still applies. One line has to carry both, and the first version
+// of this could not -- it returned the "what changed" note and suppressed the
+// caveat behind it for the rest of the app session, which is the shape of
+// card #354 reappearing inside its own fix ("a warning that can vanish").
+//
+// So the return value is not just a string: it declares which facts the
+// sentence covers, and host-tests/wallpapers asserts that coverage EQUALS the
+// facts present for every combination. That is a construction, not a text
+// match: a sentence cannot pass by mentioning the right word (see the
+// "a detector that matches the description" note).
+struct StripLine {
+  const char* text = nullptr;
+  bool saysModeChanged = false;
+  bool saysQuickResumeCleared = false;
+  bool saysCaveat = false;
+};
+StripLine stripLineAfterSelection(const SleepChoice& choice, Reach reach);
 
 enum class Room : uint8_t { Ok, TooFull, Unknown };
 Room roomFor(bool queryOk, uint64_t freeBytes, uint64_t floorBytes);

--- a/src/apps_local/wallpapers/WallpapersCore.h
+++ b/src/apps_local/wallpapers/WallpapersCore.h
@@ -78,6 +78,98 @@ bool isBuiltInFile(std::string_view fileName);
 // twenty-one defaults.
 bool sortsBefore(std::string_view a, std::string_view b);
 
+// ---------------------------------------------------------------------------
+// Does the pinned wallpaper actually reach the glass?
+//
+// Card #354: the picker marked a wallpaper with full confidence and the device
+// then slept showing something else, with nothing on any screen saying why.
+// Setting a wallpaper writes /sleep.bmp, but TWO settings decide whether
+// SleepActivity ever draws that file, and neither of them lives in this app.
+// The rules are mirrored here, freestanding, so a laptop can prove them and so
+// the picker can say a true sentence instead of drawing a confident marker.
+//
+// The mirror is exact. SleepActivity::onEnter (src/activities/boot_sleep/,
+// UPSTREAM -- not ours to change) decides in this order:
+//
+//   1. quick resume wins outright, either because the mode IS Quick Resume or
+//      because this is a timeout sleep and the timeout flag is on;
+//   2. TRANSPARENT_CUSTOM draws /sleep-overlay.*, never /sleep.bmp;
+//   3. CUSTOM draws /sleep.bmp;
+//   4. COVER_CUSTOM draws /sleep.bmp only when the sleep did not come from the
+//      reader (inside a book the cover wins);
+//   5. DARK, LIGHT, COVER and BLANK never look at it.
+//
+// The eight modes, mirrored from CrossPointSettings::SLEEP_SCREEN_MODE. That
+// header pulls in ArduinoJson and the whole persistence layer, so it cannot be
+// included on a host; WallpapersActivity.cpp static_asserts every value below
+// against the real enum, which is what stops the two from drifting.
+enum SleepScreenMode : uint8_t {
+  kSleepDark = 0,
+  kSleepLight = 1,
+  kSleepCustom = 2,
+  kSleepCover = 3,
+  kSleepCoverCustom = 4,
+  kSleepBlank = 5,
+  kSleepQuickResume = 6,
+  kSleepTransparentCustom = 7,
+  kSleepModeCount = 8,
+};
+
+// True when SleepActivity would draw /sleep.bmp for this combination.
+// `fromTimeout` is the idle auto-sleep (main.cpp's enterDeepSleep(true)) -- the
+// ordinary way this device sleeps; the power-button hold and the Paper Mono
+// short press both pass false. `fromReader` is APP_STATE.lastSleepFromReader.
+//
+// COVER_CUSTOM with fromReader returns false, which is the CONSERVATIVE answer
+// rather than the complete one: upstream falls back to the wallpaper when the
+// book has no usable cover, and this app must not promise a picture on a path
+// whose outcome depends on a cover it cannot inspect.
+bool drawsPinnedSleep(uint8_t sleepScreenMode, bool quickResumeAfterTimeout, bool fromTimeout, bool fromReader);
+
+// What the picker has to tell the user, derived from the predicate above rather
+// than restated -- a second copy of the rules is a second place to be wrong.
+enum class Reach : uint8_t {
+  Always,                // every sleep shows it
+  OutsideReaderOnly,     // COVER_CUSTOM: the book cover wins when you sleep in a book
+  BlockedByQuickResume,  // the mode is right, but quick resume beats it on idle sleep
+  BlockedByMode,         // the sleep screen is set to something that never reads /sleep.bmp
+};
+Reach reachOfPinnedSleep(uint8_t sleepScreenMode, bool quickResumeAfterTimeout);
+
+// The sentence for the picker's hint strip, or nullptr when there is nothing to
+// say. Short on purpose: the strip is one fixed 30px line and a cut sentence is
+// the defect it exists to avoid (host-tests/wallcaption measures these in the
+// real face).
+const char* reachHint(Reach reach);
+
+// The mode's name in a sentence, for saying what a selection replaced.
+const char* sleepScreenModeName(uint8_t sleepScreenMode);
+
+// What tapping a wallpaper must leave the two settings at.
+//
+// The rule the app had before #354 kept the timeout quick-resume flag ON so
+// wake would stay fast, and traded away the timeout sleep to get it -- which is
+// every ordinary sleep, so the wallpaper the user had just chosen was the one
+// thing it could never show. A picker whose whole purpose is "put this picture
+// on the sleep screen" does not get to lose that argument to a wake time.
+//
+// A mode that ALREADY draws /sleep.bmp is left alone, so a deliberate
+// COVER_CUSTOM survives being handed a new wallpaper.
+struct SleepChoice {
+  uint8_t sleepScreenMode = kSleepCustom;
+  bool quickResumeAfterTimeout = false;
+  bool tookOverMode = false;        // a deliberate mode choice was replaced
+  bool clearedQuickResume = false;  // quick wake on idle sleep was turned off
+  uint8_t previousMode = kSleepCustom;
+};
+SleepChoice choiceForSetWallpaper(uint8_t sleepScreenMode, bool quickResumeAfterTimeout);
+
+// The one-line note the picker shows after a selection changed something the
+// user had chosen elsewhere. nullptr when the selection changed nothing but the
+// picture. Criterion: a settings change the user did not ask for is never
+// silent.
+const char* takeoverNote(const SleepChoice& choice);
+
 enum class Room : uint8_t { Ok, TooFull, Unknown };
 Room roomFor(bool queryOk, uint64_t freeBytes, uint64_t floorBytes);
 

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -231,6 +231,8 @@ int cellAt(const GridGeom& g, int x, int y) {
   return -1;
 }
 
+int16_t hintTextWidth(const fui::Rect& safe) { return static_cast<int16_t>(safe.width - toybox::kMargin * 2); }
+
 void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model) {
   chrome(screen, model.title, model.rightLabel);
 
@@ -241,7 +243,14 @@ void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model) {
   const fui::Rect safe = screen.frame().safeRect();
   const int16_t hintY = static_cast<int16_t>(safe.y + kBodyTop);
   const char* line = nullptr;
-  if (model.warning != nullptr && model.warning[0] != '\0') {
+  // The sleep-screen note wins the strip, ahead of the free-space advisory.
+  // Who pays decides it: a card that is filling up already refuses loudly on
+  // the write that fails, and reports itself again the moment the note clears,
+  // while a wallpaper that cannot reach the glass has NO other voice -- the
+  // marker beside it says the opposite, which is card #354 exactly.
+  if (model.note != nullptr && model.note[0] != '\0') {
+    line = model.note;
+  } else if (model.warning != nullptr && model.warning[0] != '\0') {
     line = model.warning;
   } else if (!model.hasActive) {
     // Short enough to fit the hint strip at the grid's cut. The longer form
@@ -249,8 +258,8 @@ void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model) {
     line = "Tap one to set your sleep screen.";
   }
   if (line != nullptr) {
-    const fui::Rect rect = fui::makeRect(static_cast<int16_t>(safe.x + toybox::kMargin), hintY,
-                                         static_cast<int16_t>(safe.width - toybox::kMargin * 2), kHintH);
+    const fui::Rect rect =
+        fui::makeRect(static_cast<int16_t>(safe.x + toybox::kMargin), hintY, hintTextWidth(safe), kHintH);
     fui::TextStyle style = onPaper(screen.theme().smallText, fui::TextAlign::Left);
     std::string fitted = toybox::fittedTitle(screen.target(), line, rect.width, style);
     screen.target().text(rect, fitted.c_str(), style);

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -233,21 +233,26 @@ int cellAt(const GridGeom& g, int x, int y) {
 
 int16_t hintTextWidth(const fui::Rect& safe) { return static_cast<int16_t>(safe.width - toybox::kMargin * 2); }
 
+int16_t hintStripHeight() { return kHintH; }
+
 void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model) {
   chrome(screen, model.title, model.rightLabel);
 
-  // The hint strip, at a fixed place so the grid below it never moves. The
-  // free-space advisory wins the strip when present; otherwise, if nothing is
-  // set yet, it says so -- a grid with no thick border and no words reads as a
-  // selection that failed to draw.
+  // The hint strip, at a fixed place so the grid below it never moves. One
+  // line, and three things want it; the order is settled just below.
   const fui::Rect safe = screen.frame().safeRect();
   const int16_t hintY = static_cast<int16_t>(safe.y + kBodyTop);
   const char* line = nullptr;
-  // The sleep-screen note wins the strip, ahead of the free-space advisory.
-  // Who pays decides it: a card that is filling up already refuses loudly on
-  // the write that fails, and reports itself again the moment the note clears,
-  // while a wallpaper that cannot reach the glass has NO other voice -- the
-  // marker beside it says the opposite, which is card #354 exactly.
+  // The sleep-screen note wins, ahead of the free-space advisory. The honest
+  // statement of that trade: on a filling card with a sleep-screen note to
+  // show, the space advisory does not appear on THIS screen for the rest of the
+  // session, because warning_ is computed once per onEnter and never refreshed.
+  //
+  // It wins anyway because the advisory has other voices and the note has none.
+  // A pin that actually fails now raises the Notice screen, and buildOffer and
+  // buildEmpty draw the same warning in their own full body width. A wallpaper
+  // that cannot reach the glass is contradicted by the marker drawn beside it
+  // and by nothing else, which is card #354 exactly.
   if (model.note != nullptr && model.note[0] != '\0') {
     line = model.note;
   } else if (model.warning != nullptr && model.warning[0] != '\0') {
@@ -261,6 +266,16 @@ void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model) {
     const fui::Rect rect =
         fui::makeRect(static_cast<int16_t>(safe.x + toybox::kMargin), hintY, hintTextWidth(safe), kHintH);
     fui::TextStyle style = onPaper(screen.theme().smallText, fui::TextAlign::Left);
+    // The SMALL slot, explicitly -- the same override drawGrid() makes for the
+    // captions, for the same reason. themeTokens().smallText.font is kUiFont =
+    // FONT_SLOT_BODY (ToyboxTokens.h says so out loud), and in this screen's
+    // face set that is toybox_20, whose advanceY is 42 in a strip that is
+    // kHintH = 30 tall. Worse, fittedTitle steps DOWN from the style's font, so
+    // WHICH cut a sentence landed in depended on its length: short lines
+    // overflowed the strip at 20px and long ones quietly dropped to 14px.
+    // toybox_14's advanceY is 29, so pinning the slot makes every sentence fit
+    // and makes the measurement in host-tests/wallcaption mean something.
+    style.font = fui::FONT_SLOT_SMALL;
     std::string fitted = toybox::fittedTitle(screen.target(), line, rect.width, style);
     screen.target().text(rect, fitted.c_str(), style);
   }

--- a/src/apps_local/wallpapers/WallpapersScreens.h
+++ b/src/apps_local/wallpapers/WallpapersScreens.h
@@ -149,21 +149,27 @@ struct GridChromeModel {
   const char* rightLabel = nullptr;
   const char* warning = nullptr;  // free-space advisory, null when there is room
   bool hasActive = false;         // false -> draw the "tap one to set it" hint
-  // The sleep-screen note (#354): either the selected wallpaper cannot reach the
-  // glass under the current settings, or the last selection changed a setting
-  // the user had chosen in Settings. Wins the strip -- see buildGridChrome.
+  // The sleep-screen line (#354). Carries every fact that applies at once: what
+  // the last selection changed behind the user's back, AND any standing caveat
+  // about the wallpaper not reaching the glass. Built by
+  // wallpapers::stripLineAfterSelection / reachHint, which are what guarantee
+  // one cannot hide the other. Wins the strip -- see buildGridChrome.
   const char* note = nullptr;
 };
 
 void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model);
 
-// How wide the hint strip's sentence may be inside a given safe rect. Exposed
-// so the strip's fixed sentences can be MEASURED in the real face
-// (host-tests/wallcaption) rather than assumed to fit: the strip is one fixed
-// line at FONT_SLOT_SMALL, which is the smallest rung fittedTitle has, so its
-// only remaining move is to cut the sentence -- and a cut sentence is the
-// defect the strip exists to avoid.
+// The hint strip's box: how wide a sentence may be inside a given safe rect,
+// and how tall the strip is. Both exposed so host-tests/wallcaption can measure
+// the sentences in the face the strip really resolves rather than assume they
+// fit. Assuming is how the first version of this shipped four sentences the
+// panel cut, plus a rung whose line box was TALLER than the strip.
+//
+// buildGridChrome pins the style to FONT_SLOT_SMALL, so a sentence too wide has
+// nothing left to step down to and is cut with an ellipsis. A cut sentence is
+// the defect the strip exists to avoid.
 int16_t hintTextWidth(const freeink::ui::Rect& safe);
+int16_t hintStripHeight();
 
 // The empty state: no wallpapers on the card at all. Names the gap and how to
 // fill it, so a fresh device does not look broken.

--- a/src/apps_local/wallpapers/WallpapersScreens.h
+++ b/src/apps_local/wallpapers/WallpapersScreens.h
@@ -136,9 +136,21 @@ struct GridChromeModel {
   const char* rightLabel = nullptr;
   const char* warning = nullptr;  // free-space advisory, null when there is room
   bool hasActive = false;         // false -> draw the "tap one to set it" hint
+  // The sleep-screen note (#354): either the selected wallpaper cannot reach the
+  // glass under the current settings, or the last selection changed a setting
+  // the user had chosen in Settings. Wins the strip -- see buildGridChrome.
+  const char* note = nullptr;
 };
 
 void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model);
+
+// How wide the hint strip's sentence may be inside a given safe rect. Exposed
+// so the strip's fixed sentences can be MEASURED in the real face
+// (host-tests/wallcaption) rather than assumed to fit: the strip is one fixed
+// line at FONT_SLOT_SMALL, which is the smallest rung fittedTitle has, so its
+// only remaining move is to cut the sentence -- and a cut sentence is the
+// defect the strip exists to avoid.
+int16_t hintTextWidth(const freeink::ui::Rect& safe);
 
 // The empty state: no wallpapers on the card at all. Names the gap and how to
 // fill it, so a fresh device does not look broken.


### PR DESCRIPTION
Card #354. Mario opens Wallpapers, taps a wallpaper, the picker marks it with
full confidence. The device then sleeps on its own and the glass shows
something else. Nothing anywhere says why.

## The cause, verified against the code rather than taken from the card

Two settings decide whether `/sleep.bmp` is ever drawn, and this app was
leaving them in the one combination that guaranteed it would not.

`SleepActivity::onEnter` (`src/activities/boot_sleep/`, **UPSTREAM** by
`git cat-file -e crosspoint/develop:<path>`, not touched here) short-circuits
above the sleep-screen switch:

```
sleepScreen == QUICK_RESUME ||
(fromTimeout && quickResumeSleepScreen == QUICK_RESUME_AFTER_TIMEOUT)
   -> renderLastScreenSleepScreen()
```

`fromTimeout` is true on exactly one path: the idle auto-sleep,
`enterDeepSleep(true)` at `src/main.cpp:857`. The power-button hold and the
Paper Mono short press both pass `false`. So while that flag is on, the
ordinary sleep can never show a wallpaper of any kind, and the only sleep that
can is the one the user performs by hand.

## Where the card's diagnosis was right, and where it was not

Right, and confirmed line by line:

- the short-circuit, and that it fires regardless of `sleepScreen` including
  `CUSTOM` (`SleepActivity.cpp:500-507`);
- `fromTimeout` true only on the idle path (`main.cpp:857` vs `:876`);
- the Settings path that leaves the flag stuck on
  (`SettingsActivity.cpp:145-146` re-derives `preserveQuickResumeTimeoutOn`,
  which makes the auto-clear at `:441-443` unreachable);
- `loadActive()` reads three things and never reads `quickResumeSleepScreen`;
- a wallpaper reaches the glass in 2 of the 8 `SLEEP_SCREEN_MODE` values.
  `TRANSPARENT_CUSTOM` draws `/sleep-overlay.bmp|.png`, never `/sleep.bmp`, so
  the two are `CUSTOM` and `COVER_CUSTOM` (and `COVER_CUSTOM` only outside the
  reader).

**Wrong, and worth saying plainly:**

1. **The line numbers are stale.** `setWallpaper` is at `:215`, not `:225`, and
   `loadActive` at `:166`, not `:104`. Commit `4dd43742` moved both.

2. **It was not an omission. It was a decision.** The card says `setWallpaper`
   sets `CUSTOM` "WITHOUT calling `syncQuickResumeTimeoutForSleepScreen`". True,
   but the code did something more direct: it *set* the flag on.

   ```cpp
   if (SETTINGS.sleepScreen == CrossPointSettings::QUICK_RESUME) {
     SETTINGS.quickResumeSleepScreen = CrossPointSettings::QUICK_RESUME_AFTER_TIMEOUT;
     LOG_INF("WALL", "was QUICK_RESUME; keeping quick wake on timeout sleeps ...");
   }
   ```

   with a comment ending "The trade is that the wallpaper then shows on manual
   sleeps rather than on timeout ones." That reads as a trade and is actually
   the whole feature: a user on Quick Resume who taps a wallpaper is guaranteed
   never to see it. This is a shorter path to the bug than the card's
   three-step Settings dance, and needs no visit to Settings at all.

3. **The card's suggested shape is not implementable as written.**
   `SettingsActivity::syncQuickResumeTimeoutForSleepScreen` is a **private**
   member (`SettingsActivity.h:203`) whose behaviour depends on two instance
   fields (`preserveQuickResumeTimeoutOn`, `quickResumeTimeoutAutoEnabled`)
   that only exist while the Settings screen is open. `WallpapersActivity`
   cannot call it, and calling it with fresh state would do nothing useful. The
   rule is reimplemented in `WallpapersCore` instead, where it is freestanding
   and a host test can walk every case.

## What changed

- **`WallpapersCore`** gains the reachability rules, mirrored from
  `SleepActivity::onEnter` and freestanding, so a laptop proves them.
  `WallpapersActivity` `static_assert`s the eight mode values (and the count)
  against the real enum, so a mode added upstream fails the build rather than
  teaching the picker to say something false.
- **`choiceForSetWallpaper`** decides both settings together. The timeout flag
  always comes off. A mode that already draws the pinned file is **kept**, so a
  deliberate `COVER_CUSTOM` is handed a new picture rather than replaced.
- **Nothing is overwritten in silence.** Any settings change a tap caused is
  reported on the hint strip ("Sleep Screen was Quick Resume, now Custom.",
  "Quick Resume on Timeout turned off.", "Sleep Screen now Custom, Quick Resume
  off.") and logged. Three branches, because both settings can move on one tap
  and a two-branch note would drop one of them.
- **The hint strip says when the wallpaper cannot reach the glass**, computed
  from live SETTINGS at paint time rather than remembered from the selection --
  so leaving for Settings, turning Quick Resume back on and returning updates
  it. Sentences name settings the way `english.yaml` names them.
- **`loadActive` drops its `mode == CUSTOM` gate.** That gate was wrong in both
  directions: it hid the marker under `COVER_CUSTOM`, where the wallpaper does
  show, and drew it confidently under `CUSTOM` + quick resume, where it never
  does.
- **The tap guard** "already the sleep screen" now only skips when it can *be*
  the sleep screen. Re-tapping a blocked wallpaper is what a person does after
  nothing happened, and it repairs the settings instead of being swallowed.
  (This is the failure the `loadActive` change would otherwise have introduced.)
- **Strip priority**: the sleep note goes ahead of the free-space advisory. A
  filling card refuses loudly on the write that fails; a wallpaper that cannot
  reach the glass has no other voice, and the marker beside it says the
  opposite.

## Tests, watched failing first

`host-tests/wallpapers` walks all 8 modes x both flag values and asserts that
after a selection the wallpaper shows on a **`fromTimeout`** sleep. Written
against the shipped rule first and run: **23 failures, 9 of them that exact
assertion.** With the fix: 479 checks, 0 failed. It also asserts every blocked
state produces a sentence, that a change to a Settings choice always produces a
note, and that the three notes are distinct strings.

`host-tests/wallcaption` now measures every sentence that can land in the 30px
strip, in the face the strip actually draws in, at the bezel-inset width
(446px). That found a **pre-existing** defect unrelated to this card: the
free-space advisory overflowed the strip and was cut mid-phrase. Shortened.

### The test was wrong first, twice, and neither time did a test catch it

Worth reading if you touch this strip. `onPaper()` sets align and colour and
never touches `.font`, and `themeTokens().smallText.font` is `kUiFont` =
**`FONT_SLOT_BODY`** -- so the strip was never asking for the small slot at all.
In this screen's face set (`toybox::proseMenuFaces()`) BODY is `toybox_20`,
whose `advanceY` is 42, inside a strip that is `kHintH = 30` tall. And because
`fittedTitle` only steps DOWN, **which cut a sentence landed in was decided by
its length**: long ones fell to `toybox_14` and looked right, short ones
overflowed the strip vertically. Nothing in the code or the tests could see it.

`buildGridChrome` now pins `style.font = fui::FONT_SLOT_SMALL`, which is the
same override `drawGrid()` already makes for the captions and for the same
reason. `toybox_14`'s `advanceY` is 29, so every sentence fits. `wallcaption`
asserts both directions -- the pinned face fits the strip, and BODY does not --
so deleting the pin has something to argue with.

The first version of the measurement had bound the small slot to `toybox_10`,
which is what `drawGrid()` binds for the **captions**, not what the chrome
binds. It reported sentences fitting with 77px to spare while the panel drew
"Sleep Screen now Custom, Quick...". Four were over. **A simulator screenshot
caught that one and a cold review caught the other; no test found either.**

## A cold review found three HIGH problems, all in criteria 2 and 3

A fresh-context critic was given the card, the diff and the acceptance criteria.
It confirmed the core: the `onEnter` mirror is faithful, `SleepActivity.cpp` is
untouched, and the idle-timeout assertion is real (reverting the rule produces
18 failures across 9 of 16 combinations). Then:

**1. The fix reproduced card #354's own shape.** `currentSleepNote()` returned
the "what your tap changed" note first and reached the standing caveat only when
there was none, and the note lived until `onEnter`. So: Settings on Cover +
Custom with Quick Resume on Timeout, open Wallpapers, tap a wallpaper. The mode
is kept, the flag is cleared, the note says so -- and **"Book covers win inside
a book." was suppressed for the rest of the app session.** A confident screen
and a silent caveat, inside the fix for a confident screen and a silent caveat.

Fixed by making the line a function of both: `stripLineAfterSelection(choice,
reach)` returns *which facts its sentence covers*, and the test asserts coverage
**equals** the facts present over every mode x flag combination. That is a
construction, not a text match -- a sentence cannot pass by mentioning the right
word. Watched it fail: disabling the combined branch gives "the line drops a
standing caveat (mode 4, qr 1)", exactly the case the critic found. The activity
now holds the `SleepChoice` rather than a rendered string, which also takes the
`std::string` off the render path.

**2. The font finding above.**

**3. A failed pin was completely silent.** `if (setWallpaper(idx))
requestUpdate();` with no else: no notice, no repaint, nothing on the panel,
while the reasons went only to the log. It now raises the Notice screen and
re-arms the free-space walk, which `loop()` runs after the notice is on the
glass rather than on the input path. The strip's precedence comment had also
justified itself with two false claims (that the card "refuses loudly on the
write that fails", and "reports itself again the moment the note clears" --
`warning_` is computed once per `onEnter`). The first is true now; the comment
states the remaining trade plainly instead of explaining it away.

Two MEDIUMs taken: the test no longer builds a `std::string` from a pointer
documented to return `nullptr` (it would have crashed instead of printing a
FAIL), and the note says **None** rather than "Blank", because that is what
`SettingsList.h` shows for that value.

## Verified on the simulator, by looking

Seeded `fs_agent` into each state and drove the picker headless (`sim-shot.sh`;
screenshots in `qa-artifacts/`, untracked). Every one of these was opened and
read, not just captured:

- **The blocked hint.** Sleep Screen = Quick Resume with a wallpaper pinned and
  marked: "Sleep Screen is not set to Custom." above a grid whose marker is on
  the pinned tile.
- **The takeover note.** Tapping another wallpaper from that state: "Now Custom,
  Quick Resume off.", marker moved.
- **The case the critic found.** Cover + Custom with Quick Resume on Timeout,
  then a tap: "Quick Resume off. Book covers win." -- both facts, one line, the
  caveat intact.
- **The failure notice.** A deliberately truncated wallpaper: "COULD NOT SET IT
  / The wallpaper was not saved and your sleep screen is unchanged..." with an
  OK button. That path drew nothing at all before.
- **The settings the firmware actually wrote**, read back off the simulator's
  card: `"sleepScreen":2, "quickResumeSleepScreen":0` -- the combination in
  which an idle-timeout sleep draws the wallpaper. The firmware logged it too:

      [WALL] sleep settings changed by a selection: mode Quick Resume -> Custom,
             quick resume on timeout 1 -> 0

  Before this change that line read "keeping quick wake on timeout sleeps" and
  the flag went the other way.

## Not fixed, on purpose

`src/activities/util/BmpViewerActivity.cpp:227` ("set as sleep screen" from the
image viewer) sets `sleepScreen = CUSTOM` with the same blind spot -- it never
touches `quickResumeSleepScreen`, so an image set there is invisible on the
idle sleep in exactly the same way. `git cat-file -e crosspoint/develop:<path>`
says **UPSTREAM**, so by the worker contract it is dismissed, not filed.

## What I did NOT verify

- **Hardware. Nothing here has been on a device.** No X4 Pro was flashed and no
  real idle-timeout sleep was observed. The simulator has no deep sleep and does
  not compile `lib/hal`, so what it proves is the picker's settings write, the
  persisted result and the two hint sentences on a rendered panel -- not that
  the device wakes to the wallpaper. That last step is a host test against a
  mirror of upstream's decision, not an observation.
- **The `COVER_CUSTOM` + reader fallback.** Upstream falls back to the wallpaper
  when a book has no usable cover; `drawsPinnedSleep` returns the conservative
  `false` there rather than modelling a cover it cannot inspect. So the
  "Book covers win when you sleep in a book." hint is pessimistic by design.
- **The web Settings page** (`src/network/html/SettingsPage.html`) has its own
  copy of the sync logic in JavaScript. It was read, and it is not changed here;
  a wallpaper selected on the device while that page is open is untested.
- **The strip under a real bezel.** The simulator's safe rect is the full 480px;
  the measurements use the X4 Pro's documented insets (T10 R1 B0 L1) to get
  446px, which is 2px narrower than the panel the screenshots came from. Widest
  sentence is 419px, so there is room, but the number is derived rather than
  observed.
- **PR #135 is merged into this branch** (`95a934ed`) and its change is present
  and confirmed: `surfaceMeaning()` no longer mixes `activeIndex_`, and
  `wallpapersui::gridMeaning` exists. The merge was clean.
- **The browser emulator artifact is stale** relative to this branch, which the
  gate warns about off `xteink`. CI rebuilds and publishes it after the merge.
