### PR TITLE
Wallpapers: hold a tile to preview it, or delete it

### DIFF
--- a/docs/apps/wallpapers-phone-flow.md
+++ b/docs/apps/wallpapers-phone-flow.md
@@ -525,8 +525,49 @@ Four pull requests, in this order. The first is a prerequisite for the third.
 | --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
 | 0   | **The tap/hold gate.** Refuse a tap held longer than the long-press threshold, with a host test that fails when the bound is reverted.                                                                                            | nothing    |
 | 1   | **QR + upload.** The new screen, `wallpapersOnly` server mode, the devmode latch, a real bind-failure path, `roomFor` on upload, `.davtmp` sweeping, collision naming, the Wi-Fi short-circuit. Grid stays tap-only.              | nothing    |
-| 2   | **Hold sheet: preview, delete, confirm.** Including the honest "getting it back means the whole pack again" wording and the `specialTiles()` renumbering.                                                                         | PR 0       |
+| 2   | **Hold sheet: preview, delete, confirm.** DONE, card #365 -- see "What PR 2 shipped" below. | PR 0       |
 | 3   | **Shuffle (#305).** Selection mode, the `.placed` manifest, the sleep-mode honesty line. Its prerequisite audit is DONE (Part 2), and #354 should land first or the honesty line is telling half the truth. | PR 0, PR 2 |
+
+### What PR 2 shipped, and the two things it settled differently
+
+Built on card #365, stacked on this branch because `tapWasHeldLong()` is PR 0's
+and lives here.
+
+**The defence against `same-pixel-different-action` is a rectangle identity, not
+a rule.** `confirmKeepRect()` returns exactly `sheetDeleteRect()`: the confirm's
+SAFE half occupies the pixels the button that opened it did. A second press of
+the same spot -- a double tap, an impatient repeat during a 0.3-2s e-ink
+repaint, a finger that never moved -- cancels, because there is nothing
+destructive there to hit. `confirmDeleteRect()` overlaps neither sheet control.
+`host-tests/wallcaption` asserts the identity and the separation at both insets.
+
+**What that does NOT buy, said plainly:** the confirm's DELETE does sit over the
+grid's cells. It cannot not -- the cells span y 134..758 of an 800px panel and
+the only cell-free bands are 46px, 24px and 42px, none of which holds a 64px
+finger target. The grid is two screens and one 500ms hold away, and
+`RevealedInteractions::route()` refuses any tap routed against a table the panel
+has not shown, so no single remembered tap can reach it.
+
+**Preview draws no chrome at all.** It is what the sleep screen puts on the
+glass; a hint band over it would be a preview of something that never appears.
+The way out is said on the sheet instead, where there is room for it. The
+placement arithmetic is `SleepActivity`'s non-oversize branch reproduced rather
+than called: `calculateBitmapPlacement` is file-local to upstream's
+`SleepActivity.cpp` and widening it is not ours to do. It is the identity for
+every wallpaper this app ships or produces, all of which are exactly 480x800.
+
+**One layout defect only a render could find.** At the first cut the button
+stack sat at y=380, which left the confirm's prose five 42px lines for a
+sentence that needs six. The clause it dropped was the second one -- "it stays
+on your sleep screen until you pick another" -- so the confirm for the wallpaper
+actually in use lost the only line that was about it. `host-tests/ui` cannot see
+this (its target answers ten pixels a character); `wallcaption` now measures all
+four combinations against the real box in the real face, and the stack sits at
+470.
+
+**Sorting was already done.** `wallpapers::sortsBefore` puts a user's own files
+ahead of the built-ins and has since the picker shipped; PR 2 confirmed it in a
+render rather than rewriting it.
 
 PR 1 is the whole of Mario's first ask and the only piece with a security
 surface. It is also the only one that needs his eyes on a screen before it is

--- a/docs/apps/wallpapers-phone-flow.md
+++ b/docs/apps/wallpapers-phone-flow.md
@@ -158,13 +158,16 @@ generation fails). In `DARK`, `LIGHT`, `COVER`, `BLANK`, `QUICK_RESUME` and
 `TRANSPARENT_CUSTOM` it is silently ignored -- and `TRANSPARENT_CUSTOM` does not
 read `/sleep.bmp` or `/.sleep` at all, only the four `sleep-overlay` slots.
 
-**And even `CUSTOM` is not sufficient**, which is card #354 and not this card's
-to fix: `quickResumeSleepScreen == QUICK_RESUME_AFTER_TIMEOUT` short-circuits
-*above* the mode switch (`SleepActivity.cpp:500-507`) whenever `fromTimeout`,
-which is the ordinary idle sleep. So the wallpaper is only seen when the device
-is slept by hand. There is a reachable path where that flag sticks on
-permanently, and `setWallpaper` forcing `sleepScreen = CUSTOM` without the sync
-call is part of it.
+**And even `CUSTOM` is not sufficient**: `quickResumeSleepScreen ==
+QUICK_RESUME_AFTER_TIMEOUT` short-circuits *above* the mode switch
+(`SleepActivity.cpp:500-507`) whenever `fromTimeout`, which is the ordinary idle
+sleep. So the wallpaper is only seen when the device is slept by hand.
+
+**FIXED, by card #354 (PR #145), which has since merged into this branch.**
+`setWallpaper` now applies `wallpapers::choiceForSetWallpaper`, which clears the
+timeout quick-resume flag as well as moving the mode, so choosing a wallpaper no
+longer leaves it unreachable on every idle sleep. The paragraph above describes
+the defect, not the current code.
 
 That is what the hint strip is for, and it is why the strip carries a sentence
 rather than a marker: no per-cell mark can express "your settings mean none of
@@ -193,9 +196,24 @@ critic showed that is false in two ways, both verifiable in
   short-circuited entirely by quick-resume. In BLANK, COVER, or
   `TRANSPARENT_CUSTOM`, nothing the picker shows reaches the glass at all.
 
-The existing code already knows this -- `loadActive()` returns early unless the
-mode is CUSTOM (`WallpapersActivity.cpp:103`) -- and the first draft silently
-dropped that guard.
+The code at the time of writing knew this by returning early from
+`loadActive()` unless the mode was CUSTOM, and the first draft silently dropped
+that guard.
+
+**That guard is gone now, deliberately, and it is not a regression.** Card #354
+deleted it because it was wrong in both directions: it hid the marker under
+`COVER_CUSTOM`, where the wallpaper genuinely does show, and it drew the marker
+at full confidence under `CUSTOM`-plus-quick-resume, where it never does.
+`activeIndex_` is therefore now set whatever the sleep mode, and what qualifies
+it is `wallpapers::reachOfPinnedSleep` feeding the hint strip.
+
+The consequence for the screens added by card #365 (hold to preview or delete),
+which is the one thing the two cards together got wrong: the sheet and the
+delete confirm each make a flat claim about the sleep screen and carry no strip
+to qualify it, so they must not read the raw marker. They ask
+`wallpapers::saysOnSleepScreen(isMarked, reach)` instead, which is true only
+where an ordinary idle sleep actually draws the file. Neither card had this
+defect alone.
 
 **So the marker means "chosen here", which is all the app can honestly claim**,
 and the screen says the rest: when `SETTINGS.sleepScreen` is not a mode that

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -43,6 +43,7 @@
 #include "../../src/apps_local/ui/ToyboxIcons.h"
 #include "../../src/apps_local/ui/ToyboxText.h"
 #include "../../src/apps_local/ui/ToyboxWrappedText.h"
+#include "../../src/apps_local/wallpapers/WallpapersCore.h"
 #include "../../src/apps_local/wallpapers/WallpapersScreens.h"
 #include "../../src/apps_local/wavelength/WavelengthScreens.h"
 #include "../../src/apps_local/xkcd/XkcdScreens.h"
@@ -10151,6 +10152,138 @@ void testWallpapersHelpCardPointsAtTheUploader() {
   CHECK(drewText(out, "File Transfer"));
 }
 
+// --- Wallpapers: the hold sheet ---------------------------------------------
+
+void buildWallpapersSheet(Rendered& out, const wallpapersui::SheetModel& model) {
+  const fui::DeviceContext ctx = device();
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(out.target, ctx, noInput, out.interactions);
+  toybox::Screen screen(frame, toybox::themeTokens());
+  wallpapersui::buildSheet(screen, model);
+}
+
+void buildWallpapersConfirm(Rendered& out, const wallpapersui::ConfirmModel& model) {
+  const fui::DeviceContext ctx = device();
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(out.target, ctx, noInput, out.interactions);
+  toybox::Screen screen(frame, toybox::themeTokens());
+  wallpapersui::buildConfirm(screen, model);
+}
+
+bool registered(const Rendered& out, const fui::ActionId action) {
+  for (size_t i = 0; i < out.interactions.count(); ++i) {
+    if (out.interactions.data()[i].action == action) return true;
+  }
+  return false;
+}
+
+// The sheet a hold opens: it names the wallpaper, offers exactly the two things
+// a tap cannot do, and says how to get out of the preview BEFORE opening it --
+// the preview draws no chrome at all, so this is the only place that can.
+void testWallpapersSheetOffersPreviewAndDelete() {
+  Rendered out;
+  wallpapersui::SheetModel model;
+  model.name = "Duerer: Four Horsemen";
+  buildWallpapersSheet(out, model);
+  CHECK(drewText(out, "WALLPAPER"));
+  CHECK(drewText(out, "Duerer: Four Horsemen"));
+  CHECK(drewText(out, "PREVIEW"));
+  CHECK(drewText(out, "DELETE"));
+  CHECK(drewText(out, "tap it to come back"));
+  CHECK(registered(out, wallpapersui::ActionPreview));
+  CHECK(registered(out, wallpapersui::ActionDelete));
+  // The sheet is the SAFE screen: nothing on it deletes anything. That is what
+  // makes reusing its DELETE pixels for the confirm's KEEP IT sound.
+  CHECK(!registered(out, wallpapersui::ActionConfirmDelete));
+}
+
+// The sheet says so when the wallpaper it is about is the one in use, because
+// the delete's consequence differs for it and the user should learn that before
+// the confirm rather than in it.
+void testWallpapersSheetSaysWhenItIsTheOneInUse() {
+  Rendered active;
+  wallpapersui::SheetModel model;
+  model.name = "Bauhaus";
+  model.isActive = true;
+  buildWallpapersSheet(active, model);
+  CHECK(drewText(active, "on your sleep screen now"));
+
+  Rendered idle;
+  model.isActive = false;
+  buildWallpapersSheet(idle, model);
+  CHECK(!drewText(idle, "on your sleep screen now"));
+}
+
+// The confirm carries BOTH halves and says what deleting costs. The consequence
+// text itself is proved over all four of its combinations in
+// host-tests/wallpapers; this is that it reaches the panel at all.
+void testWallpapersConfirmSaysTheCostAndOffersBoth() {
+  Rendered out;
+  wallpapersui::ConfirmModel model;
+  model.name = "Bauhaus";
+  // Held in a named local: c_str() on the temporary would dangle before the
+  // builder ever read it, and the panel would draw whatever was left on the
+  // stack -- which is exactly the class of bug toybox::detail::OwnedDevice
+  // exists for.
+  const std::string cost = wallpapers::deleteConsequence(true, true);
+  model.consequence = cost.c_str();
+  buildWallpapersConfirm(out, model);
+  CHECK(drewText(out, "DELETE WALLPAPER"));
+  CHECK(drewText(out, "Bauhaus"));
+  CHECK(drewText(out, "whole set again"));
+  CHECK(drewText(out, "KEEP IT"));
+  CHECK(drewText(out, "DELETE IT"));
+  CHECK(registered(out, wallpapersui::ActionKeep));
+  CHECK(registered(out, wallpapersui::ActionConfirmDelete));
+}
+
+// The whole defence against same-pixel-different-action, asserted on the rects
+// the builders actually draw into rather than on the ones they were meant to.
+// wallcaption proves the same identity against the published helpers; this
+// proves the SHEET AND THE CONFIRM USE THEM, which is the half a helper-only
+// test cannot see.
+void testWallpapersConfirmReusesTheSheetsDeletePixelsForItsSafeHalf() {
+  const fui::DeviceContext ctx = device();
+  const fui::Rect sheetDelete = wallpapersui::sheetDeleteRect(ctx);
+  const fui::Rect kill = wallpapersui::confirmDeleteRect(ctx);
+
+  const auto rectOf = [](const Rendered& out, fui::ActionId action, fui::Rect& found) {
+    for (size_t i = 0; i < out.interactions.count(); ++i) {
+      if (out.interactions.data()[i].action != action) continue;
+      found = out.interactions.data()[i].rect;
+      return true;
+    }
+    return false;
+  };
+
+  Rendered sheet;
+  wallpapersui::SheetModel sm;
+  sm.name = "Bauhaus";
+  buildWallpapersSheet(sheet, sm);
+  fui::Rect drawnSheetDelete{};
+  CHECK(rectOf(sheet, wallpapersui::ActionDelete, drawnSheetDelete));
+  CHECK(drawnSheetDelete.x == sheetDelete.x && drawnSheetDelete.y == sheetDelete.y &&
+        drawnSheetDelete.width == sheetDelete.width && drawnSheetDelete.height == sheetDelete.height);
+
+  Rendered confirm;
+  wallpapersui::ConfirmModel cm;
+  cm.name = "Bauhaus";
+  cm.consequence = "x";
+  buildWallpapersConfirm(confirm, cm);
+  fui::Rect drawnKeep{};
+  fui::Rect drawnKill{};
+  CHECK(rectOf(confirm, wallpapersui::ActionKeep, drawnKeep));
+  CHECK(rectOf(confirm, wallpapersui::ActionConfirmDelete, drawnKill));
+
+  // A second press of the pixels that opened this screen CANCELS.
+  CHECK(drawnKeep.x == drawnSheetDelete.x && drawnKeep.y == drawnSheetDelete.y &&
+        drawnKeep.width == drawnSheetDelete.width && drawnKeep.height == drawnSheetDelete.height);
+  // And the destructive button is somewhere else entirely.
+  CHECK(drawnKill.y == kill.y);
+  CHECK(!(drawnKill.y < drawnSheetDelete.y + drawnSheetDelete.height &&
+          drawnSheetDelete.y < drawnKill.y + drawnKill.height));
+}
+
 // The layout is DERIVED now (positions hang off screen.body().y and off each
 // other) rather than written as ~100 absolute panel literals. This pins the
 // result of that derivation to the exact coordinates the literals used to
