### PR TITLE
infra: open the Study bridge, and record what the three doors actually held (card #348)

### DIFF
--- a/docs/bridge-security.md
+++ b/docs/bridge-security.md
@@ -88,8 +88,12 @@ exists rather than being redundant with the per-IP rule.
 
 **Nothing here can be done from this repository.** The tunnel is TOKEN-managed,
 so its routes and the zone's rules live in the dashboard rather than in a file
-on the pi, there is no `cf` CLI in this workspace, and no API token exists for
-one. Every step below is manual, and it is the only part of this card that is.
+on the pi. There IS an API token now, written 2026-09-05 when Rule 1 was
+applied: `~/.cf-waf-token`, mode 600, scoped **Zone WAF: Edit only**. It can
+write rules and cannot list zones or accounts, so hold the zone id
+(`bd1d38d600c956607a4b5f0c2f79c674`) -- nothing can rediscover it with that
+token. Everything below can be done by API or by hand; the dashboard offers the
+same entitlements, never more.
 
 Go to **dash.cloudflare.com > the `ma-r-s.com` zone > Security > WAF > Rate
 limiting rules**, and add:
@@ -114,8 +118,8 @@ limiting rules**, and add:
   is the Free plan, not a preference.** It said 20 requests per 1 minute,
   blocked for 1 hour. Neither is settable: the API refuses any period but 10
   seconds (`not entitled to use the period 60, can only use a period among
-  [10]`) and any mitigation timeout different from the period (`not entitled
-  to use a mitigation timeout different from 10`). The dashboard offers the
+[10]`) and any mitigation timeout different from the period (`not entitled
+to use a mitigation timeout different from 10`). The dashboard offers the
   same choices, because it is the same entitlement. Applied 2026-09-05 by API;
   the rule is live in the zone.
 
@@ -185,6 +189,47 @@ are using. It does **not** run the floods -- they would spend a shared rate
 limiter and lock real accounts out -- so it cannot confirm the rule fires. To
 confirm that, watch **Security > Events** in the dashboard while making the
 requests, or accept that this one is unverified from here and say so.
+
+## The gates, and why a shut one is invisible
+
+Three services face the public, and each one is opened by a single environment
+variable on the pi that **fails closed**. They do not share a name:
+
+| Service   | On the pi         | Variable                                        |
+| --------- | ----------------- | ----------------------------------------------- |
+| Read      | `/srv/readbridge` | `READ_ALLOWLIST`                                |
+| Study     | `/srv/ankibridge` | `BRIDGE_ALLOWLIST`                              |
+| Get Books | `/srv/getbooks`   | `GETBOOKS_PUBLIC_USER` + `GETBOOKS_PUBLIC_PASS` |
+
+Get Books belongs on that list even though it has no allowlist: `getbooks/app.py`
+puts HTTP Basic auth in front of everything but `/healthz`, and the second,
+deliberately public account is what every shipped reader uses
+(`src/OpdsServerStore.cpp`). Unset it and the whole world gets 401.
+
+**A shut gate is invisible to every instrument we have.** `docker compose up`
+exits 0, `/healthz` answers 200, the container healthcheck passes, `board pulse`
+even counts Get Books' 401 as ALIVE, and the owner's own account keeps working
+because he is the one on the list. Writing the WRONG variable name into a `.env`
+produces no warning at all whenever the right name is still present with its old
+value, which it always is. GitHub issue #115 is what a shut gate looks like from
+outside: a stranger, and no signal on our side at all.
+
+So the gates are verified the way a stranger experiences them:
+
+```bash
+server/verify_open.sh          # one bogus sign-in per bridge, from outside
+server/verify_open_selftest.sh # proves that classifier can reach every verdict
+```
+
+The distinction it exists to draw: "This bridge is invitation-only for now."
+means our gate refused, and "AnkiWeb / Instapaper did not accept that email and
+password." means our gate passed the attempt through and the upstream refused a
+deliberately bogus key. Those look alike and mean opposite things.
+
+**A closed allowlist also blinds the live attack run below**, for the same
+reason the local suite sets the allowlist to `*`: a bridge that refuses every
+attempt at the door reports a clean run for a service with no rate limiting at
+all. Opening the gates makes that suite meaningful for the first time.
 
 ## The attack suite
 

--- a/docs/bridge-security.md
+++ b/docs/bridge-security.md
@@ -214,6 +214,12 @@ produces no warning at all whenever the right name is still present with its old
 value, which it always is. GitHub issue #115 is what a shut gate looks like from
 outside: a stranger, and no signal on our side at all.
 
+**Current state, 2026-09-06: all three are OPEN.** `READ_ALLOWLIST=*`,
+`BRIDGE_ALLOWLIST=*`, and `GETBOOKS_PUBLIC_USER`/`_PASS` holding the pair
+`src/OpdsServerStore.cpp` ships. Only the Study one was shut when the box came
+back; the other two had been open for days while the runbook said otherwise.
+Do not take this paragraph as the reading either. Run the script.
+
 So the gates are verified the way a stranger experiences them:
 
 ```bash

--- a/server/read-bridge/README.md
+++ b/server/read-bridge/README.md
@@ -43,16 +43,21 @@ here because the reasoning still explains the shape: before approval, opening
 to `*` let strangers reach the sign-in endpoint with credentials Instapaper
 would refuse anyway, which was all risk and no capability.
 
-What has NOT been met is the other precondition, and it is the one that
-matters now. Rate limiting still lives in `bridge/ratelimit.py`, in-process,
-and its own docstring says a distributed attacker defeats it. Behind an
-allowlist that hardly mattered; open to the world it is the whole exposure,
-because sign-in is a credential-stuffing oracle by construction. **Edge rate
-limiting is the gate on opening it now, not the review.**
+The other precondition, edge rate limiting, has also been met (card #292,
+2026-09-05) -- but weaker than this file once asked for, and the difference is
+worth carrying rather than glossing. The Free plan pins the rule to 20
+requests per 10 seconds with a 10 second block, not 20 per minute blocked for
+an hour. More importantly, a per-IP edge rule was never a defence against
+DISTRIBUTED stuffing at any setting. What bounds that is `GLOBAL_LOGIN` (30
+sign-ins per minute service-wide, and there is only one of it), `LOGIN_LOCKOUT`
+per username, and Instapaper defending its own accounts. See
+`docs/bridge-security.md` and `scripts/DEPLOY-RUNBOOK.md` step 6.
 
-One thing to do rather than assume when it opens: watch a NON-OWNER sign-in
-actually succeed. That is the only evidence the approval is live, and it costs
-one attempt.
+Two things to do rather than assume when it opens. Watch a NON-OWNER sign-in
+actually succeed: that is the only evidence the approval is live. And verify
+from outside with `server/verify_open.sh` -- a deploy's exit status, a 200 on
+`/healthz` and `printenv` in the container are all compatible with the gate
+still refusing every stranger.
 
 ## Suites
 

--- a/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
+++ b/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
@@ -231,13 +231,22 @@ which is a drift generator, not a defence.
 
 ### Apply
 
-Edit in place on the pi. Never rsync'd, never pasted into a command where it
-would land in shell history and `ps` output.
+Edit in place on the pi, in an editor, on the box. The `.env` files belong to
+the ssh user (`deploy.sh` writes `/srv/<service>/` without sudo), so no sudo is
+needed. **REPLACE the existing line rather than appending a second one:** a
+`.env` with a key twice is legal and compose takes the last occurrence, which
+is a fine way to leave a file nobody can read confidently.
 
-    ssh orange   # then, on the box:
-    sudo -e /srv/readbridge/.env    # READ_ALLOWLIST=*
-    sudo -e /srv/ankibridge/.env    # BRIDGE_ALLOWLIST=*
-    sudo -e /srv/getbooks/.env      # GETBOOKS_PUBLIC_USER / GETBOOKS_PUBLIC_PASS
+    ssh orange     # then, on the box, one editor session per file:
+    #  /srv/readbridge/.env   READ_ALLOWLIST=*            (was: owner address)
+    #  /srv/ankibridge/.env   BRIDGE_ALLOWLIST=*          (was: owner address)
+    #  /srv/getbooks/.env     GETBOOKS_PUBLIC_USER=crossplay
+    #                         GETBOOKS_PUBLIC_PASS=<the pair in OpdsServerStore.cpp>
+
+**Do not `export READ_ALLOWLIST=*` in a shell.** In a `.env` file the `*` is a
+literal; in a shell it is a glob and expands to whatever files are in the
+directory, which would write a nonsense allowlist that fails closed and looks
+exactly like every other way of getting this wrong.
 
 Then recreate. **`docker compose restart` is the wrong command and it fails
 silently:** it restarts the existing container with the environment it was
@@ -294,5 +303,13 @@ name: no `~/.ssh/config` entry, and `known_hosts` holding 192.168.68.x,
 So: a failing `ssh` says nothing about the pi. Check the tunnel before
 concluding anything about the box, and read the failure carefully: a DNS error
 on `read.ma-r-s.com` means the record is gone, a TLS alert means the name is
-too deep for the zone's certificate (step 4), and a 502 means the tunnel is up
-but cannot reach the service container. Those are three different repairs.
+too deep for the zone's certificate (step 4), a **530 means the tunnel is up
+and the ORIGIN is not** (the box is off, which is where it was on 2026-09-05),
+and a 502 means the tunnel is up but cannot reach the service container. Those
+are four different repairs.
+
+**The name resolves through Tailscale, and there is no `~/.ssh/config` entry**
+-- checked 2026-09-05, because this file records a session losing time to
+exactly that. `orange` is `orange.tail77e8d2.ts.net`, `100.75.152.70`, via
+MagicDNS. So if `ssh orange` ever fails to RESOLVE rather than to connect, the
+repair is the tailnet on this Mac, not the pi and not `known_hosts`.

--- a/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
+++ b/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
@@ -43,7 +43,7 @@ The edge rule's real job is smaller and worth keeping: flood volume stops at
 Cloudflare instead of costing a one-worker uvicorn on an ARM box a socket and
 a scheduling slot.
 
-## Status: published 2026-09-03 at https://read.ma-r-s.com, allowlist still CLOSED
+## Status: all three services are OPEN to strangers since 2026-09-06
 
 Steps 1-4 are done. `/srv/readbridge` holds the service, both containers are
 up, the firewall is installed and enabled, and the isolation test passes from
@@ -58,16 +58,16 @@ Verified from a laptop, not from a deploy command's exit status:
 code and a pollToken, `GET /api/pair/poll` answers `{"pending":true}`, and
 `POST /api/pair/abandon` cleans the code up.
 
-What remains is step 5 (nobody has signed in and paired a real reader) and
-step 6 (opening the allowlist). **`READ_ALLOWLIST` is untouched and still the
-owner's address only.** Publishing the hostname does not change who may sign
-in, and it must not.
+**Step 6 was applied on 2026-09-06 and verified from outside.** All three
+doors are open; the state each one was actually in is recorded at the end of
+step 6, and two of the three were not what this file predicted. What remains
+is step 5: nobody has signed in and paired a real reader, on either bridge.
 
-Step 6 no longer has a blocker of its own: the Instapaper review landed and
-the Cloudflare rules exist. It is waiting only on the pi being powered on
-(card #347). While the box is off, all three hostnames answer **530**, which
-is Cloudflare saying the tunnel is up and the ORIGIN is not, and no allowlist
-can be applied or verified through it.
+The three hostnames are `read.ma-r-s.com`, `sync.ma-r-s.com` and
+`books.ma-r-s.com`. **The Study bridge is `sync`, and `study.ma-r-s.com` does
+not exist**: it is not in the zone and does not resolve, so a probe aimed at
+it returns nothing at all and reads as an outage rather than as a typo. Name
+the host from this list before concluding a service is down.
 
 The kill switch is one command, and it leaves everything else on the box
 alone:
@@ -286,6 +286,51 @@ third-party Instapaper credential proves a stranger can actually finish
 signing in. Do not report the first as the second.
 
 Replying on GitHub issue #115 is Mario's, not a session's.
+
+### What the three doors ACTUALLY held when the box came back (2026-09-06)
+
+Recorded because two of the three contradicted what this file and card #348
+both predicted, and because the prediction was the reason the step was sized
+as three edits rather than one.
+
+| Service   | Variable                              | Before                                   | After |
+| --------- | ------------------------------------- | ---------------------------------------- | ----- |
+| Read      | `READ_ALLOWLIST`                      | `*` already, set 2026-09-04              | `*`   |
+| Study     | `BRIDGE_ALLOWLIST`                    | the owner's address only. THE ONLY SHUT DOOR | `*` |
+| Get Books | `GETBOOKS_PUBLIC_USER` / `_PASS`      | already `crossplay` / the shipped pair   | unchanged |
+
+So exactly one variable needed writing. Read had been opened two days earlier
+and this file still said it was "untouched and still the owner's address
+only"; Get Books already carried the pair from `src/OpdsServerStore.cpp`
+byte for byte. **A runbook's own status line is a claim about a machine, not
+a reading of it.** Read the three `.env` files and the three RUNNING
+containers before deciding how big this step is.
+
+Verified after the change, from a laptop over the public internet:
+
+    server/verify_open.sh   ->  ALL THREE ARE OPEN TO STRANGERS  (exit 0)
+
+with `server/verify_open_selftest.sh` run in the same session to prove the
+classifier still reaches its SHUT verdicts, because an all-green from a probe
+nobody has watched fail is not evidence.
+
+The container is the thing to check, not only the file. `docker inspect
+<name> --format '{{range .Config.Env}}{{println .}}{{end}}'` and `docker exec
+<name> printenv <VAR>` must AGREE; when they disagree the container predates
+the edit and needs `up -d`. Both said `*` afterwards, and ankibridge's
+`Created` timestamp moved, which is what distinguishes a recreate from the
+`restart` that would have changed nothing.
+
+**Isolation was re-tested after the recreate**, because a new container is a
+new network namespace and the firewall units were installed against the old
+one. Both `scripts/isolation_test.sh` pass with every private probe timing
+out and egress working, and all three `*-firewall.service` units are enabled
+and active after the reboot.
+
+Still NOT verified, and not to be reported as if it were: no stranger has
+completed a sign-in on either bridge. `verify_open.sh` proves our gate lets
+the attempt through, and on read-bridge a non-owner Instapaper 403 is
+indistinguishable from a wrong password.
 
 ## Before any of it: can this machine even reach the pi?
 

--- a/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
+++ b/server/read-bridge/scripts/DEPLOY-RUNBOOK.md
@@ -11,20 +11,37 @@ approved. The consumer key works immediately for the account that registered
 it and for nobody else. So the first deployment proves the whole path on one
 real account, and the service stays closed while it does.
 
-**Do not set `READ_ALLOWLIST=*` yet -- but the reason has changed.** Two
-conditions gated it. The review is one of them and it is DONE: Mario reports
-it was approved, recorded 2026-09-05 on board card #252. Non-owner sign-ins
-can now succeed, so an open allowlist would finally buy capability rather than
-only risk.
+**Both conditions that gated `READ_ALLOWLIST=*` are now met, and this section
+no longer says wait.** The Instapaper review was approved (Mario, 2026-09-05,
+card #252), and the Cloudflare rules exist (card #292, applied 2026-09-05).
+Step 6 is the procedure.
 
-The other condition still stands and is now the whole of it: the only real
-defence against distributed stuffing is Cloudflare-side rate limiting, and it
-does not exist. The in-process limiters in `bridge/ratelimit.py` are defeated
-by an attacker with many addresses, by construction and by their own
-docstring. Behind an allowlist that barely mattered; open to the world it is
-the entire exposure.
+**Say the strength of that second condition honestly rather than repeating
+what this file used to promise.** It asked for 20 requests per minute with a
+one hour block. What exists is **20 requests per 10 seconds with a 10 second
+block**, because `ma-r-s.com` is on the Free plan and neither number is
+settable by API or by dashboard (`docs/bridge-security.md`, Rule 1). One
+address can therefore sustain about 120 auth POSTs a minute, not 20, and is
+free again after ten seconds rather than an hour.
 
-Open it when the Cloudflare rules exist -- and in the same change, not after.
+**And the mismatch this file has always contained, which the numbers make
+worse:** a per-IP edge rule does not defend against DISTRIBUTED credential
+stuffing, which is the threat named two paragraphs above. It never could. An
+attacker with a thousand addresses is invisible to a per-IP rule at any
+setting. What actually bounds that threat is three things, none of them the
+edge rule:
+
+- `GLOBAL_LOGIN` in `bridge/app.py`: 30 sign-ins per minute across the whole
+  service, with only one of it. Many addresses do not defeat a global ceiling.
+- `LOGIN_LOCKOUT`: exponential backoff per username, counting failures rather
+  than attempts, so a spray across accounts is slowed account by account.
+- Instapaper and AnkiWeb defend their own accounts. We are not the only thing
+  between an attacker and a login, and pretending otherwise sizes our layers
+  wrong.
+
+The edge rule's real job is smaller and worth keeping: flood volume stops at
+Cloudflare instead of costing a one-worker uvicorn on an ARM box a socket and
+a scheduling slot.
 
 ## Status: published 2026-09-03 at https://read.ma-r-s.com, allowlist still CLOSED
 
@@ -44,8 +61,13 @@ code and a pollToken, `GET /api/pair/poll` answers `{"pending":true}`, and
 What remains is step 5 (nobody has signed in and paired a real reader) and
 step 6 (opening the allowlist). **`READ_ALLOWLIST` is untouched and still the
 owner's address only.** Publishing the hostname does not change who may sign
-in, and it must not: see step 6 -- whose remaining blocker is the Cloudflare
-rate limiting, no longer the Instapaper review.
+in, and it must not.
+
+Step 6 no longer has a blocker of its own: the Instapaper review landed and
+the Cloudflare rules exist. It is waiting only on the pi being powered on
+(card #347). While the box is off, all three hostnames answer **530**, which
+is Cloudflare saying the tunnel is up and the ORIGIN is not, and no allowlist
+can be applied or verified through it.
 
 The kill switch is one command, and it leaves everything else on the box
 alone:
@@ -158,18 +180,103 @@ four assumptions about Instapaper's API in `docs/apps/instapaper-plan.md`.
 Study's equivalent cost three flags and a `-232` that looked like a curve
 problem and was a missing hash. Expect to spend time here rather than none.
 
-## 6. Later: open it
+## 6. Open it (card #348, from GitHub issue #115)
 
-The app was submitted 2026-08-31 and **approval has landed** (Mario, recorded
-2026-09-05 on board card #252). So the half of this step that was waiting on
-somebody else is done, and what is left is ours: set `READ_ALLOWLIST=*` and add
-the Cloudflare rate-limiting rules IN THE SAME SITTING. Not one without the
-other -- an open allowlist without those rules is the credential-stuffing
-oracle this ordering exists to avoid.
+Both preconditions are met; see the top of this file for what the second one
+actually delivers. This step is **config, not code**. Nothing in `bridge/` is
+edited, nothing is rebuilt, and `deploy.sh` is not the route: a `.env` change
+is a recreate.
 
-Verify the approval rather than trust this line: watch a NON-OWNER sign-in
-succeed. It costs one attempt and it is the only evidence that the keys now
-work for anyone but the registering account.
+### THERE ARE THREE DOORS, NOT ONE, AND THEY HAVE THREE DIFFERENT NAMES
+
+Issue #115 reports the Study one. It is one report of a condition affecting
+all three services, because each fails closed on its own unset variable and a
+shut door is invisible to everybody who already has access:
+
+| Service   | On the pi         | Variable                                        |
+| --------- | ----------------- | ----------------------------------------------- |
+| Read      | `/srv/readbridge` | `READ_ALLOWLIST`                                |
+| Study     | `/srv/ankibridge` | `BRIDGE_ALLOWLIST`                              |
+| Get Books | `/srv/getbooks`   | `GETBOOKS_PUBLIC_USER` + `GETBOOKS_PUBLIC_PASS` |
+
+**`READ_ALLOWLIST` and `BRIDGE_ALLOWLIST` are different names for the same
+idea and this is the whole trap of this step.** Write the wrong one into the
+wrong `.env` and: the file is edited, compose is silent, the container comes
+up, the healthcheck passes, `/healthz` answers 200, and every stranger still
+reads "This bridge is invitation-only for now." Compose only warns when the
+CORRECT name is absent entirely, and it is not absent: both currently hold an
+owner address. So a wrong-name edit produces no warning, no log line, and no
+symptom Mario can see, because his own account keeps working either way.
+
+Get Books is the same shape wearing different clothes. It is **not** open by
+design: `getbooks/app.py` puts HTTP Basic auth in front of everything but
+`/healthz`, with a second, deliberately public account for the firmware. The
+pair CrossPlay ships is in `src/OpdsServerStore.cpp` (`crossplay` /
+`r4ulp-zm4cg-awjtf-z5zfj`, public on purpose: it is in a public repo and in
+every release binary). With `GETBOOKS_PUBLIC_USER`/`PASS` unset, every stock
+reader in the world gets 401 while Mario's own credentials work perfectly.
+`board pulse` counts that 401 as ALIVE, so the board would show it green.
+
+### Why `*` and not an enumerated list
+
+`*`. An enumerated list cannot serve "anyone in the world with the OS
+installed", which is the objective: there is no registration flow and no way
+onto the list except opening a GitHub issue and waiting for Mario, which is
+precisely the failure #115 reports. The list is also not the security control
+and never was -- it is a binary switch. The controls are `LOGIN_IP`,
+`GLOBAL_LOGIN` and `LOGIN_LOCKOUT`, `CLAIM_IP`/`CLAIM_USER`, the edge rule,
+and the upstreams authenticating their own accounts. Keeping a list would add
+a per-user manual edit across two files with two different variable names,
+which is a drift generator, not a defence.
+
+### Apply
+
+Edit in place on the pi. Never rsync'd, never pasted into a command where it
+would land in shell history and `ps` output.
+
+    ssh orange   # then, on the box:
+    sudo -e /srv/readbridge/.env    # READ_ALLOWLIST=*
+    sudo -e /srv/ankibridge/.env    # BRIDGE_ALLOWLIST=*
+    sudo -e /srv/getbooks/.env      # GETBOOKS_PUBLIC_USER / GETBOOKS_PUBLIC_PASS
+
+Then recreate. **`docker compose restart` is the wrong command and it fails
+silently:** it restarts the existing container with the environment it was
+created with, so the edit appears to do nothing. `up -d` re-interpolates
+`.env`, sees a changed service config, and recreates. No `--build`: the image
+has not changed.
+
+    ssh orange 'cd /srv/readbridge && docker compose up -d'
+    ssh orange 'cd /srv/ankibridge && docker compose up -d'
+    ssh orange 'cd /srv/getbooks   && docker compose up -d'
+
+### Verify from OUTSIDE, as a stranger
+
+A deploy's exit status, a 200 on `/healthz`, a passing container healthcheck
+and `printenv` inside the box are ALL compatible with the door still shut.
+The only question worth asking is the one a stranger asks:
+
+    server/verify_open.sh          # the verdict
+    server/verify_open.sh --why    # then diagnostics, if a door is shut
+
+It posts one deliberately bogus sign-in per bridge from outside and reads the
+sentence that comes back, because the two failures look alike and mean
+opposite things:
+
+- "This bridge is invitation-only for now." -- OUR gate refused. Door shut.
+- "AnkiWeb / Instapaper did not accept that email and password." -- our gate
+  passed it through and the upstream refused a bogus key. Door OPEN.
+
+`server/verify_open_selftest.sh` proves that classifier can reach every one of
+its verdicts, including the two above, against a local stub.
+
+**One thing `verify_open.sh` cannot settle, on read-bridge only.** If the
+Instapaper application were still in owner-only mode, a non-owner xAuth
+returns 403 and the bridge prints the same "did not accept" sentence as a
+wrong password. So a green run proves OUR gate is open; only a real
+third-party Instapaper credential proves a stranger can actually finish
+signing in. Do not report the first as the second.
+
+Replying on GitHub issue #115 is Mario's, not a session's.
 
 ## Before any of it: can this machine even reach the pi?
 

--- a/server/study-bridge/README.md
+++ b/server/study-bridge/README.md
@@ -111,6 +111,15 @@ It is never rsync'd in either direction (`deploy.sh` excludes it, and that
 exclude is load-bearing) and never pasted into commands, where it would land
 in shell history and `ps` output. Edit it in place on the pi.
 
+**`BRIDGE_ALLOWLIST` is this service's gate and it fails closed: unset means
+nobody may sign in, `*` opens it.** The twin at `/srv/readbridge` calls the
+same idea `READ_ALLOWLIST`, and writing one name into the other's `.env` is
+completely silent -- no warning, no log line, and the same
+"This bridge is invitation-only for now." a stranger already saw. Verify a
+change from outside with `server/verify_open.sh`, never with `printenv` or a
+200 on `/healthz`. See `server/read-bridge/scripts/DEPLOY-RUNBOOK.md` step 6
+and `docs/bridge-security.md`.
+
 ## The pages people see
 
 `bridge/chrome.py` is the whole look: the band, the three-step rail, the

--- a/server/verify_open.sh
+++ b/server/verify_open.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Can a STRANGER use these services? Asked from outside, over the real
+# internet, exactly the way a stranger asks.
+#
+#   server/verify_open.sh          the verdict
+#   server/verify_open.sh --why    the verdict, then diagnostics from the pi
+#
+# WHY THIS EXISTS AND WHY NOTHING ELSE ANSWERS IT
+#
+# Three services are gated, each by one environment variable on the pi, and
+# every gate FAILS CLOSED. Every instrument we already have is blind to a shut
+# gate:
+#
+#   docker compose up -d          exits 0 with the gate shut
+#   /healthz                      answers 200 with the gate shut
+#   the container's healthcheck   passes with the gate shut
+#   `board pulse`                 counts books' 401 as ALIVE, which is the
+#                                 exact response a stranger's reader gets when
+#                                 the public credential pair is unset
+#   printenv inside the container is necessary and not sufficient: it says what
+#                                 the process holds, never who may sign in
+#
+# So the only question worth asking is the one a stranger asks, and the answer
+# lives in the response BODY rather than the status code. Both bridges answer
+# 200 whether they let you in or refuse you.
+#
+# THE TWO SENTENCES, AND THEY MEAN OPPOSITE THINGS
+#
+#   "This bridge is invitation-only for now."
+#       OUR gate refused. The door is shut. Nobody but the allowlist gets in.
+#
+#   "AnkiWeb did not accept that email and password."
+#   "Instapaper did not accept that email and password."
+#       Our gate let the attempt THROUGH and the upstream refused the
+#       credential. The door is open and this probe's key is wrong, which is
+#       the whole point: the key is deliberately bogus.
+#
+# A careless reader sees two sign-in failures and calls both "still broken".
+# They are opposite verdicts. That confusion is the reason this file is a
+# script and not a paragraph in a runbook.
+#
+# WHAT THIS PROVES AND WHAT IT DOES NOT
+#
+# It proves OUR gate is open. For read-bridge it does NOT prove a stranger can
+# actually sign in: if Instapaper's application were still in owner-only mode,
+# a non-owner xAuth returns 403 and the bridge prints the same "Instapaper did
+# not accept" sentence. Only a real third-party Instapaper credential separates
+# those two. Say so rather than overclaiming.
+#
+# COST: one bogus sign-in per bridge per run. LOGIN_IP is 5 per 5 minutes per
+# address, so about five runs per five minutes before this probe rate-limits
+# itself. The usernames are fresh and end in .invalid (RFC 2606), which can
+# never be a registrable domain, so no real person's account is ever touched
+# and no failure is ever recorded against one.
+set -uo pipefail
+
+WHY=0
+[ "${1:-}" = "--why" ] && WHY=1
+
+# The real services, and overridable ONLY so verify_open_selftest.sh can point
+# the classifier at a local stub and watch every branch fire. Nothing else
+# should ever set these: the entire value of this script is that it asks the
+# public internet.
+BASE_STUDY="${VERIFY_BASE_STUDY:-https://sync.ma-r-s.com}"
+BASE_READ="${VERIFY_BASE_READ:-https://read.ma-r-s.com}"
+BASE_BOOKS="${VERIFY_BASE_BOOKS:-https://books.ma-r-s.com}"
+
+# The pair CrossPlay's firmware seeds as the Get Books default
+# (src/OpdsServerStore.cpp). Public on purpose: it is in a public repository
+# and recoverable with `strings` from every release binary. It is a courtesy
+# gate against crawlers, never a secret, and never Mario's own login.
+BOOKS_USER="crossplay"
+BOOKS_PASS="r4ulp-zm4cg-awjtf-z5zfj"
+
+STAMP="$(date +%s)-$RANDOM"
+fail=0
+inconclusive=0
+
+say() { printf '%s\n' "$*"; }
+rule() { printf '%s\n' "------------------------------------------------------------"; }
+
+# ---------------------------------------------------------------- is it up
+rule
+say "IS THE BOX ANSWERING AT ALL"
+rule
+up=1
+for host in "$BASE_STUDY" "$BASE_READ" "$BASE_BOOKS"; do
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$host/healthz" 2>/dev/null)"
+  printf '  %-28s %s' "${host#https://}" "$code"
+  case "$code" in
+    200) say "  serving" ;;
+    401) say "  serving (auth in front of healthz)" ;;
+    530) say "  CLOUDFLARE 530: the tunnel is up, the ORIGIN is not. The pi is down."; up=0 ;;
+    502) say "  502: tunnel up, service container not reachable behind it."; up=0 ;;
+    000) say "  no answer at all: DNS or network from THIS machine."; up=0 ;;
+    *)   say "  unexpected"; up=0 ;;
+  esac
+done
+if [ "$up" -eq 0 ]; then
+  say
+  say "STOPPING. A gate cannot be verified on a service that is not serving."
+  say "Nothing below would mean anything. This is not a bug in the gate."
+  exit 2
+fi
+
+# ------------------------------------------------------------------ bridges
+# $1 base url  $2 human name  $3 the sentence that means OUR gate let it through
+probe_bridge() {
+  local host="$1" name="$2" through="$3"
+  local user="crossplay-gate-probe-$STAMP@example.invalid"
+  local body
+  say
+  rule
+  say "$name  (${host#https://})"
+  rule
+  say "  posting a bogus sign-in as $user"
+  body="$(curl -sS --max-time 45 -X POST "$host/login" \
+    --data-urlencode "username=$user" \
+    --data-urlencode "password=not-a-real-password-$STAMP" 2>/dev/null)"
+
+  if printf '%s' "$body" | grep -qF "This bridge is invitation-only for now."; then
+    say "  SHUT.  Our own gate refused before the credential went anywhere."
+    say "         A stranger cannot use this service."
+    say "         Fix: the allowlist variable on the pi. Mind WHICH ONE:"
+    say "           /srv/readbridge/.env   -> READ_ALLOWLIST"
+    say "           /srv/ankibridge/.env   -> BRIDGE_ALLOWLIST"
+    say "         They are DIFFERENT NAMES. Setting the other one is silent."
+    fail=1
+    return
+  fi
+  if printf '%s' "$body" | grep -qF "$through"; then
+    say "  OPEN.  Our gate passed the attempt through and the upstream refused"
+    say "         the bogus credential, which is correct. The door is open."
+    return
+  fi
+  if printf '%s' "$body" | grep -qF "Slow down"; then
+    say "  INCONCLUSIVE: rate-limited. Wait five minutes and run this again."
+    say "  This says nothing about the gate either way."
+    inconclusive=1
+    return
+  fi
+  if printf '%s' "$body" | grep -qF "Not configured"; then
+    say "  MISCONFIGURED: the bridge has no upstream application credentials."
+    say "  The gate may be open; the service still cannot sign anyone in."
+    fail=1
+    return
+  fi
+  say "  UNRECOGNISED. The sentence the service actually returned:"
+  printf '%s' "$body" | sed -n 's/.*<p class=lede>\(.*\)<\/p>.*/    "\1"/p' | head -3
+  say "  Read it before deciding. Do not assume."
+  fail=1
+}
+
+probe_bridge "$BASE_STUDY" "STUDY  (ankibridge, AnkiWeb)" \
+  "AnkiWeb did not accept that email and password."
+probe_bridge "$BASE_READ" "READ   (readbridge, Instapaper)" \
+  "Instapaper did not accept that email and password."
+
+# ---------------------------------------------------------------- get books
+# NOT "open by design". It is HTTP Basic auth with a second, deliberately
+# public account for the firmware, and it fails closed the same way the two
+# allowlists do: with GETBOOKS_PUBLIC_USER/PASS unset, every shipped reader in
+# the world gets 401 while Mario's own credentials keep working perfectly, so
+# nothing he does would ever show him the outage.
+say
+rule
+say "GET BOOKS  (${BASE_BOOKS#https://})"
+rule
+anon="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 25 "$BASE_BOOKS/opds" 2>/dev/null)"
+say "  with no credentials at all:            $anon  (401 expected: auth is on)"
+pub="$(curl -sS --max-time 25 -u "$BOOKS_USER:$BOOKS_PASS" \
+  -w '\n%{http_code}' "$BASE_BOOKS/opds" 2>/dev/null)"
+pubcode="$(printf '%s' "$pub" | tail -1)"
+say "  with the pair the FIRMWARE ships:      $pubcode"
+if [ "$pubcode" = "200" ] && printf '%s' "$pub" | grep -q "<feed"; then
+  say "  OPEN.  A stock reader gets a real OPDS feed."
+elif [ "$pubcode" = "401" ]; then
+  say "  SHUT.  The shipped public pair is refused, so EVERY stranger's reader"
+  say "         gets 401 on Get Books. Fix: GETBOOKS_PUBLIC_USER and"
+  say "         GETBOOKS_PUBLIC_PASS in /srv/getbooks/.env, matching"
+  say "         src/OpdsServerStore.cpp, then docker compose up -d."
+  fail=1
+elif [ "$pubcode" = "503" ]; then
+  say "  MISCONFIGURED: GETBOOKS_USER/GETBOOKS_PASS are unset, so the service"
+  say "  refuses everyone including Mario. See its log."
+  fail=1
+else
+  say "  UNRECOGNISED: $pubcode, and the body is not a feed. Read it."
+  fail=1
+fi
+
+# ------------------------------------------------------------- diagnostics
+# Deliberately AFTER the verdict and never part of it. What a container holds
+# is not who may sign in; this only tells you WHICH repair you need when the
+# verdict above is SHUT.
+if [ "$WHY" -eq 1 ]; then
+  say
+  rule
+  say "DIAGNOSTICS (not evidence: this is what the container HOLDS)"
+  rule
+  for pair in "readbridge:READ_ALLOWLIST" "ankibridge:BRIDGE_ALLOWLIST"; do
+    svc="${pair%%:*}"; var="${pair##*:}"
+    say "  $svc $var:"
+    ssh -o BatchMode=yes -o ConnectTimeout=10 orange \
+      "docker exec $svc printenv $var 2>/dev/null || echo '(unset or container down)'" \
+      2>&1 | sed 's/^/    /'
+  done
+  say "  getbooks GETBOOKS_PUBLIC_USER:"
+  ssh -o BatchMode=yes -o ConnectTimeout=10 orange \
+    "docker exec getbooks printenv GETBOOKS_PUBLIC_USER 2>/dev/null || echo '(unset or container down)'" \
+    2>&1 | sed 's/^/    /'
+  say
+  say "  Reading these against the verdict:"
+  say "    verdict SHUT + variable holds *      -> the container was RESTARTED,"
+  say "                                            not recreated. docker compose"
+  say "                                            restart does NOT re-read .env."
+  say "                                            Use: docker compose up -d"
+  say "    verdict SHUT + variable empty/absent -> the WRONG NAME was written"
+  say "                                            into .env. Compose is silent"
+  say "                                            about it whenever the right"
+  say "                                            name is still present with"
+  say "                                            its old owner-only value."
+fi
+
+say
+rule
+if [ "$inconclusive" -eq 1 ] && [ "$fail" -eq 0 ]; then
+  say "INCONCLUSIVE. Something was rate-limited. Run it again in five minutes."
+  exit 2
+fi
+if [ "$fail" -eq 0 ]; then
+  say "ALL THREE ARE OPEN TO STRANGERS."
+  say
+  say "One honest caveat, on read-bridge only: this proves OUR gate is open."
+  say "It does not prove Instapaper's application has left owner-only mode,"
+  say "because a non-owner 403 prints the same sentence as a wrong password."
+  say "Only a real third-party Instapaper account settles that."
+  exit 0
+fi
+say "AT LEAST ONE DOOR IS STILL SHUT. Read the section above that says SHUT."
+exit 1

