### PR TITLE
Minesweeper: tapping a satisfied number chords its neighbours

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ the browser: it fetches the day's board and nothing can be canned for it.
 | **Connect Four** | Drop a disc, get four in a line. Seven columns, one tap each.                |
 | **Yahtzee**      | Thirteen boxes, three rolls a turn, and the Joker rules in full.             |
 | **Knucklebones** | Cult of the Lamb's dice game. Matching dice multiply; yours destroy theirs.  |
-| **Minesweeper**  | Tap to dig, hold to flag. The first dig is always safe.                      |
+| **Minesweeper**  | Tap to dig, hold to flag, tap a finished number to chord its neighbours.     |
 | **Sudoku**       | Generated on the device and graded by the technique it needs, not the clues. |
 | **Sea Salt**     | Sea Salt & Paper: collect duos, bet on STOP or LAST CHANCE.                  |
 | **Toy Battle**   | Nine boards of bases and paths. Hold regions, take medals, solo or nearby.   |

--- a/docs/apps/minesweeper.md
+++ b/docs/apps/minesweeper.md
@@ -8,8 +8,9 @@ just describes one case.
 ## The rules, and the two that are built in
 
 Tap a cell to dig it. A dug cell shows how many mines touch it, or floods its
-neighbours if that number is zero. Hold a cell to plant a flag. Dig every safe
-cell to win; dig a mine to lose.
+neighbours if that number is zero. Hold a cell to plant a flag. Tap a number
+that already carries all its flags to open the rest of its neighbours at once.
+Dig every safe cell to win; dig a mine to lose.
 
 Two properties are **constructed rather than sampled for**, which is this
 project's rule about promised properties:
@@ -24,6 +25,57 @@ dense board.
 **A flag stops the flood and cannot be torn off by it.** Losing a flag you
 placed deliberately to a cascade you did not aim is the most annoying thing this
 game can do.