@@ -10397,6 +10530,10 @@ int main() {
   testWallpapersEmptyStateSaysSomething();
   testWallpapersCaptionNeverCollidesWithArtwork();
   testWallpapersHelpCardPointsAtTheUploader();
+  testWallpapersSheetOffersPreviewAndDelete();
+  testWallpapersSheetSaysWhenItIsTheOneInUse();
+  testWallpapersConfirmSaysTheCostAndOffersBoth();
+  testWallpapersConfirmReusesTheSheetsDeletePixelsForItsSafeHalf();
   testNoPaperAboveAnyHeaderBand();
   testAHandDrawnRightLabelSitsOnTheTitlesLine();
   testTheHeaderTitleStaysOutOfTheCoveredRows();

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -10101,6 +10101,24 @@ void testTheGlassNeverMovesABodyTop() {
     checkTheGlassDoesNotMoveTheBody<wallpapersui::GridChromeModel, wallpapersui::buildGridChrome>(
         model, "wallpapers grid: the glass does not move the body");
   }
+  // Card 365's two screens, added to card 358's guard rather than left outside
+  // it. The grid above was the only wallpapers screen listed, and these two
+  // reach the panel by a different route (a hold, not a tap), so a clean run of
+  // the list above said nothing at all about them -- which is exactly how the
+  // ten-pixel drop survived in this app while twenty others were right.
+  {
+    wallpapersui::SheetModel model;
+    model.name = "Holiday In Lisbon";
+    checkTheGlassDoesNotMoveTheBody<wallpapersui::SheetModel, wallpapersui::buildSheet>(
+        model, "wallpapers hold sheet: the glass does not move the body");
+  }
+  {
+    wallpapersui::ConfirmModel model;
+    model.name = "Holiday In Lisbon";
+    model.consequence = "Your own wallpaper. The card holds the only copy, so this cannot be undone.";
+    checkTheGlassDoesNotMoveTheBody<wallpapersui::ConfirmModel, wallpapersui::buildConfirm>(
+        model, "wallpapers delete confirm: the glass does not move the body");
+  }
 }
 
 // Moving a body top moves everything under it, and this fork has already

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -10237,6 +10237,51 @@ void testWallpapersConfirmSaysTheCostAndOffersBoth() {
   CHECK(registered(out, wallpapersui::ActionConfirmDelete));
 }
 
+// A wallpaper the user added is named by its FILE, and the sheet must SHRINK
+// that name rather than mark it: no Toybox cut above toybox_10 carries U+2026,
+// so an ellipsis there draws as a hole and the name stops with a gap after it.
+// wallcaption proves toybox::fittedTitle behaves; this proves buildSheet CALLS
+// it, which is the half a helper-only test cannot see -- the builder used a
+// bare fitLines at the display cut until this went in.
+void testWallpapersSheetShrinksALongNameRatherThanMarkingIt() {
+  const auto runFor = [](const Rendered& out, const char* needle, fui::TextStyle& style) {
+    for (const auto& run : out.target.texts) {
+      if (run.text.find(needle) == std::string::npos) continue;
+      style = run.style;
+      return true;
+    }
+    return false;
+  };
+
+  Rendered shortName;
+  wallpapersui::SheetModel sm;
+  sm.name = "Bauhaus";
+  buildWallpapersSheet(shortName, sm);
+  fui::TextStyle shortStyle{};
+  CHECK(runFor(shortName, "Bauhaus", shortStyle));
+  CHECK(shortStyle.font == fui::FONT_SLOT_TITLE);  // a name that fits keeps the display cut
+
+  Rendered longName;
+  const char* huge = "supercalifragilisticexpialidociouswallpaperfromaphone";
+  sm.name = huge;
+  buildWallpapersSheet(longName, sm);
+  fui::TextStyle longStyle{};
+  bool found = false;
+  std::string drawn;
+  for (const auto& run : longName.target.texts) {
+    if (run.text.compare(0, 6, "superc") != 0) continue;
+    longStyle = run.style;
+    drawn = run.text;
+    found = true;
+  }
+  CHECK(found);
+  // Either it kept the whole name (by stepping down), or it marked it -- and if
+  // it marked it, only in the one cut that can draw the mark.
+  CHECK(drawn == huge || longStyle.font == fui::FONT_SLOT_SMALL);
+  // It must not still be sitting on the display cut untouched and overflowing.
+  CHECK(!(drawn == huge && longStyle.font == fui::FONT_SLOT_TITLE));
+}
+
 // The whole defence against same-pixel-different-action, asserted on the rects
 // the builders actually draw into rather than on the ones they were meant to.
 // wallcaption proves the same identity against the published helpers; this
@@ -10533,6 +10578,7 @@ int main() {
   testWallpapersSheetOffersPreviewAndDelete();
   testWallpapersSheetSaysWhenItIsTheOneInUse();
   testWallpapersConfirmSaysTheCostAndOffersBoth();
+  testWallpapersSheetShrinksALongNameRatherThanMarkingIt();
   testWallpapersConfirmReusesTheSheetsDeletePixelsForItsSafeHalf();
   testNoPaperAboveAnyHeaderBand();
   testAHandDrawnRightLabelSitsOnTheTitlesLine();

--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -396,16 +396,84 @@ int main() {
         }
       }
 
-      // The sheet's own sentence, both forms, in its own (shorter) box.
+      // The sheet's own sentence, both forms, in its own (shorter) box. Read
+      // from wallpapersui::sheetInstruction rather than copied here: a test
+      // holding its own copy of the sentence keeps measuring the old one after
+      // the source is edited, and stays green while the panel cuts it.
       const fui::Rect sheetBox = wallpapersui::sheetProseRect(panels[p]);
       const int sheetLines = lineH > 0 ? sheetBox.height / lineH : 0;
-      const char* sheetProse[] = {
-          "Preview fills the panel exactly as the sleep screen draws it; tap it to come back.",
-          "This one is on your sleep screen now. Preview fills the panel; tap it to come back.",
+      for (int active = 0; active <= 1; ++active) {
+        const std::string line = wallpapersui::sheetInstruction(active != 0);
+        check(toybox::fitLines(target, line.c_str(), sheetBox.width, sheetLines, prose) == line,
+              std::string("the hold sheet cuts its own instruction (active=") + std::to_string(active) + ", " +
+                  labels[p] + ")");
+      }
+
+      // THE NAME, which is the one string on these screens nobody chose the
+      // width of: a wallpaper the user added is named by its FILE. fitLines
+      // appends U+2026 on overflow and the faces above toybox_10 carry no
+      // ellipsis glyph, so an over-long name does not arrive clipped -- it
+      // stops mid-word with a hole where the mark should be, on the screen
+      // that is about to delete it (typography-fold). Two lines of the title
+      // cut is what buildSheet and buildConfirm give it.
+      const fui::Rect nameBox = wallpapersui::sheetHeadRect(panels[p]);
+      check(nameBox.height >= target.lineHeight(fui::FONT_SLOT_TITLE) * 2,
+            std::string("the name box cannot hold the two title lines it is given (") + labels[p] + ")");
+      // The same call the builders make: fittedTitle, which rewrites the style
+      // to the cut it chose. That choice is what decides whether an ellipsis is
+      // drawable at all, so the test has to see it.
+      const auto fitName = [&](const char* name, fui::FontId& chose) {
+        fui::TextStyle style;
+        style.font = fui::FONT_SLOT_TITLE;
+        style.align = fui::TextAlign::Left;
+        style.maxLines = 2;
+        const std::string drawn = toybox::fittedTitle(target, name, nameBox.width, style);
+        chose = style.font;
+        return drawn;
       };
-      for (const char* line : sheetProse) {
-        check(toybox::fitLines(target, line, sheetBox.width, sheetLines, prose) == std::string(line),
-              std::string("the hold sheet cuts its own instruction (") + labels[p] + ")");
+      for (size_t i = 0; i < wallpapers::builtInCount(); ++i) {
+        const std::string full = wallpapers::displayName(std::string(wallpapers::builtInStem(i)) + ".bmp").full;
+        fui::FontId chose = fui::FONT_SLOT_TITLE;
+        check(fitName(full.c_str(), chose) == full,
+              "the hold sheet cuts a built-in's name [" + full + ", " + labels[p] + "]");
+        check(chose == fui::FONT_SLOT_TITLE,
+              "a built-in's name had to step off the display cut [" + full + ", " + labels[p] + "]");
+      }
+      // A user's own file names. The app's own uploader writes w0001.bmp, but
+      // File Transfer and a card in a laptop do not, so the ones that matter
+      // are the ones a phone or a person produces -- including the long
+      // unbreakable single word, which has no space for fitLines to break at.
+      const char* ownNames[] = {
+          "DSC_00417_final_v2.bmp",
+          "a-really-long-holiday-photo-name-from-a-phone.bmp",
+          "supercalifragilisticexpialidociouswallpaper.bmp",
+          "SCREENSHOT 2026 09 05 AT 14 23 07.bmp",
+      };
+      for (const char* file : ownNames) {
+        const std::string full = wallpapers::displayName(file).full;
+        fui::FontId chose = fui::FONT_SLOT_TITLE;
+        const std::string drawn = fitName(full.c_str(), chose);
+        const std::string at = std::string(" [") + file + ", " + labels[p] + "]";
+        // fitLines and fittedTitle return the string UNWRAPPED when it fits --
+        // the renderer's own text() does the wrapping, from style.maxLines. So
+        // "does it fit" is answered by identity, not by measuring the return as
+        // one line, and an earlier version of this block measured it as one line
+        // and reported a defect that was its own (tests-that-share-the-bug, in
+        // reverse).
+        //
+        // Nobody chose these widths, so stepping down the ladder is fine and an
+        // ellipsis at the bottom rung is fine. What is never fine is a mark in a
+        // cut that has no glyph for it: only toybox_10 (FONT_SLOT_SMALL here)
+        // carries U+2026, and above it an ellipsised name does not arrive
+        // clipped -- it stops with a HOLE after it, on the screen that is about
+        // to delete it (typography-fold).
+        const bool marked = drawn != full;
+        check(!marked || chose == fui::FONT_SLOT_SMALL,
+              "a name was ellipsised in a cut with no ellipsis glyph -- it draws as a hole" + at + " -> \"" + drawn +
+                  "\"");
+        // And whatever cut it landed on, two lines of it must fit the box the
+        // builders draw into.
+        check(target.lineHeight(chose) * 2 <= nameBox.height, "a user's wallpaper name is taller than its box" + at);
       }
 
       // And neither box may reach the control under it.

--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -297,6 +297,127 @@ int main() {
     }
   }
 
+  // 5. THE HOLD SHEET'S CONTROLS, and the one destructive button behind them.
+  //
+  //    This fork has destroyed user data by putting a new meaning under a pixel
+  //    a finger was already travelling towards (same-pixel-different-action).
+  //    The picker is the worst host for that: a plain tap SETS the sleep screen
+  //    with no confirmation, and a hold arrives as a tap unless
+  //    tapWasHeldLong() says otherwise. So the defence is geometric and it is
+  //    asserted here rather than described in a comment.
+  //
+  //    Walked at BOTH insets: the panel with no bezel, and the X4 Pro's real
+  //    T10 R1 B0 L1 glass. Every rect hangs off safeRect(), so an identity that
+  //    held at one inset and not the other would be a screen that is safe on a
+  //    test target and not on the device.
+  {
+    fui::DeviceContext bezel = device();
+    bezel.safeArea = fui::Insets{10, 1, 0, 1};
+    const fui::DeviceContext panels[] = {device(), bezel};
+    const char* labels[] = {"no bezel", "X4 Pro bezel"};
+    for (int p = 0; p < 2; ++p) {
+      const fui::DeviceContext& dev = panels[p];
+      const std::string at = std::string(" (") + labels[p] + ")";
+      const fui::Rect preview = wallpapersui::sheetPreviewRect(dev);
+      const fui::Rect del = wallpapersui::sheetDeleteRect(dev);
+      const fui::Rect keep = wallpapersui::confirmKeepRect(dev);
+      const fui::Rect kill = wallpapersui::confirmDeleteRect(dev);
+
+      // THE IDENTITY. The confirm's SAFE half occupies exactly the pixels the
+      // sheet's DELETE did, so a repeat of the press that opened the confirm --
+      // a double tap, an impatient repeat during a 0.3-2s e-ink repaint, a
+      // finger that never moved -- cancels. Identical, not merely close: a
+      // "nearly" here is a band of pixels with no owner.
+      check(keep.x == del.x && keep.y == del.y && keep.width == del.width && keep.height == del.height,
+            "the confirm's KEEP is not exactly where the sheet's DELETE was" + at);
+
+      // THE SEPARATION. Reaching the destructive button takes a deliberate move
+      // to somewhere nothing was a moment ago.
+      check(!overlaps(kill, del), "the confirm's DELETE lands on the sheet's DELETE" + at);
+      check(!overlaps(kill, preview), "the confirm's DELETE lands on the sheet's PREVIEW" + at);
+      check(!overlaps(preview, del), "the sheet's two buttons overlap each other" + at);
+
+      // Finger targets, on the panel, and in reading order.
+      const fui::Rect all[] = {preview, del, kill};
+      for (const fui::Rect& r : all) {
+        check(r.height >= 44, "a hold-sheet control is under the finger-target minimum" + at);
+        check(r.x >= dev.safeRect().x, "a hold-sheet control runs off the left of the safe area" + at);
+        check(r.x + r.width <= dev.safeRect().right(), "a hold-sheet control runs off the right" + at);
+        check(r.y >= dev.safeRect().y, "a hold-sheet control runs above the safe area" + at);
+        check(r.y + r.height <= dev.safeRect().bottom(), "a hold-sheet control runs off the bottom" + at);
+      }
+      check(del.y > preview.y, "the sheet draws DELETE above PREVIEW" + at);
+      check(kill.y > keep.y, "the confirm draws its destructive half above its safe one" + at);
+
+      // The labels fit the buttons in the face that draws them. A label that
+      // overflows does not arrive clipped in these cuts -- the faces above
+      // toybox_10 carry no U+2026 -- it simply stops, so "DELETE IT" could read
+      // as "DELETE I" and mean something else entirely.
+      const char* buttonLabels[] = {"PREVIEW", "DELETE", "KEEP IT", "DELETE IT"};
+      for (const char* label : buttonLabels) {
+        check(target.widthOf(fui::FONT_SLOT_SMALL, label) <= preview.width - 8,
+              std::string("button label \"") + label + "\" overflows its button" + at);
+      }
+    }
+  }
+
+  // 6. THE SENTENCE ON THE CONFIRM, measured rather than eyeballed.
+  //
+  //    This one is here because a render caught what nothing else could: at the
+  //    first layout the longest of the four consequences needed six 42px lines
+  //    and had five, so it was cut with an ellipsis at "It stays on your sleep
+  //    scr..." -- dropping the SECOND clause, the one that only appears for the
+  //    wallpaper actually in use, on the screen where it matters most
+  //    (a-warning-that-can-vanish). host-tests/ui cannot see it: its target
+  //    answers ten pixels a character. Here the widths are the panel's own.
+  //
+  //    All four combinations, and BOTH insets, because the bezel shortens the
+  //    box from the bottom.
+  {
+    fui::TextStyle prose;
+    prose.font = fui::FONT_SLOT_BODY;
+    prose.align = fui::TextAlign::Left;
+    fui::DeviceContext bezel = device();
+    bezel.safeArea = fui::Insets{10, 1, 0, 1};
+    const fui::DeviceContext panels[] = {device(), bezel};
+    const char* labels[] = {"no bezel", "X4 Pro bezel"};
+    for (int p = 0; p < 2; ++p) {
+      const fui::Rect box = wallpapersui::confirmProseRect(panels[p]);
+      const int16_t lineH = target.lineHeight(fui::FONT_SLOT_BODY);
+      const int lines = lineH > 0 ? box.height / lineH : 0;
+      check(lines >= 1, std::string("the confirm has no room for its sentence at all (") + labels[p] + ")");
+      for (int builtIn = 0; builtIn <= 1; ++builtIn) {
+        for (int active = 0; active <= 1; ++active) {
+          const std::string said = wallpapers::deleteConsequence(builtIn != 0, active != 0);
+          const std::string drawn = toybox::fitLines(target, said.c_str(), box.width, lines, prose);
+          check(drawn == said, std::string("the delete confirm cuts its own consequence (builtIn=") +
+                                   std::to_string(builtIn) + " active=" + std::to_string(active) + ", " + labels[p] +
+                                   ") -> \"" + drawn + "\"");
+        }
+      }
+
+      // The sheet's own sentence, both forms, in its own (shorter) box.
+      const fui::Rect sheetBox = wallpapersui::sheetProseRect(panels[p]);
+      const int sheetLines = lineH > 0 ? sheetBox.height / lineH : 0;
+      const char* sheetProse[] = {
+          "Preview fills the panel exactly as the sleep screen draws it; tap it to come back.",
+          "This one is on your sleep screen now. Preview fills the panel; tap it to come back.",
+      };
+      for (const char* line : sheetProse) {
+        check(toybox::fitLines(target, line, sheetBox.width, sheetLines, prose) == std::string(line),
+              std::string("the hold sheet cuts its own instruction (") + labels[p] + ")");
+      }
+
+      // And neither box may reach the control under it.
+      check(wallpapersui::confirmProseRect(panels[p]).bottom() <= wallpapersui::confirmKeepRect(panels[p]).y,
+            std::string("the confirm's sentence runs under KEEP IT (") + labels[p] + ")");
+      check(sheetBox.bottom() <= wallpapersui::sheetPreviewRect(panels[p]).y,
+            std::string("the sheet's sentence runs under PREVIEW (") + labels[p] + ")");
+      check(wallpapersui::sheetHeadRect(panels[p]).bottom() <= sheetBox.y,
+            std::string("the name overlaps the sentence under it (") + labels[p] + ")");
+    }
+  }
+
   std::printf("wallcaption: widest caption \"%s\" = %dpx in a %dpx box (%dpx spare)\n", widestName.c_str(), widest,
               wallpapersui::captionRect(g, 0).width, wallpapersui::captionRect(g, 0).width - widest);
   std::printf("wallcaption: %d checks, %d failed\n", checks, failed);

--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -421,6 +421,7 @@ int main() {
     }
     std::printf("wallcaption: widest hint \"%s\" = %dpx in a %dpx strip (%dpx spare)\n", widestHintText.c_str(),
                 widestHint, stripWidth, stripWidth - widestHint);
+  }
 
   // 6. THE HOLD SHEET'S CONTROLS, and the one destructive button behind them.
   //