--- a/server/verify_open_selftest.sh
+++ b/server/verify_open_selftest.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Does verify_open.sh actually work? Watch every verdict it can reach.
+#
+#   server/verify_open_selftest.sh
+#
+# Same precedent as verify_attacks.sh: a check nobody has seen fail is not a
+# check. This one matters more than most, because the thing verify_open.sh
+# distinguishes is TWO SIGN-IN FAILURES THAT LOOK ALIKE. A classifier that
+# silently matched neither sentence, or matched both, would print a confident
+# verdict either way and nobody would know.
+#
+# So this stands up a stub that answers with each canned body in turn and
+# asserts the exit code: 0 open, 1 shut, 2 cannot tell. It needs no network,
+# no pi, and no credentials.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PORT="${VERIFY_SELFTEST_PORT:-9310}"
+PY="$(command -v python3)"
+fail=0
+
+if [ -z "$PY" ]; then
+  echo "SKIP: no python3, so the stub cannot run."
+  exit 0
+fi
+
+stub() {
+  # $1 = scenario name the stub serves
+  SCENARIO="$1" "$PY" - "$PORT" <<'PYEOF' &
+import base64, os, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+SC = os.environ["SCENARIO"]
+SHUT = b"<p class=lede>This bridge is invitation-only for now.</p>"
+ANKI = b"<p class=lede>AnkiWeb did not accept that email and password.</p>"
+INSTA = b"<p class=lede>Instapaper did not accept that email and password.</p>"
+SLOW = b"<h1>Slow down</h1><p class=lede>Too many attempts.</p>"
+WEIRD = b"<p class=lede>Something nobody has written a branch for.</p>"
+FEED = b'<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom"></feed>'
+# The pair the firmware ships; the stub accepts exactly it.
+OK = b"Basic " + base64.b64encode(b"crossplay:r4ulp-zm4cg-awjtf-z5zfj")
+
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def send(self, code, body, hdrs=()):
+        self.send_response(code)
+        self.send_header("Content-Length", str(len(body)))
+        for k, v in hdrs:
+            self.send_header(k, v)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path.startswith("/healthz"):
+            return self.send(200, b"ok")
+        if self.path.startswith("/opds"):
+            auth = self.headers.get("authorization", "").encode()
+            if SC == "books_shut" or auth != OK:
+                return self.send(401, b"unauthorized",
+                                 [("WWW-Authenticate", 'Basic realm="Get Books"')])
+            return self.send(200, FEED)
+        return self.send(404, b"no")
+
+    def do_POST(self):
+        n = int(self.headers.get("content-length") or 0)
+        self.rfile.read(n)
+        if SC == "shut":
+            return self.send(200, SHUT)
+        if SC == "slow":
+            return self.send(200, SLOW)
+        if SC == "weird":
+            return self.send(200, WEIRD)
+        # open, and books_shut: both bridges let the attempt through. Which
+        # upstream sentence comes back does not depend on the port here, so
+        # answer with both -- verify_open.sh greps for one each.
+        return self.send(200, ANKI + INSTA)
+
+
+HTTPServer(("127.0.0.1", int(sys.argv[1])), H).serve_forever()
+PYEOF
+  STUB_PID=$!
+  for _ in $(seq 1 50); do
+    curl -sS -o /dev/null --max-time 1 "http://127.0.0.1:$PORT/healthz" && return 0
+    "$PY" -c 'import time;time.sleep(0.1)'
+  done
+  echo "  the stub never came up on $PORT"
+  return 1
+}
+
+kill_stub() {
+  [ -n "${STUB_PID:-}" ] && kill "$STUB_PID" 2>/dev/null
+  wait "$STUB_PID" 2>/dev/null
+  STUB_PID=""
+}
+trap kill_stub EXIT
+
+run_case() {
+  # $1 scenario  $2 expected exit  $3 what it means
+  local sc="$1" want="$2" meaning="$3" got out
+  printf '%-14s ' "$sc"
+  if ! stub "$sc" > /dev/null 2>&1; then
+    echo "STUB FAILED"
+    fail=1
+    return
+  fi
+  out="$(VERIFY_BASE_STUDY="http://127.0.0.1:$PORT" \
+         VERIFY_BASE_READ="http://127.0.0.1:$PORT" \
+         VERIFY_BASE_BOOKS="http://127.0.0.1:$PORT" \
+         bash "$HERE/verify_open.sh" 2>&1)"
+  got=$?
+  kill_stub
+  if [ "$got" = "$want" ]; then
+    printf 'ok    exit %s  (%s)\n' "$got" "$meaning"
+  else
+    printf 'FAIL  exit %s, wanted %s  (%s)\n' "$got" "$want" "$meaning"
+    printf '%s\n' "$out" | sed 's/^/      /'
+    fail=1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# FIRST: are the sentences still the service's own words?
+#
+# Everything below this point tests the classifier against a stub, and a stub
+# says whatever it was told to say. If somebody rewords a refusal in
+# accounts.py, the stub keeps agreeing with the classifier and both keep
+# agreeing with nothing real. So the literals are checked against the source
+# that produces them.
+#
+# Verified on 2026-09-05 by running both real services in-process and reading
+# what they actually returned, in three configurations each: variable unset
+# (SHUT), variable set to * (OPEN), and the TWIN'S variable name set to *
+# (byte-identical to unset, which is the trap this whole card is about).
+# ---------------------------------------------------------------------------
+echo "the sentences, against the source that produces them"
+check_literal() {
+  # $1 file  $2 literal
+  if grep -qF "$2" "$1"; then
+    printf '  ok    %s\n' "$2"
+  else
+    printf '  GONE  %s\n' "$2"
+    printf '        not in %s any more. verify_open.sh cannot classify it.\n' "$1"
+    fail=1
+  fi
+}
+check_literal "$HERE/read-bridge/bridge/accounts.py"  "This bridge is invitation-only for now."
+check_literal "$HERE/study-bridge/bridge/accounts.py" "This bridge is invitation-only for now."
+check_literal "$HERE/read-bridge/bridge/instapaper.py" "Instapaper did not accept that email and password."
+check_literal "$HERE/study-bridge/bridge/accounts.py" "AnkiWeb did not accept that email and password."
+# And the variable names themselves, because they are the trap.
+check_literal "$HERE/read-bridge/bridge/accounts.py"  'os.environ.get("READ_ALLOWLIST"'
+check_literal "$HERE/study-bridge/bridge/accounts.py" 'os.environ.get("BRIDGE_ALLOWLIST"'
+echo
+
+echo "proving verify_open.sh can reach each verdict"
+echo
+run_case open       0 "all three open to a stranger"
+run_case shut       1 "both bridges refuse before the credential leaves us"
+run_case books_shut 1 "bridges open, Get Books refuses the shipped pair"
+run_case slow       2 "rate-limited, so the gate is unknowable right now"
+run_case weird      1 "a sentence with no branch is a failure, never a pass"
+
+# The one that needs no stub: nothing listening at all must be exit 2, not a
+# confident verdict. This is the state the pi was in on 2026-09-05.
+printf '%-14s ' "box_down"
+out="$(VERIFY_BASE_STUDY="http://127.0.0.1:$PORT" \
+       VERIFY_BASE_READ="http://127.0.0.1:$PORT" \
+       VERIFY_BASE_BOOKS="http://127.0.0.1:$PORT" \
+       bash "$HERE/verify_open.sh" 2>&1)"
+got=$?
+if [ "$got" = 2 ]; then
+  echo "ok    exit 2  (nothing serving: refuses to judge the gate)"
+else
+  echo "FAIL  exit $got, wanted 2  (nothing serving)"
+  printf '%s\n' "$out" | sed 's/^/      /'
+  fail=1
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "every verdict verify_open.sh can print was reached on purpose."
+  exit 0
+fi
+echo "verify_open.sh does NOT classify correctly. Do not trust its verdict."
+exit 1