+
+## Chording: a shortcut, never a second kind of move
+
+Tap a revealed number whose flag count already equals it and every remaining
+neighbour opens at once. It is the standard Minesweeper move, and the card that
+asked for it (#249) called its absence "the difference between playing and
+clicking": without it the same three-cell shape is opened by hand over and over
+on every board.
+
+**The gesture is a plain tap**, on a cell the player has learnt is spent. No new
+gesture was added, and that is deliberate: `wasTouchTap` has no duration gate on
+this platform, so a hold-to-chord would have had to fight the flag hold that
+already owns a long press. A press held past the 400ms flag threshold is
+swallowed and does not chord -- see the section below for why that is load
+bearing rather than an oversight.
+
+**A chord that finds a mine detonates.** The move trusts the player's flags, so
+a number whose count is right and whose placement is wrong opens a mine and ends
+the game. That is the real game, and the gentle alternative -- refusing the
+chord unless the flags are correct -- cannot be built without the game telling
+the player something it should not know. Mario's call, recorded on the card.
+
+**A count that does not match does nothing, silently.** No partial opening of
+"the ones that must be safe": that is the game doing the player's reasoning for
+them. `chord()` returns false and touches nothing, and the activity repaints
+only on a change, which is how this game already says no.
+
+The correctness is structural rather than promised: `chord()` calls `reveal()`
+on each neighbour in turn, so it reaches **byte-for-byte the state that tapping
+those cells one at a time would**. The flood, the loss, the win check and the
+saved board therefore need no knowledge of chording at all, and there is no
+second implementation that has to agree with the first. `reveal()` refuses
+everything once it has set `Lost`, so a detonating chord stops exactly where the
+taps would have. The host suite asserts that equivalence directly, on hand-built
+boards and on 585 chords found across 400 dealt ones.
+
+The routing -- what a tap on a cell *means* -- lives in `dig()` in the core,
+next to the rules, not in the activity: it is a rule, and the core is the only
+layer the host suite can prove.
+
+The simulator is not nothing here, and it is worth being exact about what it is.
+It substitutes its own `HalGPIO` rather than compiling `lib/hal`, and that stub
+does model suppression and touch-down routing -- a scripted `TAP:x,y,hold-ms`
+really does exercise the hold, the swallow and the lift, which is how the
+screenshots below were taken. What it cannot model is the device's **two** slop
+thresholds against its one, and that gap is precisely where the bug in the
+section below lives. Real, but not covering the case that mattered.
+
+The how-to gained a fifth page for it. Every other rule in this game can be
+found by tapping the board; this one cannot, because the cell it wants is one
+the player has been taught is finished.
 
 ## Tap to dig, hold to flag
 
@@ -46,6 +98,28 @@ Sliding to another cell restarts the hold, so dragging never plants a flag
 nobody meant, and the cell under a finger draws a heavy border while the hold
 builds: on this panel an unmarked hold is indistinguishable from a tap that
 missed.
+
+`swallowCurrentTouch` fires **unconditionally**, on every hold that reaches
+400ms, including holds on revealed cells where `toggleFlag` does nothing. That
+looks like a wart -- why eat a contact the hold ignored? -- and making it
+conditional is a way to dig a cell the finger never rested on:
+
+`isScreenTouchHeld` reports `touchUpPoint`, the **latest** contact sample, with
+no slop gate at all. `wasScreenTapped` reports `touchDownPoint`, the **first**
+sample, and stays valid until motion passes the 59px release slop
+(`TOUCH_TAP_RELEASE_SLOP_PX`, against a 28px stationary slop and a 60px cell). A
+finger that lands on covered cell A, rolls onto revealed cell B and rests there
+re-arms the hold at B; the hold fires at B, `toggleFlag` refuses, and the lift
+then taps **A**. The window is about one cell wide, and the cell it digs can be
+a mine.
+
+Suppressing the contact is the only thing making those two positions unable to
+disagree. The price is that a press held past 400ms on a number does not chord.
+Chording is a quick tap, which is what it is everywhere else, and that is the
+cheap half of the trade. Neither the host suite nor the simulator can catch the
+other half: the suite never touches the activity at all, and the simulator --
+which does model the hold, the swallow and the lift -- has one slop threshold
+where the device has two, so the 29-59px window does not exist there to be hit.
 
 ## The grid is hit-tested, not registered
 

--- a/host-tests/minesweeper/test_minesweeper.cpp
+++ b/host-tests/minesweeper/test_minesweeper.cpp
@@ -374,6 +374,491 @@ void testAFlaggedSafeCellIsNotCleared() {
   CHECK(game.status == Status::Won);
 }
 
+// --- chording ---------------------------------------------------------------
+//
+// Tapping a revealed number whose flags already equal it opens every remaining
+// neighbour at once. The card called it "the difference between playing and
+// clicking".
+//
+// The rule the owner picked is the unforgiving one, which is the real game: a
+// chord trusts the player's flags, so chording a number whose flags are in the
+// WRONG places opens a mine and loses. The gentler version cannot be built
+// without the game telling the player something it should not know.
+//
+// A chord is a SHORTCUT, not a new kind of move, and that is asserted directly
+// rather than described: it goes through reveal() cell by cell, so the flood,
+// the loss, the win and any saved board see exactly the sequence of taps it
+// replaces. testAChordIsExactlyTheTapsItReplaces is that claim.
+
+// A board with one mine at (3,0) and its neighbour (2,1) open, showing 1.
+// Flagging the mine satisfies (2,1), so a chord there opens the rest.
+Game satisfiedOne() {
+  Game game{};
+  start(game, 21u);
+  game.status = Status::Playing;
+  game.cell[3][0] |= kMine;
+  // Reveal by hand rather than by reveal(), which would flood the whole board
+  // and leave nothing for the chord to open.
+  game.cell[2][1] |= kRevealed;
+  return game;
+}
+
+// Every neighbour opens -- ALL of them, checked one at a time.
+//
+// The first version of this test could not see the difference between a chord
+// and a chord that opened only its first neighbour. Its board had a single mine
+// in a corner, so the first neighbour in reading order touched nothing, flooded
+// the entire field and WON; every later reveal() was then refused because the
+// status was Won, and the assertions passed on cells the flood had opened
+// rather than the chord. A mutant revealing one neighbour and stopping survived
+// it. (The comment also claimed five neighbours, the array listed six, and the
+// true count is seven.)
+//
+// So: mines in the two far corners as well, which walls the flood off, and the
+// expected set is DERIVED from the board rather than typed out.
+void testAChordOpensEveryNeighbourWhenTheFlagsMatch() {
+  Game game{};
+  start(game, 21u);
+  game.status = Status::Playing;
+  game.cell[3][0] |= kMine;
+  // Three more mines placed so that no neighbour of (2,1) is a zero -- each
+  // opened cell reveals itself and stops, so nothing floods and the chord is
+  // the only thing that could have opened all seven.
+  //
+  // They must sit OUTSIDE (2,1)'s own eight, or they change the number under
+  // test. The first attempt put them at (1,2) and (3,2), which are two of the
+  // neighbours, making the cell a 3 that the single flag no longer satisfied.
+  // These three are all two cells away in one axis.
+  game.cell[0][0] |= kMine;
+  game.cell[1][3] |= kMine;
+  game.cell[4][3] |= kMine;
+  game.cell[2][1] |= kRevealed;
+
+  CHECK(neighbouringMines(game, 2, 1) == 1);
+  CHECK(toggleFlag(game, 3, 0));
+  CHECK(neighbouringFlags(game, 2, 1) == 1);
+
+  // The expected set, derived: every neighbour that is covered and unflagged.
+  int expected[8][2];
+  int expectedCount = 0;
+  for (int dc = -1; dc <= 1; ++dc) {
+    for (int dr = -1; dr <= 1; ++dr) {
+      if (dc == 0 && dr == 0) continue;
+      const int c = 2 + dc;
+      const int r = 1 + dr;
+      if (!inside(c, r)) continue;
+      if (game.cell[c][r] & (kRevealed | kFlagged)) continue;
+      expected[expectedCount][0] = c;
+      expected[expectedCount][1] = r;
+      ++expectedCount;
+    }
+  }
+  // Seven: eight neighbours less the flagged mine. Asserted so a board edited
+  // later cannot quietly shrink what this test covers.
+  CHECK(expectedCount == 7);
+
+  const int before = revealedCount(game);
+  CHECK(chord(game, 2, 1));
+  CHECK(game.status == Status::Playing);
+  for (int i = 0; i < expectedCount; ++i) CHECK(game.cell[expected[i][0]][expected[i][1]] & kRevealed);
+  // And nothing beyond them: no flood ran, so exactly seven cells changed. This
+  // is the half that catches "opened the first one and stopped" in the other
+  // direction -- a chord that opened too much would fail here.
+  CHECK(revealedCount(game) - before == expectedCount);
+  CHECK((game.cell[3][0] & kRevealed) == 0);
+  CHECK(game.cell[3][0] & kFlagged);
+  // The other mines are still buried: a chord opens neighbours, never mines it
+  // was not pointed at.
+  CHECK((game.cell[0][0] & kRevealed) == 0);
+  CHECK((game.cell[1][3] & kRevealed) == 0);
+  CHECK((game.cell[4][3] & kRevealed) == 0);
+  // Every neighbour it opened is a number, which is what makes "exactly seven"
+  // meaningful rather than lucky.
+  for (int i = 0; i < expectedCount; ++i) {
+    CHECK(neighbouringMines(game, expected[i][0], expected[i][1]) > 0);
+  }
+}
+
+void testAChordWithTooFewFlagsDoesNothingAtAll() {
+  Game game = satisfiedOne();
+  // The number says 1 and no flag has been planted, so the move is refused.
+  // Silently: the activity repaints only when the rules report a change, so
+  // "false and nothing touched" is how this game says no.
+  Game before = game;
+  CHECK(neighbouringFlags(game, 2, 1) == 0);
+  CHECK(!chord(game, 2, 1));
+  CHECK(std::memcmp(&before, &game, sizeof(Game)) == 0);
+
+  // Too MANY flags is refused the same way, and does not partially open.
+  CHECK(toggleFlag(game, 3, 0));
+  CHECK(toggleFlag(game, 2, 0));
+  before = game;
+  CHECK(neighbouringFlags(game, 2, 1) == 2);
+  CHECK(!chord(game, 2, 1));
+  CHECK(std::memcmp(&before, &game, sizeof(Game)) == 0);
+}
+
+void testAChordNeedsARevealedNumberAndALiveGame() {
+  Game game = satisfiedOne();
+  CHECK(toggleFlag(game, 3, 0));
+
+  // A covered cell is not a number yet, whatever it will say later.
+  CHECK(!chord(game, 1, 1));
+  CHECK((game.cell[1][1] & kRevealed) == 0);
+  // Nor is a flagged one.
+  CHECK(!chord(game, 3, 0));
+  // Nor is anywhere off the board.
+  CHECK(!chord(game, -1, 0));
+  CHECK(!chord(game, kColumns, kRows));
+
+  // And a settled game accepts nothing, exactly as reveal() and toggleFlag()
+  // do not.
+  Game settled = satisfiedOne();
+  CHECK(toggleFlag(settled, 3, 0));
+  settled.status = Status::Lost;
+  Game before = settled;
+  CHECK(!chord(settled, 2, 1));
+  CHECK(std::memcmp(&before, &settled, sizeof(Game)) == 0);
+}
+
+void testAChordOnAWrongFlagLosesThroughTheSamePathAsATap() {
+  Game game{};
+  start(game, 77u);
+  game.status = Status::Playing;
+  game.cell[3][0] |= kMine;
+  game.cell[2][1] |= kRevealed;
+  // The count is right and the flag is in the wrong place: the player has
+  // asserted (2,0) is the mine, so the chord opens (3,0) and detonates.
+  CHECK(toggleFlag(game, 2, 0));
+  CHECK(neighbouringFlags(game, 2, 1) == 1);
+
+  CHECK(chord(game, 2, 1));
+  CHECK(game.status == Status::Lost);
+  CHECK(over(game));
+  // The losing path is reveal()'s, so the board is frozen the same way and the
+  // struck mine is bared the same way -- there is no second way to lose here.
+  CHECK(game.cell[3][0] & kRevealed);
+  CHECK(game.cell[3][0] & kMine);
+  CHECK(!reveal(game, 7, 9));
+  CHECK(!toggleFlag(game, 7, 9));
+  CHECK(!chord(game, 2, 1));
+}
+
+// --- an independent model of the rules --------------------------------------
+//
+// The invariant below is the headline claim, and the first version of it could
+// not fail. Its reference was a helper called byHand() that was chord()'s loop
+// body transcribed, so `chord(a) == byHand(b)` held for ANY implementation of
+// reveal, any board and any status -- 585 green checks proving that chord's
+// loop is byHand's loop. A test derived from the code's own assumption cannot
+// falsify it.
+//
+// So the reference is written from the RULEBOOK instead, sharing no code with
+// MinesweeperCore: its own mine count, its own recursive flood (the core uses
+// an explicit queue), its own win check, its own loss handling. A bug anywhere
+// in the core's flood, ordering, win detection or loss path now makes the two
+// disagree.
+
+int modelMinesAround(const Game& game, const int column, const int row) {
+  int count = 0;
+  for (int c = column - 1; c <= column + 1; ++c) {
+    for (int r = row - 1; r <= row + 1; ++r) {
+      if (c == column && r == row) continue;
+      if (c < 0 || c >= kColumns || r < 0 || r >= kRows) continue;
+      if (game.cell[c][r] & kMine) ++count;
+    }
+  }
+  return count;
+}
+
+int modelFlagsAround(const Game& game, const int column, const int row) {
+  int count = 0;
+  for (int c = column - 1; c <= column + 1; ++c) {
+    for (int r = row - 1; r <= row + 1; ++r) {
+      if (c == column && r == row) continue;
+      if (c < 0 || c >= kColumns || r < 0 || r >= kRows) continue;
+      if (game.cell[c][r] & kFlagged) ++count;
+    }
+  }
+  return count;
+}
+
+bool modelWon(const Game& game) {
+  for (int c = 0; c < kColumns; ++c) {
+    for (int r = 0; r < kRows; ++r) {
+      if (game.cell[c][r] & kMine) continue;
+      if ((game.cell[c][r] & kRevealed) == 0) return false;
+    }
+  }
+  return true;
+}
+
+// Recursion, where the core uses a queue. Eighty cells is nothing on a host.
+void modelOpen(Game& game, const int column, const int row) {
+  if (column < 0 || column >= kColumns || row < 0 || row >= kRows) return;
+  if (game.cell[column][row] & (kRevealed | kFlagged)) return;
+  game.cell[column][row] |= kRevealed;
+  if (modelMinesAround(game, column, row) != 0) return;
+  for (int c = column - 1; c <= column + 1; ++c) {
+    for (int r = row - 1; r <= row + 1; ++r) {
+      if (c == column && r == row) continue;
+      modelOpen(game, c, r);
+    }
+  }
+}
+
+// One dig, as the rulebook describes it.
+void modelDig(Game& game, const int column, const int row) {
+  if (game.status != Status::Playing) return;
+  if (column < 0 || column >= kColumns || row < 0 || row >= kRows) return;
+  if (game.cell[column][row] & (kRevealed | kFlagged)) return;
+  if (game.cell[column][row] & kMine) {
+    game.cell[column][row] |= kRevealed;
+    game.status = Status::Lost;
+    return;
+  }
+  modelOpen(game, column, row);
+  if (modelWon(game)) game.status = Status::Won;
+}
+
+// The chord, as the rulebook describes it: a live revealed number carrying
+// exactly its flags opens each remaining neighbour, in reading order, and stops
+// wherever the game stops.
+bool modelChord(Game& game, const int column, const int row) {
+  if (game.status != Status::Playing) return false;
+  if (column < 0 || column >= kColumns || row < 0 || row >= kRows) return false;
+  if ((game.cell[column][row] & kRevealed) == 0) return false;
+  if (modelFlagsAround(game, column, row) != modelMinesAround(game, column, row)) return false;
+  for (int c = column - 1; c <= column + 1; ++c) {
+    for (int r = row - 1; r <= row + 1; ++r) {
+      if (c == column && r == row) continue;
+      modelDig(game, c, r);
+    }
+  }
+  return true;
+}
+
+bool sameGame(const Game& a, const Game& b) { return std::memcmp(&a, &b, sizeof(Game)) == 0; }
+
+// The invariant worth asserting directly: a chord reaches the IDENTICAL board
+// state to revealing its remaining neighbours one at a time, in the same order.
+// Not a similar state, not the same count -- the same bytes, status and all. It
+// is what makes the win check, the loss, the flood and the saved board correct
+// for free rather than by a second implementation that has to agree.
+//
+// Equivalence is to REVEAL, not to dig: a chord does not recurse, so a
+// neighbour that becomes satisfied is not itself chorded. modelChord says so by
+// calling modelDig rather than itself.
+void testAChordIsExactlyTheRevealsItReplaces() {
+  // A zero among the neighbours, so the chord has to cascade and not merely
+  // uncover six cells. One mine in the corner, one flag on it, and (1,1) is
+  // the 1 that gets chorded.
+  Game chorded{};
+  start(chorded, 31u);
+  chorded.status = Status::Playing;
+  chorded.cell[0][0] |= kMine;
+  chorded.cell[1][1] |= kRevealed;
+  CHECK(toggleFlag(chorded, 0, 0));
+  Game modelled = chorded;
+
+  CHECK(chord(chorded, 1, 1));
+  CHECK(modelChord(modelled, 1, 1));
+  CHECK(sameGame(chorded, modelled));
+  // It really did cascade rather than stop at the eight neighbours: everything
+  // but the flagged mine is open, and that is a win.
+  CHECK(revealedCount(chorded) == kCells - 1);
+  CHECK(chorded.status == Status::Won);
+
+  // The same equivalence where the chord LOSES, which is the case a shortcut
+  // is most tempting to special-case.
+  Game losing{};
+  start(losing, 32u);
+  losing.status = Status::Playing;
+  losing.cell[3][0] |= kMine;
+  losing.cell[2][1] |= kRevealed;
+  CHECK(toggleFlag(losing, 2, 0));
+  Game losingModel = losing;
+  CHECK(chord(losing, 2, 1));
+  CHECK(modelChord(losingModel, 2, 1));
+  CHECK(losing.status == Status::Lost);
+  CHECK(sameGame(losing, losingModel));
+}
+
+// And over real dealt boards rather than three hand-built ones: play games,
+// scan the whole board for every legal chord, and check each one against the
+// model. A special case that only bites on a board nobody hand-wrote is exactly
+// what this catches.
+//
+// The driver flags CORRECTLY most of the time -- it may look at the mines,
+// being a test and not a player -- because a purely random flagger satisfies a
+// number by accident about once a game, and almost always wrongly. That found
+// 46 chords over 600 games, 35 of them losses, which is not a sweep of the
+// winning path at all.
+void testChordMatchesTheModelOnRealBoards() {
+  uint32_t seed = 13579u;
+  int chords = 0;
+  int chordLosses = 0;
+  int chordWins = 0;
+  int cascades = 0;
+  for (int match = 0; match < 400; ++match) {
+    Game game{};
+    start(game, seed = seed * 1664525u + 1013904223u);
+    uint32_t pick = seed;
+    reveal(game, static_cast<int>(pick >> 8) % kColumns, static_cast<int>(pick >> 16) % kRows);
+
+    int guard = 0;
+    while (!over(game) && ++guard <= kCells * 3) {
+      // Every chord the board currently offers, compared against the model.
+      // The first legal one is played so the game moves on.
+      bool played = false;
+      for (int column = 0; column < kColumns && !played; ++column) {
+        for (int row = 0; row < kRows && !played; ++row) {
+          Game viaChord = game;
+          if (!chord(viaChord, column, row)) continue;
+          Game viaModel = game;
+          CHECK(modelChord(viaModel, column, row));
+          CHECK(sameGame(viaChord, viaModel));
+          ++chords;
+          if (viaChord.status == Status::Lost) ++chordLosses;
+          if (viaChord.status == Status::Won) ++chordWins;
+          if (revealedCount(viaChord) - revealedCount(game) > 8) ++cascades;
+          game = viaChord;
+          played = true;
+        }
+      }
+      if (played) continue;
+
+      const uint32_t roll = nextRandom(pick);
+      const int column = static_cast<int>(roll >> 8) % kColumns;
+      const int row = static_cast<int>(roll >> 16) % kRows;
+      if ((roll & 3) == 0) {
+        // Mostly a correct flag, so numbers actually become satisfied;
+        // sometimes a wrong one, so chords that detonate happen too.
+        const bool honest = (roll & 4) != 0;
+        int planted = -1;
+        for (int i = 0; i < kCells && planted < 0; ++i) {
+          const int c = (column + i) % kColumns;
+          const int r = (row + i / kColumns) % kRows;
+          const uint8_t cell = game.cell[c][r];
+          if (cell & (kRevealed | kFlagged)) continue;
+          if (((cell & kMine) != 0) != honest) continue;
+          toggleFlag(game, c, r);
+          planted = 1;
+        }
+        if (planted < 0) dig(game, column, row);
+      } else {
+        dig(game, column, row);
+      }
+    }
+  }
+  // The sweep is worthless if it never found a chord to make, and EACH outcome
+  // it is meant to cover must actually have occurred, or the comparison above
+  // proved nothing about it. A chord that wins is its own case: it is the one
+  // where reveal() stops answering part way through for a reason that is not a
+  // loss.
+  CHECK(chords > 500);
+  CHECK(chordLosses > 0);
+  CHECK(cascades > 0);
+  // NOT asserted here, and the absence is the point: this driver plants a wrong
+  // flag one time in eight, so its games end in detonation and it produced ZERO
+  // winning chords across 585. A chord that WINS is covered by
+  // testAChordCanWinTheGame below, which plays perfectly to reach one. Naming
+  // the gap beats a counter that quietly reads zero.
+  std::printf("  (winning chords are not reachable here: %d seen; see testAChordCanWinTheGame)\n", chordWins);
+  std::printf("  chords on dealt boards: %d vs model, %d lost, %d cascaded\n", chords, chordLosses, cascades);
+}
+
+// A chord that WINS, which is the third outcome and the one no sweep above
+// reaches: the driver there mis-flags deliberately, so its games all detonate.
+//
+// This one plays perfectly -- it may read the mines, being a test -- and its
+// last move is usually a chord. Winning matters separately from losing because
+// it is the other way reveal() stops answering part way through a chord: once
+// allSafeCellsRevealed sets Won, canReveal refuses the rest, and a chord that
+// assumed it could keep going would diverge from the model exactly there.
+void testAChordCanWinTheGame() {
+  uint32_t seed = 8642u;
+  int wins = 0;
+  int chordWins = 0;
+  int chords = 0;
+  for (int match = 0; match < 200; ++match) {
+    Game game{};
+    start(game, seed = seed * 1664525u + 1013904223u);
+    reveal(game, static_cast<int>(seed >> 8) % kColumns, static_cast<int>(seed >> 16) % kRows);
+    // Flag every mine, correctly. Now no chord can ever detonate.
+    for (int c = 0; c < kColumns; ++c) {
+      for (int r = 0; r < kRows; ++r) {
+        if (game.cell[c][r] & kMine) toggleFlag(game, c, r);
+      }
+    }
+
+    int guard = 0;
+    while (!over(game) && ++guard <= kCells * 3) {
+      bool played = false;
+      for (int c = 0; c < kColumns && !played; ++c) {
+        for (int r = 0; r < kRows && !played; ++r) {
+          Game viaChord = game;
+          if (!chord(viaChord, c, r)) continue;
+          Game viaModel = game;
+          CHECK(modelChord(viaModel, c, r));
+          CHECK(sameGame(viaChord, viaModel));
+          ++chords;
+          if (viaChord.status == Status::Won) ++chordWins;
+          game = viaChord;
+          played = true;
+        }
+      }
+      if (played) continue;
+      // No chord available: open a safe cell by hand and look again.
+      bool dug = false;
+      for (int c = 0; c < kColumns && !dug; ++c) {
+        for (int r = 0; r < kRows && !dug; ++r) {
+          if (game.cell[c][r] & (kMine | kRevealed | kFlagged)) continue;
+          reveal(game, c, r);
+          dug = true;
+        }
+      }
+      if (!dug) break;
+    }
+    CHECK(game.status != Status::Lost);
+    if (game.status == Status::Won) ++wins;
+  }
+  // Every game must be won -- with every mine flagged there is no way to lose --
+  // and a chord must have been the winning move in some of them.
+  CHECK(wins == 200);
+  CHECK(chordWins > 0);
+  std::printf("  perfect play: %d/200 won, %d chords, %d of them the winning move\n", wins, chords, chordWins);
+}
+
+// The routing decision is a rule too, so it is proved here rather than in the
+// activity where nothing can reach it: one tap of the DIG tool digs a covered
+// cell and chords a satisfied number, and a tap that means neither changes
+// nothing.
+void testDigRoutesATapToTheMoveItMeans() {
+  Game game = satisfiedOne();
+  // Covered: a plain dig.
+  CHECK(dig(game, 0, 5));
+  CHECK(game.cell[0][5] & kRevealed);
+
+  // A revealed number with its flag planted: a chord.
+  Game ready = satisfiedOne();
+  CHECK(toggleFlag(ready, 3, 0));
+  CHECK(dig(ready, 2, 1));
+  CHECK(ready.cell[1][1] & kRevealed);
+
+  // The same number without the flag: nothing, and nothing touched.
+  Game idle = satisfiedOne();
+  Game before = idle;
+  CHECK(!dig(idle, 2, 1));
+  CHECK(std::memcmp(&before, &idle, sizeof(Game)) == 0);
+
+  // A flagged cell is still protected from the dig tool.
+  Game guarded = satisfiedOne();
+  CHECK(toggleFlag(guarded, 3, 0));
+  CHECK(!dig(guarded, 3, 0));
+  CHECK((guarded.cell[3][0] & kRevealed) == 0);
+}
+
 }  // namespace
 
 int main() {
@@ -390,6 +875,14 @@ int main() {
   testMinesReachEveryCell();
   testStartClearsAFinishedBoard();
   testAFlaggedSafeCellIsNotCleared();
+  testAChordOpensEveryNeighbourWhenTheFlagsMatch();
+  testAChordWithTooFewFlagsDoesNothingAtAll();
+  testAChordNeedsARevealedNumberAndALiveGame();
+  testAChordOnAWrongFlagLosesThroughTheSamePathAsATap();
+  testAChordIsExactlyTheRevealsItReplaces();
+  testChordMatchesTheModelOnRealBoards();
+  testAChordCanWinTheGame();
+  testDigRoutesATapToTheMoveItMeans();
 
   std::printf("%d checks, %d failed\n", checks, failures);
   return failures == 0 ? 0 : 1;

--- a/host-tests/ui/test_ui.cpp
+++ b/host-tests/ui/test_ui.cpp
@@ -5728,9 +5728,11 @@ void testTheSettledBoardStaysAndWearsItsVerdict() {
 }
 
 void testTheHowToPagesAndEndsOnGotIt() {
-  // Four pages now: the win condition (flags are notes, none are needed) got
-  // a page of its own in the art pass.
-  CHECK(mineui::howToPages() == 4);
+  // Five pages now: the win condition (flags are notes, none are needed) got
+  // a page of its own in the art pass, and the chord got the fifth -- a move
+  // that cannot be discovered by tapping, because the cell it wants is one the
+  // player has learnt is spent.
+  CHECK(mineui::howToPages() == 5);
   for (int page = 0; page < mineui::howToPages(); ++page) {
     mineui::HowToModel model;
     model.page = page;
@@ -5742,6 +5744,33 @@ void testTheHowToPagesAndEndsOnGotIt() {
     char progress[16];
     std::snprintf(progress, sizeof(progress), "%d OF %d", page + 1, mineui::howToPages());
     CHECK(out.target.drew(progress));
+
+    // The lesson fits the box it is drawn into, measured with the LINE CAP
+    // LIFTED. buildHowTo hands the sentence a flat 150px rect at maxLines 4, so
+    // a wording needing five lines is clipped and ellipsized -- and above the
+    // 10px cut the Toybox faces carry NO ellipsis glyph, so the overrun draws
+    // as nothing at all and the screenshot still looks fine.
+    //
+    // **What this can and cannot catch.** The fake target answers a flat width
+    // per character, far narrower than the real Jersey cut: all five of these
+    // lines measure 40-60px against the 150px box, so the check has enormous
+    // slack and would only fail on a runaway string. It is a floor, not the
+    // margin. The marginal case is not measured here at all -- it is avoided,
+    // by keeping every lesson line shorter than one already shipping and
+    // rendering correctly. Measuring it properly needs the real cuts, which is
+    // what host-tests/tilefit does for Connections and what this suite cannot.
+    //
+    // The lesson is identified by its box, the only 150px-tall text rect on the
+    // screen, and a page where that box is not found FAILS rather than
+    // skipping: a layout change must break this test, not silence it.
+    const FakeTarget::TextRun* lesson = nullptr;
+    for (const auto& run : out.target.texts) {
+      if (run.rect.height == 150) lesson = &run;
+    }
+    CHECK(lesson != nullptr);
+    if (lesson != nullptr) {
+      CHECK(lesson->rect.height >= uncappedWrappedHeight(out.target, *lesson));
+    }
   }
 }
 

--- a/site/recipes/minesweeper.txt
+++ b/site/recipes/minesweeper.txt
@@ -13,3 +13,27 @@
 # NOT reproducible byte-for-byte yet: the board is seeded from millis(), so the
 # minefield differs every run. That is task #8, and this file is honest about
 # it rather than implying otherwise.
+
+# --- the chord screenshots (card #249) -------------------------------------
+#
+# These ARE reproducible, and the trick is worth keeping: pin the seed instead
+# of hoping. Temporarily replace the millis() seed in
+# MinesweeperActivity::beginGame() with 3843u, and the first dig at (0,0) deals
+# a board whose (1,1) reads 1 with its only mine at (0,2). Flag that, tap the
+# 1, and the chord cascades 63 cells in one move.
+#
+# rm -f fs_agent/.crosspoint/shelf.cfg fs_agent/.crosspoint/minesweeper.sav
+# ./scripts_local/sim-shot.sh \
+#   '1500:TAP:120,635;3500:TAP:241,687;5500:TAP:240,479;7500:TAP:240,672;9500:TAP:30,128;11500:TAP:30,248,900;15000:TAP:90,188;19000:QUIT' \
+#   '14000:qa-artifacts/chord-before.bmp;17000:qa-artifacts/chord-after.bmp'
+#
+# The taps in order: GAMES on Home, the page-2 dot, MINESWEEPER, PLAY, dig
+# (0,0), a 900ms hold to flag (0,2), then the chord on (1,1). DOWN does NOT
+# move a selection on the shelf -- it pages, and past the last page it lands in
+# another folder, which is how one run opened Wallpapers. Tap the page dot.
+#
+# Swap the last tap for '15000:TAP:90,188,700' to hold the number for 700ms
+# instead: it must do NOTHING. The hold reaches the flag threshold, toggleFlag
+# refuses on a revealed cell, and the contact is swallowed. That is deliberate --
+# see docs/apps/minesweeper.md; letting the lift through hands the tap to the
+# touch-DOWN cell, which can be a different, covered, mined one.

--- a/src/apps_local/minesweeper/MinesweeperActivity.cpp
+++ b/src/apps_local/minesweeper/MinesweeperActivity.cpp
@@ -201,6 +201,24 @@ void MinesweeperActivity::loop() {
         // undo. In FLAG mode it simply agrees with the tap.
         holdFired = true;
         if (ms::toggleFlag(game, column, row)) requestUpdate();
+        // UNCONDITIONAL, and it must stay that way. Swallowing only when the
+        // flag was actually planted looks harmless -- on a revealed cell the
+        // hold does nothing, so why eat the contact? -- and it opens a way to
+        // dig a cell the finger never rested on:
+        //
+        //   isScreenTouchHeld reports touchUpPoint, the LATEST contact sample,
+        //   with no slop gate at all. wasScreenTapped reports touchDownPoint,
+        //   the FIRST sample, and stays valid until motion passes the 59px
+        //   release slop. A finger that lands on covered cell A, rolls 29-59px
+        //   onto revealed cell B and rests there re-arms the hold at B; the
+        //   hold fires at B, toggleFlag refuses because B is revealed, and the
+        //   lift then taps A. Cells are 60px, so that window is about one cell
+        //   wide, and the cell it digs can be a mine.
+        //
+        // Suppressing the contact is what makes those two positions unable to
+        // disagree. The cost is that a press held past kFlagHoldMs on a number
+        // does not chord -- chording is a quick tap, which is what it is
+        // everywhere else -- and that is the cheap half of this trade.
         mappedInput.swallowCurrentTouch();
       }
       return;
@@ -231,8 +249,19 @@ void MinesweeperActivity::loop() {
       // the grid still reaches route(), which has its own digest gate for the
       // chrome. See Activity::surfaceMeaning().
       if (!surfaceRevealed()) return;
-      // The rules decide legality, not the screen and not here.
-      const bool changed = flagMode ? ms::toggleFlag(game, column, row) : ms::reveal(game, column, row);
+      // FLAG mode does NOT chord, and that is a decision rather than an
+      // oversight: chording is a dig, so it would make the FLAG tool able to
+      // end the game. The hold branch above already refuses the same thing for
+      // the same reason -- a move you did not mean should never cost more than
+      // an extra tap to undo, and digging is the one move that can cost the
+      // run. A player in FLAG mode taps the number again in DIG.
+      //
+      // The rules decide legality, and what the tap even MEANS: ms::dig digs a
+      // covered cell and chords a revealed number that already carries its
+      // flags. The choice between them is a rule, so it lives in the core
+      // where the host suite can reach it -- there is nothing here that could
+      // prove it, and the simulator never runs this file's input at all.
+      const bool changed = flagMode ? ms::toggleFlag(game, column, row) : ms::dig(game, column, row);
       if (changed) requestUpdate();
       return;
     }

--- a/src/apps_local/minesweeper/MinesweeperCore.h
+++ b/src/apps_local/minesweeper/MinesweeperCore.h
@@ -212,6 +212,74 @@ inline bool reveal(Game& game, const int column, const int row) {
   return true;
 }
 
+// How many flags the player has planted around a cell, counting the eight
+// neighbours. The mirror of neighbouringMines, and deliberately a separate
+// count: one is what the board knows, the other is what the player believes,
+// and the chord is the move that bets they agree.
+inline int neighbouringFlags(const Game& game, const int column, const int row) {
+  int count = 0;
+  for (int dc = -1; dc <= 1; ++dc) {
+    for (int dr = -1; dr <= 1; ++dr) {
+      if (dc == 0 && dr == 0) continue;
+      if (has(game, column + dc, row + dr, kFlagged)) ++count;
+    }
+  }
+  return count;
+}
+
+// Chording: tap a revealed number that already carries its flags, and every
+// remaining neighbour opens at once.
+//
+// **It is a shortcut, not a new kind of move**, and that is built in rather
+// than promised: it calls reveal() on each remaining neighbour in turn, in a
+// fixed order, so it reaches byte-for-byte the state that REVEALING those
+// cells one at a time would. The flood, the loss, the win check and the saved
+// board therefore need no knowledge of it, and there is no second
+// implementation that has to agree with the first.
+//
+// Precisely: the equivalence is to reveal(), not to dig(). A chord does NOT
+// recurse -- a neighbour that becomes a satisfied number as a result is not
+// itself chorded. One press, one chord, which is what every Minesweeper does
+// and what keeps a mis-flag's damage to the cells the player actually pointed
+// at.
+//
+// The rule when the flags are WRONG is the unforgiving one, which is the real
+// game: the move trusts the player's flags, so a chord whose count is right
+// and whose placement is not opens a mine and loses -- through reveal(), the
+// only way to lose here. The gentle version cannot be built without the game
+// telling the player something it should not know. Once reveal() sets Lost,
+// its own canReveal() refuses the remaining neighbours, so the chord stops
+// exactly where the taps would have.
+//
+// A count that does not match does NOTHING, and returns false to say so: the
+// activity repaints only on a change, which is how this game already says no.
+// Partially opening "the ones that must be safe" would be the game doing the
+// player's reasoning for them.
+//
+// A revealed zero is not special-cased. It satisfies itself with no flags, and
+// its neighbours are already open unless a flag that stopped the flood was
+// later lifted -- in which case opening them is precisely right.
+inline bool chord(Game& game, const int column, const int row) {
+  if (!inside(column, row)) return false;
+  // Playing, spelled out. Only Playing has revealed cells today, so the check
+  // below would catch Fresh anyway -- but that is a coincidence of how the
+  // board is dealt, not a rule, and a guard that holds by coincidence is one
+  // refactor from not holding. (over() cannot be used: it is declared below,
+  // which is why canReveal() spells its own check out too.)
+  if (game.status != Status::Playing) return false;
+  if ((game.cell[column][row] & kRevealed) == 0) return false;
+  if (neighbouringFlags(game, column, row) != neighbouringMines(game, column, row)) return false;
+
+  bool changed = false;
+  for (int dc = -1; dc <= 1; ++dc) {
+    for (int dr = -1; dr <= 1; ++dr) {
+      if (dc == 0 && dr == 0) continue;
+      if (reveal(game, column + dc, row + dr)) changed = true;
+    }
+  }
+  return changed;
+}
+
 // Plant or lift a flag. Never on a revealed cell, and never once the game is
 // settled.
 inline bool toggleFlag(Game& game, const int column, const int row) {
@@ -225,6 +293,17 @@ inline bool toggleFlag(Game& game, const int column, const int row) {
 // Mines minus flags planted. Goes negative when the player over-flags, which is
 // information rather than an error: it says the board disagrees with them.
 inline int minesRemaining(const Game& game) { return kMines - flagCount(game); }
+
+// One tap of the DIG tool, wherever it lands: a covered cell opens, a revealed
+// number that already carries its flags chords, and anything else is refused.
+//
+// The routing lives here rather than in the activity because it is a rule, and
+// this is the only layer the host suite can prove. reveal() already refuses a
+// revealed cell, so the two cases cannot both fire.
+inline bool dig(Game& game, const int column, const int row) {
+  if (reveal(game, column, row)) return true;
+  return chord(game, column, row);
+}
 
 inline bool over(const Game& game) { return game.status == Status::Won || game.status == Status::Lost; }
 

--- a/src/apps_local/minesweeper/MinesweeperScreens.cpp
+++ b/src/apps_local/minesweeper/MinesweeperScreens.cpp
@@ -187,13 +187,19 @@ bool lastGameLost(const ms::Game& board) {
   return false;
 }
 
-// The four lessons. The fourth is the win condition, and that flags are notes
+// The five lessons. The fourth is the win condition, and that flags are notes
 // rather than homework -- which nothing on the device said before.
+//
+// The fifth is the chord, and it is here because a move nobody is told about is
+// worth half of one. Every other rule on this list can be discovered by tapping
+// the board; this one cannot, because the cell it wants is one a player has
+// learnt is already spent.
 const char* const kLessonLines[] = {
     "A NUMBER COUNTS THE MINES TOUCHING IT, CORNERS INCLUDED.",
     "TAP TO DIG. HOLD TO PLANT A FLAG. THE BUTTON UNDER THE BOARD SWITCHES WHAT A TAP DOES.",
     "YOUR FIRST DIG IS ALWAYS SAFE, AND ALWAYS OPENS A SPACE.",
     "OPEN EVERY SAFE CELL AND THE FIELD IS CLEARED. FLAGS ARE NOTES: NONE ARE NEEDED TO WIN.",
+    "TAP A NUMBER THAT HAS ALL ITS FLAGS AND THE REST OPENS. A WRONG FLAG ENDS IT.",
 };
 
 // One diagram per lesson, centred in the vertical band it is given.
@@ -204,6 +210,10 @@ void lessonDiagram(toybox::Screen& screen, const int page, const int16_t bandTop
   static const char* const kTools[] = {"oF."};
   static const char* const kFlood[] = {"oo...", "oo**.", "ooo..", "ooo*."};
   static const char* const kWon[] = {"ooooo", "ooo*o", "ooooo", "ooFoo"};
+  // The chord's board: a 1 with its one flag already planted, and the covered
+  // cells it will open. The state to RECOGNISE, which is the half a picture
+  // can carry -- the sentence carries what happens next.
+  static const char* const kChord[] = {".F.", ".o.", "..."};
 
   const char* const* rows = kCount;
   int columns = 3;
@@ -223,6 +233,10 @@ void lessonDiagram(toybox::Screen& screen, const int page, const int16_t bandTop
     columns = 5;
     rowCount = 4;
     cell = smallCell;
+  } else if (page == 4) {
+    rows = kChord;
+    columns = 3;
+    rowCount = 3;
   }
   const int16_t width = static_cast<int16_t>(cell * columns);
   const int16_t height = static_cast<int16_t>(cell * rowCount);
@@ -285,7 +299,7 @@ bool cellAt(const fui::DeviceContext& device, const int x, const int y, int& col
   return true;
 }
 
-int howToPages() { return 4; }
+int howToPages() { return 5; }
 
 void buildMenu(toybox::Screen& screen, const MenuModel& model) {
   const fui::Rect room = menuFrontDoor(screen, model);


### PR DESCRIPTION
Closes card #249.

Tapping a revealed number whose flag count already equals it opens every
remaining unflagged neighbour at once. Standard Minesweeper; the card called its
absence "the difference between playing and clicking".

## The gesture is a plain tap

No new gesture. `wasTouchTap` has no duration gate on this platform, so
hold-to-chord would have had to fight the flag hold that already owns a long
press. A press held past the 400ms flag threshold is swallowed and does **not**
chord. That is deliberate and load bearing, not an oversight -- see the safety
section below.

## The three rules, settled from how the game already works

**A chord that finds a mine detonates**, through `reveal()` -- the only way to
lose in this app. The move trusts the player's flags, and the gentle alternative
cannot be built without the game telling the player something it should not know.
`reveal()` refuses everything once it has set `Lost`, so a detonating chord stops
exactly where the reveals would have. There is no second losing path.

**A count that does not match does nothing, silently.** `chord()` returns false
and touches nothing; the activity repaints only on a change, which is how this
game already says no.

**A chord is a shortcut, not a new kind of move**: `chord()` calls `reveal()` on
each remaining neighbour in turn, so it reaches byte-for-byte the state those
reveals would. Equivalence is to `reveal`, not to `dig` -- a chord does **not**
recurse, and that is now stated rather than implied.

Logic and routing both live in `MinesweeperCore.h`. What a tap _means_ is a rule,
and the core is the only layer the host suite can prove.

## A cold review stopped the first version of this, and it was right

**The `swallowCurrentTouch()` change was reverted.** The first version made the
swallow conditional on the flag actually being planted, so a slow press on a
number would chord. That can dig a cell the finger never rested on:

- `isScreenTouchHeld` -> `isTouchHeldAt` reports `touchUpPoint`, the **latest**
  contact sample, with no slop gate at all.
- `wasScreenTapped` -> `wasTouchTap` reports `touchDownPoint`, the **first**
  sample, and stays valid until motion passes the 59px release slop
  (`TOUCH_TAP_RELEASE_SLOP_PX`), against a 28px stationary slop.
- Land on covered cell A, roll onto revealed cell B and rest there: the hold
  re-arms at B, `toggleFlag` refuses because B is revealed, and the lift taps
  **A**. Cells are 60px, so that window is about one cell wide, and A can be a
  mine.

The unconditional swallow is the only thing making those two positions unable to
disagree. It is restored, with the reason as a comment at the call site so nobody
re-does it. Verified on screen: a 700ms hold on a satisfied number now changes
nothing.

**The headline invariant was a tautology.** Its reference, `byHand()`, was
`chord()`'s loop body transcribed, so `sameGame(chord, byHand)` held for _any_
implementation of `reveal` -- 585 green checks proving chord's loop is byHand's
loop. It is now compared against a model written from the rulebook, sharing no
code with the core: its own mine count, its own **recursive** flood where the core
uses an explicit queue, its own win check.

Proof the new one bites: a mutant that declares a win with one safe cell still
covered is caught **176 times** by the model comparison. Under `byHand` both sides
called the same `reveal()`, produced the same wrong status, and agreed.

**Two more tests were not testing their names.** The neighbour test's board had a
single corner mine, so the first neighbour was a zero that flooded and _won_, and
every later reveal was refused -- a mutant opening only the first neighbour
survived. The board now walls the flood off, the expected set is derived from the
board instead of typed out, and the count is asserted in both directions. And no
sweep had ever produced a **winning** chord (0 of 585), so
`testAChordCanWinTheGame` was added: 200/200 games won, 2868 chords, 196 of them
the winning move. The old sweep now states in writing that it cannot reach one.

Also from the review: `chord()` gained an explicit `Playing` guard (it held only
by the coincidence that a Fresh board has nothing revealed).

## Tests

Watched red first: `chord()` went in as a stub returning `false`, and **23 checks
failed at the assertions**, not the compiler. Mutants caught, each by the test
written for it: dropping the flag-count guard, refusing to detonate, bypassing
`reveal()`, chord recursing, reversing the neighbour order, and the win-detection
off-by-one above.

Totals: 585 chords on dealt boards compared against the model (189 losing, 44
cascading), plus 2868 under perfect play.

## Verified

- `./scripts_local/check.sh --committed` returned **`CHECKSH-VERDICT: green`**, read by grepping
  `CHECKSH-VERDICT:` rather than reading the last line or `$?`. It ran on
  `adc16030`; the only change since is this file's own documentation
  (`docs/apps/minesweeper.md`, correcting an overclaim about the simulator), so
  no rebuild was taken for it. An earlier run came back **`withheld`** -- behind
  origin, which is not a pass -- which is why this branch is rebased onto
  current `xteink`.
- Simulator, seed pinned to 3843 so the minefield is known: the chord cascades 63
  cells, a 700ms hold does nothing, and how-to page 5 fits its four lines with the
  sentence intact. Screenshots looked at, not just captured. Recipe in
  `site/recipes/minesweeper.txt`.

## Not verified

- **Hardware.** No device ran this.
- **The drift window itself.** The bug above is argued from the SDK source
  (`InputManager.cpp`), not reproduced. The simulator models one slop threshold
  where the device has two, so the 29-59px case does not exist there, and the host
  suite never touches the activity. What ships is the input path exactly as it was
  before this branch, which is the reason to be confident, not a test.
- **How-to line fit at real font metrics.** The ui suite's fake target measures
  40-60px for lines that really wrap to three and four, so its assertion is a
  floor, not the margin. The margin is avoided rather than measured: the chord
  line is 77 characters against the 87-character line already shipping on page 4.
- **The repaint.** 63 cells changing at once is the largest single repaint this
  game can produce; in the simulator a paint is ~1ms, on the panel 0.3-2s.
- Nobody has played a whole game with it.