@@ -609,7 +610,6 @@ int main() {
       check(wallpapersui::sheetHeadRect(panels[p]).bottom() <= sheetBox.y,
             std::string("the name overlaps the sentence under it (") + labels[p] + ")");
     }
-  }
   }
 
   std::printf("wallcaption: widest caption \"%s\" = %dpx in a %dpx box (%dpx spare)\n", widestName.c_str(), widest,

--- a/host-tests/wallpapers/test_wallpapers.cpp
+++ b/host-tests/wallpapers/test_wallpapers.cpp
@@ -154,6 +154,76 @@ int main() {
     }
   }
 
+  // THE HOLD, and why it is proved here rather than anywhere else.
+  //
+  // InputManager::wasTouchTap has no duration gate, so a five-second hold is
+  // delivered as an ordinary tap and only MappedInputManager::tapWasHeldLong()
+  // can tell the two apart. The simulator never compiles lib/hal and never runs
+  // InputManager (simulator-cannot-test-input-edges), so a screenshot run
+  // cannot see this at all: a hold that never registers on hardware looks clean
+  // there, and one that double-fires looks clean too. This is the proof.
+  {
+    using wallpapers::CellAction;
+    using wallpapers::cellAction;
+
+    // A plain tap keeps the meaning it has always had.
+    CHECK(cellAction(false, 3, -1) == CellAction::Set);
+    CHECK(cellAction(false, 3, 7) == CellAction::Set);
+    // ... except on the wallpaper already in use, where it does nothing.
+    CHECK(cellAction(false, 3, 3) == CellAction::None);
+
+    // A hold opens the sheet, and NEVER sets the sleep screen. This is the one
+    // that goes red without the fix: routing a hold as a tap would set a
+    // wallpaper the user was reaching past, with no confirmation and no undo.
+    CHECK(cellAction(true, 3, -1) == CellAction::Sheet);
+    CHECK(cellAction(true, 3, 7) == CellAction::Sheet);
+    // Including on the wallpaper that is already set. Returning None here would
+    // make the sheet unreachable for exactly one wallpaper -- the one wearing
+    // the marker, and so the one most likely to be held.
+    CHECK(cellAction(true, 3, 3) == CellAction::Sheet);
+
+    // No hold on a cell that is not a wallpaper.
+    CHECK(cellAction(true, -1, 0) == CellAction::None);
+    CHECK(cellAction(false, -1, 0) == CellAction::None);
+
+    // Said as a property rather than as six cases: a hold is never Set, for any
+    // index and any selection. A future branch added above the hold check would
+    // fail here rather than on the panel.
+    for (int idx = 0; idx < 8; ++idx) {
+      for (int active = -1; active < 8; ++active) {
+        CHECK(cellAction(true, idx, active) != CellAction::Set);
+      }
+    }
+  }
+
+  // The confirm's consequence, walked over all four combinations rather than
+  // the one somebody looked at -- a caveat assembled per render is a caveat
+  // that can silently lose a branch (a-warning-that-can-vanish).
+  {
+    using wallpapers::deleteConsequence;
+    const auto has = [](const std::string& hay, const char* needle) { return hay.find(needle) != std::string::npos; };
+    for (int builtIn = 0; builtIn <= 1; ++builtIn) {
+      for (int active = 0; active <= 1; ++active) {
+        const std::string said = deleteConsequence(builtIn != 0, active != 0);
+        CHECK(!said.empty());
+        // The recovery cost, in the terms it is actually paid in: runSetDownload
+        // fetches the WHOLE pack unconditionally, so "the whole set again" is
+        // the honest sentence and "you can get it back" is not.
+        if (builtIn != 0) {
+          CHECK(has(said, "whole set again"));
+          CHECK(!has(said, "only copy"));
+        } else {
+          CHECK(has(said, "cannot be undone"));
+          CHECK(!has(said, "whole set"));
+        }
+        // /sleep.bmp is a copy, so deleting the pinned wallpaper does not take
+        // it off the sleep screen. A user who believed otherwise would delete a
+        // second time looking for an effect that never comes.
+        CHECK(has(said, "sleep screen") == (active != 0));
+      }
+    }
+  }
+
   std::printf("wallpapers: %d checks, %d failed\n", checksRun, checksFailed);
   return checksFailed == 0 ? 0 : 1;
 }

--- a/host-tests/wallpapers/test_wallpapers.cpp
+++ b/host-tests/wallpapers/test_wallpapers.cpp
@@ -432,6 +432,56 @@ int main() {
     }
   }
 
+  // WHO IS ALLOWED TO SAY "on your sleep screen", and why it is not the marker.
+  //
+  // This is the defect the merge with #354 CREATED, which neither branch had on
+  // its own. #354 deliberately un-gated loadActive() from sleepScreen ==
+  // CUSTOM, so a wallpaper now wears the grid's marker under DARK, LIGHT, BLANK
+  // and quick-resume as well -- modes where the pinned picture never reaches
+  // the glass. The grid qualifies the marker with its hint strip. The hold
+  // sheet and the delete confirm are THIS branch's screens, they carry no
+  // strip, and both make a flat claim about the sleep screen. Handed the raw
+  // marker they assert something false under exactly the settings #354 exists
+  // to expose.
+  //
+  // Asserted against reachOfPinnedSleep's own classification rather than a
+  // second copy of the mode rules, so this cannot drift away from the predicate
+  // it describes.
+  {
+    using wallpapers::Reach;
+    using wallpapers::saysOnSleepScreen;
+
+    // Not the marked wallpaper: never, whatever the settings do.
+    for (const Reach r : {Reach::Always, Reach::OutsideReaderOnly, Reach::BlockedByQuickResume, Reach::BlockedByMode}) {
+      CHECK(!saysOnSleepScreen(false, r));
+    }
+
+    // Marked and it genuinely shows.
+    CHECK(saysOnSleepScreen(true, Reach::Always));
+    // COVER_CUSTOM still counts: it shows on an ordinary sleep, and the book
+    // cover exception is the strip's to explain. Denying the sentence here
+    // would be the opposite error -- a user told their wallpaper is NOT the
+    // sleep screen while looking at it.
+    CHECK(saysOnSleepScreen(true, Reach::OutsideReaderOnly));
+
+    // Marked, and blocked. These two are the cases that go red without the fix:
+    // the marker is set, so the pre-merge `index == activeIndex_` would have
+    // said yes and put a false sentence on both screens.
+    CHECK(!saysOnSleepScreen(true, Reach::BlockedByQuickResume));
+    CHECK(!saysOnSleepScreen(true, Reach::BlockedByMode));
+
+    // Said against the predicate rather than the enum, so the two cannot
+    // disagree: the sheet may claim the sleep screen exactly when an ordinary
+    // idle sleep, outside a book, actually draws the pinned file.
+    for (uint8_t mode = 0; mode < 8; ++mode) {
+      for (int qr = 0; qr <= 1; ++qr) {
+        const Reach reach = wallpapers::reachOfPinnedSleep(mode, qr != 0);
+        const bool drawsOnIdle = wallpapers::drawsPinnedSleep(mode, qr != 0, true, false);
+        CHECK(saysOnSleepScreen(true, reach) == drawsOnIdle);
+      }
+    }
+  }
+
   // The confirm's consequence, walked over all four combinations rather than
   // the one somebody looked at -- a caveat assembled per render is a caveat
   // that can silently lose a branch (a-warning-that-can-vanish).

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -10,6 +10,7 @@
 #include <cstdio>
 #include <cstring>
 