### PR DESCRIPTION
The orange pi came back. Card #348 said three doors were shut. **One was.**

| Service | Variable | Before | After |
| --- | --- | --- | --- |
| Read | `READ_ALLOWLIST` | already `*`, set 2026-09-04 | `*` |
| Study | `BRIDGE_ALLOWLIST` | the owner's address only. The only shut door. | `*` |
| Get Books | `GETBOOKS_PUBLIC_USER` / `_PASS` | already `crossplay` / the pair `src/OpdsServerStore.cpp` ships, byte for byte | unchanged |

The change on the pi is config, not code, and is not in this diff. What is in
this diff is the correction to the docs that predicted otherwise, plus
`verify_open.sh` and `verify_open_selftest.sh`, which existed only on the
unpushed local branch `app/openbridge` and would have been lost with its
worktree.

## What the docs were claiming

`DEPLOY-RUNBOOK.md` said in as many words that "`READ_ALLOWLIST` is untouched
and still the owner's address only". It had been `*` for two days. A runbook's
status line is a claim about a machine, not a reading of one; step 6 now
carries the reading and says to take it the same way.

Also recorded, because it cost time before the box was even touched: the Study
bridge is **`sync.ma-r-s.com`**. `study.ma-r-s.com` is not in the zone and does
not resolve, so a probe aimed at it returns nothing at all and reads as an
outage rather than as a wrong hostname.

## Verification

From a laptop, over the public internet, after the change:

    server/verify_open.sh   ->  ALL THREE ARE OPEN TO STRANGERS   (exit 0)

`server/verify_open_selftest.sh` was run in the same session and reached all
six verdicts including both SHUT ones, so the green is from a probe that was
watched failing rather than one that only ever passes.

`docker inspect` and `docker exec printenv` agree on all three services, and
ankibridge's `Created` timestamp moved, which is what distinguishes the `up -d`
that re-reads `.env` from the `restart` that would have changed nothing.

Both `isolation_test.sh` pass after the recreate (every private probe times
out, egress works) and all three `*-firewall.service` units are enabled and
active after the reboot. A new container is a new network namespace, so this
was not assumed.

Gate: `CHECKSH-VERDICT: host-green-device-skipped exit=0`. Docs and two shell
scripts only, no C++ touched.

## Not verified

**No stranger has completed a sign-in on either bridge.** `verify_open.sh`
proves our gate passes the attempt through; on read-bridge a non-owner
Instapaper 403 prints the same sentence as a wrong password, so only a real
third-party Instapaper account settles that one. Hardware is not involved.

Replying to GitHub issue #115 is Mario's call, not a session's, and has not
been done.