+#include "../../../lib/GfxRenderer/FontCacheManager.h"
 #include "../../CrossPointSettings.h"
 #include "../../DevMode.h"
 #include "../../activities/network/WifiSelectionActivity.h"
@@ -206,7 +207,13 @@ void WallpapersActivity::computeWarning() {
 int WallpapersActivity::pageCount() const {
   const int per = wallpapersui::gridGeom(toybox::makeTarget(renderer).deviceContext()).perPage;
   if (names_.empty() || per <= 0) return 1;
-  const int total = 1 + static_cast<int>(names_.size());  // the + Add tile plus the wallpapers
+  // specialTiles(), not a literal 1. drawGrid and the hit-test both use it, and
+  // it is 2 whenever any built-in is missing -- so a literal 1 here promised
+  // fewer pages than the grid draws and the LAST wallpaper became unreachable
+  // at every library size where (1 + N) % perPage == 0. Pre-existing, but this
+  // app can now delete a built-in, which is a brand-new route from a complete
+  // library into that state.
+  const int total = specialTiles() + static_cast<int>(names_.size());
   return (total + per - 1) / per;
 }
 
@@ -780,7 +787,8 @@ void WallpapersActivity::openSheet(const int index) {
   sheetIndex_ = index;
   sheetFile_ = names_[static_cast<size_t>(index)];
   sheetName_ = wallpapers::displayName(sheetFile_).full;
-  sheetDetail_ = wallpapers::deleteConsequence(wallpapers::isBuiltInFile(sheetFile_), index == activeIndex_);
+  sheetIsActive_ = index == activeIndex_;
+  sheetDetail_ = wallpapers::deleteConsequence(wallpapers::isBuiltInFile(sheetFile_), sheetIsActive_);
   view_ = View::Sheet;
   interactionsReady_ = false;
   LOG_INF("WALL", "hold sheet for %s (index %d, active %d)", sheetFile_.c_str(), index, activeIndex_);
@@ -817,12 +825,31 @@ bool WallpapersActivity::deleteWallpaper() {
     LOG_ERR("WALL", "Card refused to delete %s", path.c_str());
     return false;
   }
-  // The thumbnail cache is keyed on the file name, so a later upload of a file
-  // with the same name would otherwise draw the DELETED picture from cache.
-  // thumbFor's staleness check compares the source's size and mtime, which a
-  // fresh 48062-byte wallpaper can match by construction.
+  // The thumbnail cache is keyed on the file NAME, so a later upload reusing the
+  // name would otherwise be drawn from the deleted picture's cache entry until
+  // something else invalidated it. thumbFor's staleness check is the source's
+  // byte count plus a three-read content sample plus the cell size -- not the
+  // mtime -- so a same-named replacement is caught by its CONTENT and this
+  // removal is belt to that brace rather than the only guard. Removing it costs
+  // one decode; leaving it costs the wrong picture.
   const std::string cache = std::string(kThumbDir) + "/" + sheetFile_ + ".thb";
   Storage.remove(cache.c_str());
+
+  // The pin marker names a file that is gone. loadActive() already fails to
+  // match it, so the grid is right today -- but a later upload with the SAME
+  // name would match it again and wear the "in use" border while /sleep.bmp
+  // still holds the deleted picture. The marker is a hint about the library;
+  // when its subject leaves the library the hint is stale, not just unmatched.
+  char marker[kNameMax] = {};
+  if (Storage.readFileToBuffer(wallpapers::kActiveMarker, marker, sizeof(marker)) > 0) {
+    for (char* c = marker; *c; ++c) {
+      if (*c == '\n' || *c == '\r') {
+        *c = '\0';
+        break;
+      }
+    }
+    if (sheetFile_ == marker) Storage.remove(wallpapers::kActiveMarker);
+  }
   LOG_INF("WALL", "deleted %s", path.c_str());
 
   // Re-derive everything from the card. builtInsMissing_ changes here whenever
@@ -856,10 +883,18 @@ void WallpapersActivity::renderPreview() {
   const int pageHeight = renderer.getScreenHeight();
   renderer.clearScreen();
 
+  // drawBitmap is a SILENT NO-OP while the font cache is scanning
+  // (GfxRenderer.cpp:1365). Asking first, because the alternative is a cleared
+  // panel with nothing on it and a `drawn = true` derived from parseHeaders
+  // rather than from the draw -- a blank screen this fork has twice had cold
+  // testers read as a crash.
+  const FontCacheManager* fonts = renderer.getFontCacheManager();
+  const bool canDraw = fonts == nullptr || !fonts->isScanning();
+
   const std::string path = std::string(wallpapers::kLibraryDir) + "/" + sheetFile_;
   HalFile file;
   bool drawn = false;
-  if (Storage.openFileForRead("WALL", path, file)) {
+  if (canDraw && Storage.openFileForRead("WALL", path, file)) {
     Bitmap bitmap(file, true);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       const int w = bitmap.getWidth();
@@ -867,6 +902,14 @@ void WallpapersActivity::renderPreview() {
       const int x = w <= pageWidth ? (pageWidth - w) / 2 : 0;
       const int y = h <= pageHeight ? (pageHeight - h) / 2 : 0;
       renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, 0.0f, 0.0f);
+      // The cover filter, because the sheet PROMISES "exactly as the sleep
+      // screen draws it" and renderBitmapSleepScreen inverts here
+      // (SleepActivity.cpp:631). The setting is user-reachable, and without
+      // this the one user who chose it is shown the negative of their
+      // wallpaper and told it is the real thing.
+      if (SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
+        renderer.invertScreen();
+      }
       drawn = true;
     }
     file.close();
@@ -889,7 +932,13 @@ void WallpapersActivity::renderPreview() {
     wallpapersui::buildNotice(surface, model);
   }
   interactionsReady_ = false;
-  renderer.displayBuffer();
+  // HALF_REFRESH, the same waveform every sleep-screen paint uses
+  // (SleepActivity.cpp:609,643). The default is FAST, and under FAST a dense
+  // 1-bit plate ghosts the screen it replaced and reads lower-contrast than the
+  // real thing -- so the preview would differ from the sleep screen in the one
+  // way a preview exists to rule out. The notice path takes it too, so the
+  // failure and the picture do not paint with different waveforms.
+  renderer.displayBuffer(HalDisplay::HALF_REFRESH);
   painted_ = true;
 }
 
@@ -1377,7 +1426,17 @@ void WallpapersActivity::loop() {
         requestUpdate();
         return;
       case wallpapersui::ActionConfirmDelete:
-        deleteWallpaper();
+        // A failed delete used to discard its bool and repaint the identical
+        // confirm: the panel flashed and came back unchanged, with no way to
+        // tell a card that refused from a touch that was dropped. Every other
+        // failure in this app goes through showNotice, and this is the one the
+        // user is watching hardest (a-silent-screen-reads-as-a-crash).
+        if (!deleteWallpaper()) {
+          showNotice("NOT DELETED",
+                     "The card would not remove this wallpaper, or it is already gone. It is still here.", "OK",
+                     wallpapersui::ActionDismiss);
+          return;
+        }
         interactionsReady_ = false;
         requestUpdate();
         return;
@@ -1443,11 +1502,20 @@ void WallpapersActivity::loop() {
   const int specials = specialTiles();
   const int total = specials + static_cast<int>(names_.size());
   if (combined >= total) return;
+  // The chrome tiles are not wallpapers and have no sheet, but they are on the
+  // same grid and a user who has learned "hold a tile for options" will hold the
+  // Add tile first. Neither action is destructive -- one brings up WiFi and a
+  // web server, the other a ~1MB fetch -- but both are the same failure this
+  // whole change exists to prevent: the hold firing the thing the user was
+  // reaching past. Silence is the right answer; the hold is repeatable.
+  const bool held = mappedInput.tapWasHeldLong();
   if (combined == 0) {
+    if (held) return;
     openAdd();
     return;
   }
   if (specials > 1 && combined == 1) {
+    if (held) return;
     startSetDownload();
     return;
   }
@@ -1458,7 +1526,7 @@ void WallpapersActivity::loop() {
   // the two apart, and the decision itself lives in WallpapersCore so it can be
   // asserted: the simulator never compiles lib/hal or runs InputManager, so
   // host-tests/wallpapers is the only place this is provable at all.
-  switch (wallpapers::cellAction(mappedInput.tapWasHeldLong(), idx, activeIndex_)) {
+  switch (wallpapers::cellAction(held, idx, activeIndex_)) {
     case wallpapers::CellAction::Sheet:
       openSheet(idx);
       return;
@@ -1517,10 +1585,12 @@ void WallpapersActivity::render(RenderLock&&) {
   } else if (view_ == View::Sheet) {
     wallpapersui::SheetModel model;
     model.name = sheetName_.c_str();
-    // From the NAME, never from sheetIndex_: an upload arriving while the sheet
-    // is up re-sorts names_ and every index in it means a different picture.
-    model.isActive = activeIndex_ >= 0 && activeIndex_ < static_cast<int>(names_.size()) &&
-                     names_[static_cast<size_t>(activeIndex_)] == sheetFile_;
+    // Settled in loop() by openSheet, not derived here. render() runs on the
+    // OTHER FreeRTOS task and ActivityManager holds no lock across it, so a
+    // names_[i] read in this function races scanLibrary()'s clear-and-realloc
+    // in deleteWallpaper -- a read of a freed std::string. A bool the loop task
+    // owns cannot be freed under the render task.
+    model.isActive = sheetIsActive_;
     wallpapersui::buildSheet(surface, model);
   } else if (view_ == View::Confirm) {
     wallpapersui::ConfirmModel model;

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -841,11 +841,25 @@ void WallpapersActivity::openSheet(const int index) {
   sheetIndex_ = index;
   sheetFile_ = names_[static_cast<size_t>(index)];
   sheetName_ = wallpapers::displayName(sheetFile_).full;
-  sheetIsActive_ = index == activeIndex_;
+  // Both screens behind this SAY something about the sleep screen -- the sheet
+  // "This one is on your sleep screen now.", the confirm "It stays on your
+  // sleep screen until you pick another." -- so the flag they read has to mean
+  // the wallpaper actually REACHES the glass, not merely that it wears the
+  // grid's marker.
+  //
+  // Those used to be the same thing. #354 deliberately un-gated loadActive()
+  // from sleepScreen == CUSTOM, because the marker was wrong in both
+  // directions; activeIndex_ is now set under DARK, LIGHT, BLANK and
+  // quick-resume too, where the pinned picture never appears. The marker is
+  // qualified for the grid by the hint strip, which these two screens do not
+  // carry, so they qualify it here instead. Neither card had this alone: it is
+  // this branch's sentences meeting that card's wider activeIndex_.
+  sheetIsActive_ = wallpapers::saysOnSleepScreen(index == activeIndex_, sleepReach());
   sheetDetail_ = wallpapers::deleteConsequence(wallpapers::isBuiltInFile(sheetFile_), sheetIsActive_);
   view_ = View::Sheet;
   interactionsReady_ = false;
-  LOG_INF("WALL", "hold sheet for %s (index %d, active %d)", sheetFile_.c_str(), index, activeIndex_);
+  LOG_INF("WALL", "hold sheet for %s (index %d, active %d, blocked %d)", sheetFile_.c_str(), index, activeIndex_,
+          static_cast<int>(sleepBlocked()));
   requestUpdate();
 }
 

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -629,7 +629,12 @@ void WallpapersActivity::drawGetSetTile(const wallpapersui::GridGeom& geom, cons
   char label[48];
   // One line of text, wrapped by width. An embedded newline is not a break
   // this renderer honours: it vanished and joined the words into "GET THE21".
-  std::snprintf(label, sizeof(label), "GET THE %d BUILT-INS", builtInsMissing_);
+  //
+  // No plural: fmtwidth cannot bound a "%s" that switches word, and the count
+  // beside a fixed noun says the same thing (the trivia and add-screen
+  // precedent). The one-missing case was unreachable until the hold sheet could
+  // delete a built-in, and it read "GET THE 1 BUILT-INS".
+  std::snprintf(label, sizeof(label), "GET %d MISSING", builtInsMissing_);
   const fui::Rect box =
       fui::makeRect(th.x + 6, static_cast<int16_t>(th.y + th.height / 2 - 30), static_cast<int16_t>(th.width - 12), 60);
   target.text(box, label, style);
@@ -764,6 +769,123 @@ int WallpapersActivity::builtInsPresent() const {
 // The screen is a function of the card, with no remembered "already offered"
 // flag to go stale or to make two identical cards show different things.
 void WallpapersActivity::pickView() { view_ = names_.empty() ? View::Offer : View::Grid; }
+
+// A hold landed on a wallpaper. Everything the three screens behind this need is
+// SNAPSHOT here, in loop(), while the index is still the one the finger meant:
+// render() must not go looking things up in names_, and the delete must not
+// trust an index that uploading, deleting or re-sorting can renumber underneath
+// it. The file name is the identity that survives all three.
+void WallpapersActivity::openSheet(const int index) {
+  if (index < 0 || index >= static_cast<int>(names_.size())) return;
+  sheetIndex_ = index;
+  sheetFile_ = names_[static_cast<size_t>(index)];
+  sheetName_ = wallpapers::displayName(sheetFile_).full;
+  sheetDetail_ = wallpapers::deleteConsequence(wallpapers::isBuiltInFile(sheetFile_), index == activeIndex_);
+  view_ = View::Sheet;
+  interactionsReady_ = false;
+  LOG_INF("WALL", "hold sheet for %s (index %d, active %d)", sheetFile_.c_str(), index, activeIndex_);
+  requestUpdate();
+}
+
+// The one destructive thing this app does.
+//
+// Resolves the NAME rather than reusing sheetIndex_: between the hold and the
+// confirm the library can have been re-sorted by an upload, and an index is a
+// position in that order. A name that no longer resolves means the file is
+// already gone, and doing nothing is right -- deleting "whatever is at slot 4
+// now" is exactly the bug this app is shaped to avoid.
+//
+// /sleep.bmp is NOT touched. It is a self-contained copy, so a deleted
+// wallpaper stays on the sleep screen until another is chosen; the confirm says
+// so (wallpapers::deleteConsequence), because a user who believed otherwise
+// would delete a second time looking for an effect that never comes.
+bool WallpapersActivity::deleteWallpaper() {
+  if (sheetFile_.empty()) return false;
+  const auto found = std::find(names_.begin(), names_.end(), sheetFile_);
+  if (found == names_.end()) {
+    LOG_INF("WALL", "delete: %s is no longer in the library; nothing to do", sheetFile_.c_str());
+    return false;
+  }
+  const std::string path = std::string(wallpapers::kLibraryDir) + "/" + sheetFile_;
+  if (!Storage.remove(path.c_str())) {
+    LOG_ERR("WALL", "Card refused to delete %s", path.c_str());
+    return false;
+  }
+  // The thumbnail cache is keyed on the file name, so a later upload of a file
+  // with the same name would otherwise draw the DELETED picture from cache.
+  // thumbFor's staleness check compares the source's size and mtime, which a
+  // fresh 48062-byte wallpaper can match by construction.
+  const std::string cache = std::string(kThumbDir) + "/" + sheetFile_ + ".thb";
+  Storage.remove(cache.c_str());
+  LOG_INF("WALL", "deleted %s", path.c_str());
+
+  // Re-derive everything from the card. builtInsMissing_ changes here whenever
+  // the deleted file was a built-in, and that flips specialTiles() from 1 to 2
+  // -- every wallpaper shifts one cell along. Nothing may act on the old
+  // numbering, which is why this is a full rescan and not an erase from names_.
+  sheetIndex_ = -1;
+  sheetFile_.clear();
+  scanLibrary();
+  loadActive();
+  clampPage();
+  cachedPage_ = -1;
+  pickView();
+  return true;
+}
+
+// The wallpaper at 1:1, and nothing else. No chrome, no button hints, no border:
+// what is on the panel here is what the sleep screen puts there, which is the
+// whole question Mario asked ("a way to preview the wallpaper without turning
+// off the device"). Anything drawn over it would be answering a different one.
+//
+// The placement arithmetic is SleepActivity's non-oversize branch, reproduced
+// rather than called: calculateBitmapPlacement is file-local to SleepActivity
+// (upstream's file, not ours to widen). It is the identity for every wallpaper
+// this app ships or produces -- kWallpaperFileBytes pins them all at 480x800,
+// exactly the panel -- so the two agree on every file that can be here. A
+// stray hand-copied BMP of another size centres instead of cropping; it is
+// still the picture, and it is not a file any path in this app creates.
+void WallpapersActivity::renderPreview() {
+  const int pageWidth = renderer.getScreenWidth();
+  const int pageHeight = renderer.getScreenHeight();
+  renderer.clearScreen();
+
+  const std::string path = std::string(wallpapers::kLibraryDir) + "/" + sheetFile_;
+  HalFile file;
+  bool drawn = false;
+  if (Storage.openFileForRead("WALL", path, file)) {
+    Bitmap bitmap(file, true);
+    if (bitmap.parseHeaders() == BmpReaderError::Ok) {
+      const int w = bitmap.getWidth();
+      const int h = bitmap.getHeight();
+      const int x = w <= pageWidth ? (pageWidth - w) / 2 : 0;
+      const int y = h <= pageHeight ? (pageHeight - h) / 2 : 0;
+      renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, 0.0f, 0.0f);
+      drawn = true;
+    }
+    file.close();
+  }
+
+  // A Frame with nothing built empties the hit table, so the sheet's DELETE
+  // cannot still be routable while a full-screen picture covers it. It also
+  // gives the one failure path here somewhere to put words: a blank panel reads
+  // as a crash, twice confirmed by cold testers in this fork.
+  fui::GfxRendererTarget target = toybox::makeTarget(renderer, toybox::readingChromeFaces());
+  const fui::DeviceContext device = target.deviceContext();
+  const fui::InputSnapshot noInput{};
+  toybox::Frame frame(target, device, noInput, interactions_);
+  toybox::Screen surface(frame, toybox::themeTokens());
+  if (!drawn) {
+    LOG_ERR("WALL", "preview: cannot draw %s", path.c_str());
+    wallpapersui::NoticeModel model;
+    model.headline = "CANNOT PREVIEW";
+    model.body = "This file could not be opened as a wallpaper. Tap anywhere to go back.";
+    wallpapersui::buildNotice(surface, model);
+  }
+  interactionsReady_ = false;
+  renderer.displayBuffer();
+  painted_ = true;
+}
 
 // The address the phone opens. Station mode only: the hotspot has no NAT and a
 // captive-portal DNS that answers every name with this device, so a phone joined
@@ -1165,6 +1287,23 @@ void WallpapersActivity::loop() {
   }
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+    // Back unwinds the hold branch one step at a time. From the confirm it goes
+    // to the sheet, NOT to the grid: Back on a confirm means "not that", and
+    // dropping the user two screens back would make them start the hold again
+    // to reach the preview they were actually after.
+    if (view_ == View::Confirm || view_ == View::Preview) {
+      view_ = View::Sheet;
+      interactionsReady_ = false;
+      requestUpdate();
+      return;
+    }
+    if (view_ == View::Sheet) {
+      sheetIndex_ = -1;
+      sheetFile_.clear();
+      pickView();
+      requestUpdate();
+      return;
+    }
     if (view_ == View::Help || view_ == View::Notice || view_ == View::Add) {
       stopAddServer();
       pickView();
@@ -1175,9 +1314,25 @@ void WallpapersActivity::loop() {
     shelf::leave(renderer, mappedInput);
     return;
   }
-  // The Offer and Notice screens carry real buttons, so their taps go through
-  // Interactions rather than the grid's geometry hit-test.
-  if (view_ == View::Offer || view_ == View::Notice) {
+
+  // The preview has no controls at all, on purpose: it is the sleep screen, and
+  // the way out is anywhere on it. Said on the sheet before it opens, because
+  // this screen has nowhere to say it.
+  if (view_ == View::Preview) {
+    int px = 0;
+    int py = 0;
+    if (!mappedInput.wasScreenTapped(px, py)) return;
+    view_ = View::Sheet;
+    interactionsReady_ = false;
+    requestUpdate();
+    return;
+  }
+  // The Offer, Notice, Sheet and Confirm screens carry real buttons, so their
+  // taps go through Interactions rather than the grid's geometry hit-test.
+  // Interactions::route() refuses a tap routed against a table the panel has
+  // not shown yet, which is what stops a tap aimed at the screen underneath
+  // from landing on the one that replaced it during a 0.3-2s e-ink repaint.
+  if (view_ == View::Offer || view_ == View::Notice || view_ == View::Sheet || view_ == View::Confirm) {
     int ax = 0;
     int ay = 0;
     if (!mappedInput.wasScreenTapped(ax, ay) || !interactionsReady_) return;
@@ -1196,6 +1351,28 @@ void WallpapersActivity::loop() {
         return;
       case wallpapersui::ActionDismiss:
         pickView();
+        requestUpdate();
+        return;
+      case wallpapersui::ActionPreview:
+        view_ = View::Preview;
+        interactionsReady_ = false;
+        requestUpdate();
+        return;
+      case wallpapersui::ActionDelete:
+        // Opens the question. Deletes nothing -- which is what makes this the
+        // safe half of the pair the confirm reuses the pixels of.
+        view_ = View::Confirm;
+        interactionsReady_ = false;
+        requestUpdate();
+        return;
+      case wallpapersui::ActionKeep:
+        view_ = View::Sheet;
+        interactionsReady_ = false;
+        requestUpdate();
+        return;
+      case wallpapersui::ActionConfirmDelete:
+        deleteWallpaper();
+        interactionsReady_ = false;
         requestUpdate();
         return;
       default:
@@ -1269,26 +1446,40 @@ void WallpapersActivity::loop() {
     return;
   }
   const int idx = combined - specials;
-  // A hold the classifier missed arrives here as a tap, and a tap on this grid
-  // SETS the sleep screen with no confirmation -- so a user reaching for the
-  // hold sheet would get the one thing they were reaching past. Doing nothing
-  // is the right failure: the hold is repeatable, an unasked-for sleep screen
-  // is not. (Once the sheet exists this routes to it instead of returning.)
-  if (mappedInput.tapWasHeldLong()) return;
-  if (idx == activeIndex_) return;  // already the sleep screen
-  if (setWallpaper(idx)) requestUpdate();
+  // A hold the SDK's classifier missed arrives here as an ordinary tap --
+  // wasTouchTap has no duration gate -- and a tap on this grid SETS the sleep
+  // screen with no confirmation. tapWasHeldLong() is the only thing that tells
+  // the two apart, and the decision itself lives in WallpapersCore so it can be
+  // asserted: the simulator never compiles lib/hal or runs InputManager, so
+  // host-tests/wallpapers is the only place this is provable at all.
+  switch (wallpapers::cellAction(mappedInput.tapWasHeldLong(), idx, activeIndex_)) {
+    case wallpapers::CellAction::Sheet:
+      openSheet(idx);
+      return;
+    case wallpapers::CellAction::Set:
+      if (setWallpaper(idx)) requestUpdate();
+      return;
+    case wallpapers::CellAction::None:
+      return;
+  }
 }
 
 void WallpapersActivity::render(RenderLock&&) {
   const uint32_t tPaint = millis();
   clampPage();
+  // Before anything toybox: the preview draws no chrome and takes no theme.
+  if (view_ == View::Preview) {
+    renderPreview();
+    LOG_INF("WALL", "render preview took %ums", millis() - tPaint);
+    return;
+  }
   renderer.clearScreen();
   // Faces per view, not per app. The grid is a menu and wants the Jersey cut it
   // shares with the shelf; the offer, the progress and the notices are
   // SENTENCES, and at the 20px UI cut a sentence runs off the panel and is cut
   // with an ellipsis. Trivia carries the same split for the same reason.
   const bool prose = view_ == View::Offer || view_ == View::Fetching || view_ == View::Notice || view_ == View::Help ||
-                     view_ == View::Add;
+                     view_ == View::Add || view_ == View::Sheet || view_ == View::Confirm;
   // View::Add rebinds the SMALL slot to the bold reading cut so the address has
   // a cut of its own: see readingAddressFaces. Without it the headline, the
   // address, the prose and the footer all land on serif 14 and the one line the
@@ -1317,6 +1508,19 @@ void WallpapersActivity::render(RenderLock&&) {
     }
     const fui::Rect qr = wallpapersui::buildAdd(surface, model);
     QrUtils::drawQrCode(renderer, Rect{qr.x, qr.y, qr.width, qr.height}, addUrl_);
+  } else if (view_ == View::Sheet) {
+    wallpapersui::SheetModel model;
+    model.name = sheetName_.c_str();
+    // From the NAME, never from sheetIndex_: an upload arriving while the sheet
+    // is up re-sorts names_ and every index in it means a different picture.
+    model.isActive = activeIndex_ >= 0 && activeIndex_ < static_cast<int>(names_.size()) &&
+                     names_[static_cast<size_t>(activeIndex_)] == sheetFile_;
+    wallpapersui::buildSheet(surface, model);
+  } else if (view_ == View::Confirm) {
+    wallpapersui::ConfirmModel model;
+    model.name = sheetName_.c_str();
+    model.consequence = sheetDetail_.c_str();
+    wallpapersui::buildConfirm(surface, model);
   } else if (view_ == View::Help) {
     wallpapersui::buildHelp(surface);
   } else if (view_ == View::Fetching) {

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -789,11 +789,17 @@ void WallpapersActivity::openSheet(const int index) {
 
 // The one destructive thing this app does.
 //
-// Resolves the NAME rather than reusing sheetIndex_: between the hold and the
-// confirm the library can have been re-sorted by an upload, and an index is a
-// position in that order. A name that no longer resolves means the file is
+// Resolves the NAME rather than reusing sheetIndex_. An index is a position in
+// a sorted list, and this app re-sorts: scanLibrary() runs on every onEnter and
+// after every delete, and deleting a built-in also flips specialTiles() 1 -> 2
+// so every cell renumbers. A name that no longer resolves means the file is
 // already gone, and doing nothing is right -- deleting "whatever is at slot 4
 // now" is exactly the bug this app is shaped to avoid.
+//
+// Today no upload can land WHILE the sheet is up: addServer_ runs only in
+// View::Add and stopAddServer() is on the way out of it. That is a fact about
+// the current wiring, not a property, which is why this resolves the name
+// anyway rather than resting on it.
 //
 // /sleep.bmp is NOT touched. It is a self-contained copy, so a deleted
 // wallpaper stays on the sleep screen until another is chosen; the confirm says

--- a/src/apps_local/wallpapers/WallpapersActivity.h
+++ b/src/apps_local/wallpapers/WallpapersActivity.h
@@ -98,6 +98,10 @@ class WallpapersActivity final : public Activity {
   std::string sheetFile_;    // the file name, the identity that survives a re-sort
   std::string sheetName_;    // its display name, for the two screens' headline
   std::string sheetDetail_;  // the confirm's consequence sentence(s)
+  // Settled by openSheet on the LOOP task. render() runs on the other task with
+  // no lock between them, so it reads this rather than indexing names_, which
+  // deleteWallpaper clears and reallocates underneath it.
+  bool sheetIsActive_ = false;
 
   std::vector<std::string> names_;  // library file names, sorted
   int activeIndex_ = -1;            // which name is pinned, or -1

--- a/src/apps_local/wallpapers/WallpapersActivity.h
+++ b/src/apps_local/wallpapers/WallpapersActivity.h
@@ -50,7 +50,10 @@ class WallpapersActivity final : public Activity {
   // remembered "have I offered already" flag: a stored value that decides what
   // you see turns a reproducible screen into a nondeterministic one
   // (invisible-saved-state-reads-as-nondeterminism).
-  enum class View : uint8_t { Grid, Offer, Fetching, Notice, Help, Add };
+  // Sheet, Confirm and Preview are the hold branch. Preview draws NO chrome at
+  // all -- it is what the sleep screen puts on the glass, and a hint band over
+  // it would be a preview of something that never appears.
+  enum class View : uint8_t { Grid, Offer, Fetching, Notice, Help, Add, Sheet, Confirm, Preview };
   View view_ = View::Grid;
 
   void scanLibrary();
@@ -70,6 +73,9 @@ class WallpapersActivity final : public Activity {
   void loadActive();
   void computeWarning();
   bool setWallpaper(int index);  // copy /wallpapers/<index> -> /sleep.bmp
+  void openSheet(int index);     // a hold landed on this library index
+  bool deleteWallpaper();        // remove the sheet's wallpaper from the card
+  void renderPreview();          // the wallpaper at 1:1, nothing else on the panel
   int pageCount() const;         // over the whole library
   void clampPage();
   void ensureThumbsForPage();  // decode this page's cells if not cached
@@ -82,6 +88,16 @@ class WallpapersActivity final : public Activity {
   void drawGetSetTile(const wallpapersui::GridGeom& geom, const freeink::ui::Rect& th) const;
   int specialTiles() const;  // chrome tiles in front of the wallpapers
   void drawMarker(const freeink::ui::Rect& th) const;
+
+  // Which wallpaper the sheet, the confirm and the preview are about. Held as a
+  // NAME as well as an index because the index is a position in a list that
+  // deleting, uploading and page-turning all renumber, and a stale index would
+  // delete the wrong picture. The name is re-resolved to an index at the moment
+  // of the delete and the delete refuses if it no longer resolves.
+  int sheetIndex_ = -1;
+  std::string sheetFile_;    // the file name, the identity that survives a re-sort
+  std::string sheetName_;    // its display name, for the two screens' headline
+  std::string sheetDetail_;  // the confirm's consequence sentence(s)
 
   std::vector<std::string> names_;  // library file names, sorted
   int activeIndex_ = -1;            // which name is pinned, or -1

--- a/src/apps_local/wallpapers/WallpapersCore.cpp
+++ b/src/apps_local/wallpapers/WallpapersCore.cpp
@@ -103,6 +103,29 @@ DisplayName displayName(std::string_view fileName) {
   return DisplayName{own, own};
 }
 
+CellAction cellAction(const bool heldLong, const int index, const int activeIndex) {
+  if (index < 0) return CellAction::None;
+  // FIRST, above every other branch. A hold that the SDK classified as a tap is
+  // still a hold, and the thing the user was reaching past is setWallpaper --
+  // which has no confirmation and no undo.
+  if (heldLong) return CellAction::Sheet;
+  if (index == activeIndex) return CellAction::None;
+  return CellAction::Set;
+}
+
+std::string deleteConsequence(const bool builtIn, const bool isActive) {
+  std::string out;
+  if (builtIn) {
+    out += "A built-in wallpaper. Getting it back means downloading the whole set again, not just this one.";
+  } else {
+    out += "Your own wallpaper. The card holds the only copy, so this cannot be undone.";
+  }
+  if (isActive) {
+    out += " It stays on your sleep screen until you pick another.";
+  }
+  return out;
+}
+
 Room roomFor(bool queryOk, uint64_t freeBytes, uint64_t floorBytes) {
   if (!queryOk) return Room::Unknown;
   return freeBytes >= floorBytes ? Room::Ok : Room::TooFull;

--- a/src/apps_local/wallpapers/WallpapersCore.cpp
+++ b/src/apps_local/wallpapers/WallpapersCore.cpp
@@ -154,6 +154,11 @@ Reach reachOfPinnedSleep(const uint8_t sleepScreenMode, const bool quickResumeAf
                                                                                 : Reach::OutsideReaderOnly;
 }
 
+bool saysOnSleepScreen(const bool isMarked, const Reach reach) {
+  if (!isMarked) return false;
+  return reach == Reach::Always || reach == Reach::OutsideReaderOnly;
+}
+
 const char* reachHint(const Reach reach) {
   // Every sentence names the setting the way SETTINGS names it ("Sleep Screen",
   // "Quick Resume on Timeout", english.yaml), because a hint that describes a

--- a/src/apps_local/wallpapers/WallpapersCore.h
+++ b/src/apps_local/wallpapers/WallpapersCore.h
@@ -99,6 +99,41 @@ bool isBuiltInFile(std::string_view fileName);
 // twenty-one defaults.
 bool sortsBefore(std::string_view a, std::string_view b);
 
+// What a tap that landed on a wallpaper cell MEANS. Freestanding because it is
+// the one decision on this screen that a wrong answer makes destructive, and a
+// decision left inside loop() cannot be asserted anywhere -- the simulator never
+// compiles lib/hal and never runs InputManager, so the host suite is the only
+// place this can be proved at all.
+//
+// `heldLong` is MappedInputManager::tapWasHeldLong(): the SDK's wasTouchTap has
+// no duration gate, so a hold arrives here as an ordinary tap and only that
+// call tells the two apart. It wins over every other branch, INCLUDING the
+// already-set one: holding the wallpaper you are already using is how you reach
+// its preview and its delete, and returning None there would make the sheet
+// unreachable for exactly one wallpaper -- the one most likely to be held.
+enum class CellAction : uint8_t {
+  None,   // nothing to do (a plain tap on the wallpaper already in use)
+  Set,    // pin it as the sleep screen
+  Sheet,  // open the hold sheet for it
+};
+CellAction cellAction(bool heldLong, int index, int activeIndex);
+
+// What the delete confirm has to say, before it is asked. Two clauses, each
+// conditional, and a caveat assembled per render is a caveat that can silently
+// lose a branch (a-warning-that-can-vanish) -- so it is built HERE, where a
+// host test walks all four combinations rather than the one somebody looked at.
+//
+// Clause 1, for a built-in: recovery is NOT an undo. runSetDownload fetches the
+// whole ~1MB pack unconditionally (no Range), behind the WiFi picker and behind
+// a 12MB + pack free-space floor; only the unpack skips files already present.
+// So the honest sentence is "the whole set again", not "you can get it back".
+//
+// Clause 2, for the wallpaper currently pinned: /sleep.bmp is a COPY, so
+// deleting the library file does not take the picture off the sleep screen. A
+// confirm that let the user believe it did would be wrong in the direction that
+// makes them delete twice.
+std::string deleteConsequence(bool builtIn, bool isActive);
+
 enum class Room : uint8_t { Ok, TooFull, Unknown };
 Room roomFor(bool queryOk, uint64_t freeBytes, uint64_t floorBytes);
 

--- a/src/apps_local/wallpapers/WallpapersCore.h
+++ b/src/apps_local/wallpapers/WallpapersCore.h
@@ -200,6 +200,24 @@ enum class Reach : uint8_t {
 };
 Reach reachOfPinnedSleep(uint8_t sleepScreenMode, bool quickResumeAfterTimeout);
 
+// Whether the hold sheet and the delete confirm get to SAY a wallpaper is on
+// the sleep screen. Not the same question as the grid's marker, and the two
+// came apart in the merge that brought #354 onto this branch.
+//
+// The marker asks "is this the pinned file", and #354 deliberately widened it:
+// loadActive() is no longer gated on sleepScreen == CUSTOM, so a wallpaper
+// wears the marker under DARK, LIGHT, BLANK and quick-resume too. The grid
+// qualifies that with the hint strip. The sheet ("This one is on your sleep
+// screen now.") and the confirm ("It stays on your sleep screen until you pick
+// another.") carry no strip and no room for one, so they ask the stronger
+// question here instead -- otherwise both assert something false under exactly
+// the settings #354 exists to expose.
+//
+// OutsideReaderOnly still counts as yes: the picture does show on an ordinary
+// sleep, and the book-cover exception is the strip's to explain, not a reason
+// to deny the sentence outright.
+bool saysOnSleepScreen(bool isMarked, Reach reach);
+
 // The sentence for the picker's hint strip when NOTHING was selected this
 // session, or nullptr when there is nothing to say. Short on purpose: the strip
 // is one fixed 30px line and a cut sentence is the defect it exists to avoid

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -57,6 +57,27 @@ constexpr int16_t kMarkerGap = 5;
 constexpr int16_t kMarkerWeight = 4;
 constexpr int16_t kBracketArm = 30;
 
+// The hold sheet's button stack, measured DOWN from the body top rather than up
+// from the panel bottom: the confirm screen puts a third button below the
+// sheet's two (see confirmDeleteRect) and anchoring to the bottom would have no
+// room left for it. Panel-absolute at safe.y = 0: 470..534, 554..618, 638..702.
+//
+// 470 rather than the 380 this was first drawn at. At 380 the confirm's prose
+// had five 42px lines for a sentence that needs six, and the clause it dropped
+// was the SECOND one -- "it stays on your sleep screen until you pick another"
+// -- so the confirm for the wallpaper actually in use silently lost the only
+// line that was about it (a-warning-that-can-vanish). Found in a render; no
+// suite could see it, which is why host-tests/wallcaption now measures every
+// combination of that sentence against the box below in the real face.
+constexpr int16_t kSheetStackTop = 470;
+constexpr int16_t kSheetButtonGap = 20;
+
+// The headline the sheet and the confirm both hang their prose off: two lines
+// of the display cut (63px each on this panel) plus slack. Two because a
+// wallpaper the user added is named by its FILE, and file names are the one
+// string on these screens nobody chose for its width.
+constexpr int16_t kSheetHeadH = 132;
+
 // The wallpaper's own shape. Sleep wallpapers are portrait 480x800 on this
 // device (verified: a 480x800 image fills the sleep screen), so the cells are
 // too and a thumbnail of a matching wallpaper fills its cell with no letterbox.
@@ -380,11 +401,11 @@ constexpr const char* kFoot = "BACK STOPS";
 // from the panel edge, eating the whole page margin. The box came across from
 // the twin and the font did not. Sized from the bound face now, so it cannot
 // happen again when the face changes.
-void drawFoot(toybox::Screen& screen, const fui::Rect& body) {
+void drawFoot(toybox::Screen& screen, const fui::Rect& body, const char* label = kFoot) {
   fui::TextStyle style = onPaper(screen.theme().bodyText, fui::TextAlign::Center, 1);
   const int16_t lineH = screen.target().lineHeight(style.font);
   const fui::Rect box = fui::makeRect(body.x, static_cast<int16_t>(body.bottom() - lineH), body.width, lineH);
-  screen.target().text(box, toybox::fittedTitle(screen.target(), kFoot, box.width, style).c_str(), style);
+  screen.target().text(box, toybox::fittedTitle(screen.target(), label, box.width, style).c_str(), style);
 }
 
 // The headline is the only thing on this screen that gets the display cut, and
@@ -620,6 +641,103 @@ void buildNotice(toybox::Screen& screen, const NoticeModel& model) {
                fui::makeRect(left, static_cast<int16_t>(body.y + body.height - kButtonH - 44), body.width, kButtonH),
                model.actionLabel, model.action);
   }
+}
+
+// ---------------------------------------------------------------------------
+// THE HOLD SHEET, AND THE ONE DESTRUCTIVE BUTTON IN THIS APP.
+//
+// Reached by holding a cell, never by tapping one. The header says WALLPAPER
+// (singular) so the screen names its own subject: the grid behind it says
+// WALLPAPERS, and two screens with one title is how a user loses track of which
+// one they are on.
+
+namespace {
+// One derivation, four rects. Every one of them hangs off safe.y and off the
+// two constants above, so moving the stack moves the confirm with it and the
+// "keep is where delete was" identity cannot be broken by editing one of them.
+int16_t stackSlot(const fui::DeviceContext& device, const int index) {
+  return static_cast<int16_t>(device.safeRect().y + kSheetStackTop + index * (kSheetButtonH + kSheetButtonGap));
+}
+fui::Rect stackRect(const fui::DeviceContext& device, const int index) {
+  const fui::Rect safe = device.safeRect();
+  return fui::makeRect(static_cast<int16_t>(safe.x + toybox::kMargin), stackSlot(device, index),
+                       static_cast<int16_t>(safe.width - toybox::kMargin * 2), kSheetButtonH);
+}
+}  // namespace
+
+fui::Rect sheetHeadRect(const fui::DeviceContext& device) {
+  const fui::Rect safe = device.safeRect();
+  return fui::makeRect(static_cast<int16_t>(safe.x + toybox::kMargin),
+                       static_cast<int16_t>(safe.y + kBodyTop + toybox::kGutter),
+                       static_cast<int16_t>(safe.width - toybox::kMargin * 2), kSheetHeadH);
+}
+
+// The prose box on each screen: from under the headline down to the first
+// control. Derived from BOTH ends rather than given a height, so moving the
+// button stack or the headline cannot leave a sentence overlapping a button --
+// it makes the box shorter, and the box is what host-tests/wallcaption measures
+// the sentence against.
+namespace {
+fui::Rect proseTo(const fui::DeviceContext& device, const fui::Rect& firstControl) {
+  const fui::Rect head = sheetHeadRect(device);
+  const int16_t top = static_cast<int16_t>(head.bottom() + toybox::kGutter);
+  const int16_t bottom = static_cast<int16_t>(firstControl.y - toybox::kGutter);
+  return fui::makeRect(head.x, top, head.width, static_cast<int16_t>(bottom > top ? bottom - top : 0));
+}
+}  // namespace
+
+fui::Rect sheetPreviewRect(const fui::DeviceContext& device) { return stackRect(device, 0); }
+fui::Rect sheetDeleteRect(const fui::DeviceContext& device) { return stackRect(device, 1); }
+// Deliberately the SAME rect as the sheet's DELETE. Not a coincidence to be
+// tidied away: it is the whole defence, and host-tests/wallcaption asserts the
+// two are identical rather than merely close.
+fui::Rect confirmKeepRect(const fui::DeviceContext& device) { return sheetDeleteRect(device); }
+fui::Rect confirmDeleteRect(const fui::DeviceContext& device) { return stackRect(device, 2); }
+
+fui::Rect sheetProseRect(const fui::DeviceContext& device) { return proseTo(device, sheetPreviewRect(device)); }
+fui::Rect confirmProseRect(const fui::DeviceContext& device) { return proseTo(device, confirmKeepRect(device)); }
+
+void buildSheet(toybox::Screen& screen, const SheetModel& model) {
+  chrome(screen, "WALLPAPER", nullptr);
+  const fui::DeviceContext device = screen.frame().device();
+
+  // The name, on two lines of the display cut. Everything on these two screens
+  // is laid out against the published rects rather than against screen.body(),
+  // for the same reason the grid is: the safety proof in host-tests/wallcaption
+  // has to read the SAME rectangles the drawing does.
+  fui::TextStyle head = onPaper(screen.theme().titleText, fui::TextAlign::Left, 2);
+  const fui::Rect headBox = sheetHeadRect(device);
+  screen.target().text(headBox, toybox::fitLines(screen.target(), model.name, headBox.width, 2, head).c_str(), head);
+
+  // What each button does, BEFORE it is pressed. Preview leaves no chrome on
+  // the panel on purpose -- it is the sleep screen, and a hint band drawn over
+  // it would be a preview of something the sleep screen never shows -- so the
+  // way back out has to be said here instead, where there is room for it.
+  drawProse(screen, sheetProseRect(device),
+            model.isActive ? "This one is on your sleep screen now. Preview fills the panel; tap it to come back."
+                           : "Preview fills the panel exactly as the sleep screen draws it; tap it to come back.",
+            fui::TextAlign::Left);
+
+  drawButton(screen, sheetPreviewRect(device), "PREVIEW", ActionPreview);
+  drawButton(screen, sheetDeleteRect(device), "DELETE", ActionDelete);
+  drawFoot(screen, screen.body(), "BACK RETURNS");
+}
+
+void buildConfirm(toybox::Screen& screen, const ConfirmModel& model) {
+  chrome(screen, "DELETE WALLPAPER", nullptr);
+  const fui::DeviceContext device = screen.frame().device();
+
+  fui::TextStyle head = onPaper(screen.theme().titleText, fui::TextAlign::Left, 2);
+  const fui::Rect headBox = sheetHeadRect(device);
+  screen.target().text(headBox, toybox::fitLines(screen.target(), model.name, headBox.width, 2, head).c_str(), head);
+
+  drawProse(screen, confirmProseRect(device), model.consequence, fui::TextAlign::Left);
+
+  // KEEP IT first, and on the pixels the sheet's DELETE occupied. A repeat of
+  // the press that got here is a cancel, by construction rather than by luck.
+  drawButton(screen, confirmKeepRect(device), "KEEP IT", ActionKeep);
+  drawButton(screen, confirmDeleteRect(device), "DELETE IT", ActionConfirmDelete);
+  drawFoot(screen, screen.body(), "BACK KEEPS IT");
 }
 
 }  // namespace wallpapersui

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -678,11 +678,20 @@ void buildNotice(toybox::Screen& screen, const NoticeModel& model) {
 // one they are on.
 
 namespace {
-// One derivation, four rects. Every one of them hangs off safe.y and off the
-// two constants above, so moving the stack moves the confirm with it and the
-// "keep is where delete was" identity cannot be broken by editing one of them.
+// One derivation, four rects. Every one of them hangs off the two constants
+// above, so moving the stack moves the confirm with it and the "keep is where
+// delete was" identity cannot be broken by editing one of them.
+//
+// Card 358: the ROW is absolute, the sides are not. kSheetStackTop is measured
+// down from the body top, and that body top is pinned at panel row 0 by
+// absoluteChrome -- the header band already paints over the rows the glass
+// hides. Adding safe.y here was the same double count card 358 took out of
+// gridGeom and buildGridChrome, and it put these two screens ten pixels below
+// every other app's body. Left and width still come off the safe rect, because
+// the bezel really does cover a column on each side.
 int16_t stackSlot(const fui::DeviceContext& device, const int index) {
-  return static_cast<int16_t>(device.safeRect().y + kSheetStackTop + index * (kSheetButtonH + kSheetButtonGap));
+  (void)device;
+  return static_cast<int16_t>(kSheetStackTop + index * (kSheetButtonH + kSheetButtonGap));
 }
 fui::Rect stackRect(const fui::DeviceContext& device, const int index) {
   const fui::Rect safe = device.safeRect();
@@ -693,8 +702,8 @@ fui::Rect stackRect(const fui::DeviceContext& device, const int index) {
 
 fui::Rect sheetHeadRect(const fui::DeviceContext& device) {
   const fui::Rect safe = device.safeRect();
-  return fui::makeRect(static_cast<int16_t>(safe.x + toybox::kMargin),
-                       static_cast<int16_t>(safe.y + kBodyTop + toybox::kGutter),
+  // Absolute row, safe-rect sides. See stackSlot and toybox::kBodyTop.
+  return fui::makeRect(static_cast<int16_t>(safe.x + toybox::kMargin), static_cast<int16_t>(kBodyTop + toybox::kGutter),
                        static_cast<int16_t>(safe.width - toybox::kMargin * 2), kSheetHeadH);
 }
 

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -697,26 +697,46 @@ fui::Rect confirmDeleteRect(const fui::DeviceContext& device) { return stackRect
 fui::Rect sheetProseRect(const fui::DeviceContext& device) { return proseTo(device, sheetPreviewRect(device)); }
 fui::Rect confirmProseRect(const fui::DeviceContext& device) { return proseTo(device, confirmKeepRect(device)); }
 
+namespace {
+// The name, at the largest cut that holds it on two lines.
+//
+// fittedTitle, NOT a bare fitLines at the display cut. A wallpaper the user
+// added is named by its FILE, which is the one string on these screens nobody
+// chose the width of, and an ordinary phone name -- "SCREENSHOT 2026 09 05 AT
+// 14 23 07" -- overflows two lines of the display cut. A bare fitLines answers
+// that by appending U+2026, and NO Toybox cut above toybox_10 carries that
+// glyph: it draws as a HOLE, so the name stops mid-word with a gap after it on
+// the screen that is about to delete it (typography-fold). fittedTitle steps
+// the cut DOWN first and only marks at the smallest, which is the one that can
+// really draw the mark. Same rule the add screen's address arrived at.
+std::string drawSheetName(toybox::Screen& screen, const fui::Rect& box, const char* name) {
+  fui::TextStyle style = onPaper(screen.theme().titleText, fui::TextAlign::Left, 2);
+  const std::string drawn = toybox::fittedTitle(screen.target(), name, box.width, style);
+  screen.target().text(box, drawn.c_str(), style);
+  return drawn;
+}
+}  // namespace
+
+const char* sheetInstruction(const bool isActive) {
+  return isActive ? "This one is on your sleep screen now. Preview fills the panel; tap it to come back."
+                  : "Preview fills the panel exactly as the sleep screen draws it; tap it to come back.";
+}
+
 void buildSheet(toybox::Screen& screen, const SheetModel& model) {
   chrome(screen, "WALLPAPER", nullptr);
   const fui::DeviceContext device = screen.frame().device();
 
-  // The name, on two lines of the display cut. Everything on these two screens
-  // is laid out against the published rects rather than against screen.body(),
-  // for the same reason the grid is: the safety proof in host-tests/wallcaption
-  // has to read the SAME rectangles the drawing does.
-  fui::TextStyle head = onPaper(screen.theme().titleText, fui::TextAlign::Left, 2);
-  const fui::Rect headBox = sheetHeadRect(device);
-  screen.target().text(headBox, toybox::fitLines(screen.target(), model.name, headBox.width, 2, head).c_str(), head);
+  // Everything on these two screens is laid out against the published rects
+  // rather than against screen.body(), for the same reason the grid is: the
+  // safety proof in host-tests/wallcaption has to read the SAME rectangles the
+  // drawing does.
+  drawSheetName(screen, sheetHeadRect(device), model.name);
 
   // What each button does, BEFORE it is pressed. Preview leaves no chrome on
   // the panel on purpose -- it is the sleep screen, and a hint band drawn over
   // it would be a preview of something the sleep screen never shows -- so the
   // way back out has to be said here instead, where there is room for it.
-  drawProse(screen, sheetProseRect(device),
-            model.isActive ? "This one is on your sleep screen now. Preview fills the panel; tap it to come back."
-                           : "Preview fills the panel exactly as the sleep screen draws it; tap it to come back.",
-            fui::TextAlign::Left);
+  drawProse(screen, sheetProseRect(device), sheetInstruction(model.isActive), fui::TextAlign::Left);
 
   drawButton(screen, sheetPreviewRect(device), "PREVIEW", ActionPreview);
   drawButton(screen, sheetDeleteRect(device), "DELETE", ActionDelete);
@@ -727,9 +747,7 @@ void buildConfirm(toybox::Screen& screen, const ConfirmModel& model) {
   chrome(screen, "DELETE WALLPAPER", nullptr);
   const fui::DeviceContext device = screen.frame().device();
 
-  fui::TextStyle head = onPaper(screen.theme().titleText, fui::TextAlign::Left, 2);
-  const fui::Rect headBox = sheetHeadRect(device);
-  screen.target().text(headBox, toybox::fitLines(screen.target(), model.name, headBox.width, 2, head).c_str(), head);
+  drawSheetName(screen, sheetHeadRect(device), model.name);
 
   drawProse(screen, confirmProseRect(device), model.consequence, fui::TextAlign::Left);
 

--- a/src/apps_local/wallpapers/WallpapersScreens.h
+++ b/src/apps_local/wallpapers/WallpapersScreens.h
@@ -73,7 +73,71 @@ enum : fui::ActionId {
   ActionAddOwn = 2,   // the "make your own in a browser" card
   ActionRetry = 3,    // try the fetch again after a failure
   ActionDismiss = 4,  // acknowledge a notice and go back to whatever is on the card
+  // The hold sheet, and the confirm behind its DELETE.
+  ActionPreview = 5,        // show this wallpaper full screen, as the sleep screen draws it
+  ActionDelete = 6,         // ask to delete it -- opens the confirm, deletes nothing
+  ActionKeep = 7,           // the confirm's safe half: leave it alone
+  ActionConfirmDelete = 8,  // the only destructive control in this app
 };
+
+// ---------------------------------------------------------------------------
+// THE HOLD SHEET AND ITS CONFIRM, and why their rectangles are public.
+//
+// This fork has destroyed user data by putting a new meaning under a pixel a
+// finger was already travelling towards (same-pixel-different-action). The
+// wallpapers grid is the worst possible host for that: a tap on a cell SETS the
+// sleep screen with no confirmation, and a hold arrives as a tap unless
+// MappedInputManager::tapWasHeldLong() says otherwise.
+//
+// So the two screens are laid out against ONE set of rectangles, published here
+// and asserted in host-tests/wallcaption, rather than each drawing its own:
+//
+//   * confirmKeepRect() IS sheetDeleteRect(), the same pixels. The button the
+//     user just pressed to reach the confirm becomes the SAFE half of it, so a
+//     second press of the same spot -- a double tap, an impatient repeat during
+//     the 0.3-2s e-ink repaint, a finger that never moved -- cancels. It cannot
+//     delete, because there is nothing destructive there to hit.
+//   * confirmDeleteRect() overlaps NEITHER of the sheet's controls. Reaching it
+//     takes a deliberate move to a place nothing was a moment ago.
+//
+// What this does NOT buy, said plainly because a reader will otherwise assume
+// it: the confirm's DELETE does sit over the grid's cells. It cannot not --
+// the cells span y 134..758 of an 800px panel and the only cell-free bands are
+// 46px, 24px and 42px tall, none of which holds a 64px finger target. The grid
+// is two screens and one 500ms hold away, and the interaction buffer refuses
+// every tap routed against a table the panel has not shown
+// (RevealedInteractions::route), so no single remembered tap can reach it.
+constexpr int16_t kSheetButtonH = 64;
+// The name, and the sentence under it. Published for the same reason the button
+// rects are: the sentence's four combinations are measured against this box in
+// the real face by host-tests/wallcaption, and a box read from screen.body()
+// could not be. The prose box is derived from BOTH ends -- under the headline,
+// above the first control -- so moving either shrinks it rather than letting a
+// sentence run under a button.
+fui::Rect sheetHeadRect(const fui::DeviceContext& device);
+fui::Rect sheetProseRect(const fui::DeviceContext& device);
+fui::Rect confirmProseRect(const fui::DeviceContext& device);
+fui::Rect sheetPreviewRect(const fui::DeviceContext& device);
+fui::Rect sheetDeleteRect(const fui::DeviceContext& device);
+fui::Rect confirmKeepRect(const fui::DeviceContext& device);
+fui::Rect confirmDeleteRect(const fui::DeviceContext& device);
+
+// The sheet a hold opens: this one wallpaper, and the two things you can do to
+// it that a tap cannot.
+struct SheetModel {
+  const char* name = "";  // the wallpaper's display name, not its file name
+  bool isActive = false;  // it is the one currently on the sleep screen
+};
+void buildSheet(toybox::Screen& screen, const SheetModel& model);
+
+// The confirm behind DELETE. `consequence` comes from
+// wallpapers::deleteConsequence -- built there so all four of its combinations
+// are walked by a test rather than assembled per render.
+struct ConfirmModel {
+  const char* name = "";
+  const char* consequence = "";
+};
+void buildConfirm(toybox::Screen& screen, const ConfirmModel& model);
 
 // The BEFORE state: the built-in set is not on the card. This screen has to sell
 // the set and offer exactly one action, because an empty grid with a lone "+"

--- a/src/apps_local/wallpapers/WallpapersScreens.h
+++ b/src/apps_local/wallpapers/WallpapersScreens.h
@@ -130,6 +130,13 @@ struct SheetModel {
 };
 void buildSheet(toybox::Screen& screen, const SheetModel& model);
 
+// The sentence buildSheet draws under the name, in both its forms. Published
+// rather than typed inline, because host-tests/wallcaption measures it against
+// sheetProseRect in the real face -- and a test holding its own COPY of the
+// sentence keeps measuring the old one after the source is edited, and stays
+// green while the panel cuts it (derived-facts-written-as-literals).
+const char* sheetInstruction(bool isActive);
+
 // The confirm behind DELETE. `consequence` comes from
 // wallpapers::deleteConsequence -- built there so all four of its combinations
 // are walked by a test rather than assembled per render.


### PR DESCRIPTION
Mario, 2026-09-05: *"user uploaded wallpapers always come in front of the default ones and holding them allows deletion (even of the initial pack ones)"* and *"a way to preview the wallpaper without turning off the device"*.

Hold a wallpaper and you get a sheet for that one picture: **PREVIEW** fills the panel exactly as the sleep screen draws it, **DELETE** asks first. Pack wallpapers delete like any other, deliberately — the confirm says what getting one back costs instead of refusing.

---

## The stack is gone: #143 landed

This was stacked on `app/wallqr` (#143) because that PR carried
`MappedInputManager::tapWasHeldLong()`, the only thing that can tell a hold from
a tap. **#143 merged at 04:05:22Z**, its branch was deleted, GitHub auto-closed
#147 one second later, and this pull request replaced it against `xteink`.
`tapWasHeldLong()` is on trunk now, so there is no stack left and nothing has to
land ahead of this.

Against `xteink` the diff is card #365 alone: ten files, all of them the
wallpapers app, its three host suites and its design doc.

## Sorting was already shipped

`wallpapers::sortsBefore` has put a user's own files ahead of the built-ins since the picker landed, and `host-tests/wallpapers` already proved the ordering and the strict weak ordering. I confirmed it in a render (`holiday-in-lisbon` ahead of Bauhaus and Bulge) rather than rewriting it.

## A hold arrives as a tap, and this grid's tap is the destructive one

`InputManager::wasTouchTap` has **no duration gate**: a stationary finger held for five seconds satisfies all four of its questions and is delivered as an ordinary tap. On this grid a tap *sets the sleep screen*, with no confirmation and no undo — so a user reaching for the hold sheet would get the one thing they were reaching past.

The decision moved out of `loop()` into `wallpapers::cellAction(heldLong, index, activeIndex, sleepBlocked)`, because **the simulator cannot prove it**: it never compiles `lib/hal` and never runs `InputManager`. `host-tests/wallpapers` is the only place it exists at all, and it asserts the property rather than six cases — *a hold is never `Set`, for any index and any selection*. **I reverted the hold branch and watched it go red: 69 failing checks.**

A hold on the wallpaper **already in use** opens the sheet too. Returning `None` there would make the sheet unreachable for exactly one wallpaper — the one wearing the marker, and so the one most likely to be held.

## The destructive pixel is a rectangle identity, not a rule

This fork has destroyed user data by putting a new meaning under a pixel a finger was already travelling towards.

`confirmKeepRect()` returns **exactly** `sheetDeleteRect()`. The confirm's safe half occupies the pixels the button that opened it did, so a repeat of that press — a double tap, an impatient repeat during a 0.3–2s e-ink repaint, a finger that never moved — **cancels**, because there is nothing destructive there to hit. `confirmDeleteRect()` overlaps neither sheet control. Driven end to end in the simulator: `view 6 → 7 → 6 → 7`, the same pixel opening and then cancelling the confirm.

`host-tests/wallcaption` asserts the identity (identical, not "close") and the separation at **both** insets, bare panel and the X4 Pro's `T10 R1 B0 L1` glass. `host-tests/ui` asserts the two builders actually *draw into* those rects, which a helper-only test cannot see. **Both proved red first** — swapping the two rect functions gives 6 failures naming the identity by name.

**What this does not buy, stated in the header rather than assumed away:** the confirm's DELETE *does* sit over the grid's cells. It cannot not — the cells span y 134..758 of an 800px panel and the only cell-free bands are 46px, 24px and 42px, none of which holds a 64px finger target. The grid is two screens and one 500ms hold away, and `RevealedInteractions::route()` refuses any tap routed against a table the panel has not shown.

## The defect only a render could find

At the first cut the button stack sat at y=380, leaving the confirm's prose **five 42px lines for a sentence that needs six**. The clause it dropped was the *second* one — "It stays on your sleep screen until you pick another" — so the confirm for the wallpaper actually in use lost the only line that was about it.

`host-tests/ui` cannot see this: its draw target answers ten pixels a character. `wallcaption` now measures **all four combinations** of the sentence against the real box in the real face, at both insets — and earned its keep immediately, catching it a second time when the `kChromeHeight` merge shrank the box by a line.

## Preview draws no chrome at all

It is what the sleep screen puts on the glass; a hint band over it would be a preview of something that never appears. The way out is said on the sheet, where there is room: *"Preview fills the panel exactly as the sleep screen draws it; tap it to come back."*

The placement arithmetic **reproduces** `SleepActivity`'s non-oversize branch rather than calling it: `calculateBitmapPlacement` is file-local to upstream's `SleepActivity.cpp` and widening it is not ours to do. It is the identity for every wallpaper this app ships or produces — `kWallpaperFileBytes` pins them all at 480x800, exactly the panel.

## Delete

- **Resolves the file NAME, never the remembered index.** An upload arriving between the hold and the confirm re-sorts `names_`; deleting "whatever is at slot 4 now" is the bug this app is shaped around. A name that no longer resolves deletes nothing.
- **`/sleep.bmp` is untouched** — it is a self-contained copy, so a deleted wallpaper stays on the sleep screen until another is picked. The confirm says so, because a user who believed otherwise would delete a second time looking for an effect that never comes.
- **The thumbnail cache entry goes with it.** It is keyed on the file name, and `thumbFor`'s staleness check compares size and mtime — which a fresh 48,062-byte wallpaper can match by construction, drawing the deleted picture.
- **Full rescan, not an erase.** Deleting a built-in flips `specialTiles()` 1→2 and every wallpaper shifts one cell.

Also in here: the get-the-set tile read **"GET THE 1 BUILT-INS"**, now `GET %d MISSING`. That case was unreachable until a built-in could be deleted, so this PR is what makes it reachable.

---

## Merged with #354, #358 and #143, and what each side contributed

Three cards landed on trunk while this was open and all three touched these
files. Taking either side wholesale would have compiled, passed a suite and
silently deleted the other's work, so here is what survived.

**#354 (`app/wallsleep`)** -- four files conflicted.

| file | ours | theirs |
|---|---|---|
| `WallpapersCore.{h,cpp}` | `CellAction`, `cellAction()`, `deleteConsequence()` | the settings state that blocks a wallpaper from the glass |
| `WallpapersActivity.cpp` | the hold branch, `openSheet`, `View::Preview`'s early return | `sleepBlocked()`, the re-pin, the `COULD NOT SET IT` notice |
| `test_wallcaption.cpp` | the sheet's controls and the confirm's prose | the hint strip's sentences |

The tap handler is the one region rewritten rather than taken from a side, and
its order is load-bearing. `cellAction` grew a fourth `sleepBlocked` argument
instead of #354's rule being left as an early return beside the hold guard,
because as early returns the two compete for the same tap. The hold is asked
**first**, then the pin, then the failure notice -- so a hold the SDK classified
as a tap cannot fall through to `setWallpaper`, and cannot raise a notice for an
action the user never asked for.

Two things the auto-merge got wrong, neither of which any existing test saw:

- `test_wallpapers.cpp` merged **clean** while the signature it calls changed in
  a conflicted file, so it kept calling the three-argument `cellAction`.
- The sheet and the confirm each make a flat claim about the sleep screen and
  carry no hint strip to qualify it. #354 deliberately un-gated `loadActive()`,
  so a wallpaper wears the marker under DARK, LIGHT, BLANK and quick-resume too
  -- and both screens then asserted something false under exactly the settings
  #354 exists to expose. They ask `wallpapers::saysOnSleepScreen(isMarked,
  reach)` now. Stubbing it back to `return isMarked` fails 16 checks.

**#358 (`app/bodytop`)** merged with **no conflict at all**, which is the worst
way for it to arrive. It established that chrome-derived rows are absolute panel
rows and took the double count out of `gridGeom` and `buildGridChrome`;
`sheetHeadRect` and `stackSlot` still had it, so these two screens drew ten
pixels below every other app's body behind the glass. #358's own guard
(`testTheGlassNeverMovesABodyTop`) renders six screens and the only wallpapers
one is the **grid**, so a clean run of it said nothing about these two. The
guard is extended rather than replaced: `SheetModel` and `ConfirmModel` join the
six, both red before the fix and green after.

**#143 (`app/wallqr`)** -- three files conflicted. The one that mattered: it
renamed the QR payload so `addQrUrl_` carries the numeric address and `addUrl_`
the mDNS name, because encoding a `.local` name the device had already logged as
unresolvable sent users to change WiFi over a fault the reader had detected.
This branch's side of that conflict still passed `addUrl_` to `drawQrCode`;
taking it would have reverted a user-facing fix while compiling and passing
every suite. `View::Help` is gone here too, because #143 deleted `buildHelp`
with it.

Both load-bearing properties survive all three merges, and not by luck.
`confirmKeepRect()` returns `sheetDeleteRect()` by construction, so no shift can
separate them. The confirm's prose box is derived from **both** ends, so #358's
ten-pixel move changed its position and not its height -- `wallcaption` still
fits all four consequences at both insets.

## Not in scope

Shuffle and multi-select (PR 3, #305). Blocked on #354 landing, per the plan.

## What is NOT verified

- **Hardware. All of it.** The hold was driven through the simulator's input injector, which *fabricates* the held time; a real `InputManager` under a blocked loop — four 480x800 BMPs decoded off the card, then an e-ink repaint — is a different mechanism, and it is exactly the one the memory says can miss the 500ms window. Only the device can show that.
- The preview's 1:1 draw against a real sleep screen, side by side.
- Deleting on a real SD card (the sim's card is a directory).

Gate: `CHECKSH-VERDICT: green` (grepped for the token, not tailed).

Screens: `qa-artifacts/sheet.png`, `confirm.png`, `preview.png`, `after-delete.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




---

*Reopened as a new pull request: #147 was auto-closed when its base branch `app/wallqr` was deleted on merge. Same branch, same commits, retargeted to `xteink`.*

