### PR TITLE
board: record who reported each card, and recover it for all 378

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -111,6 +111,43 @@ written but **not yet applied**; until `server/board/migrate.sh` has run it,
 a card that reaches `cards` by any route other than `board` gets no blocker.
 `server/board/migrate.sh --list` says whether it is still pending.
 
+## Who reported a card
+
+`source` says by what MECHANISM a card arrived -- the CLI, the site's form, a
+GitHub issue, the error trigger. It never said whose observation it was, so a
+bug Mario hit on his own device and a bug an audit found by reading code were
+both `source: session`. He asked "what have I reported?" and the answer had to
+be reconstructed from conversation, which does not scale and cannot be trusted.
+
+Every card carries a `reporter`:
+
+| value | who |
+| --- | --- |
+| `mario` | he hit it, asked for it, or ruled on it, and said so |
+| `user` | a person who is not Mario: the public report form, a GitHub issue |
+| `session` | our own side found it: an audit, a gate, a cold review, a probe, the error trigger |
+| `unknown` | nothing establishes either way |
+
+```bash
+board new "<title>" --from <app> --reporter mario|user|session
+board list --from-mario           # the question he asks
+board list --reporter unknown     # what nobody stamped
+```
+
+**The default is `unknown`, deliberately not `session`.** A path that forgets
+to stamp has to be visible rather than quietly credit one of our own sessions,
+because the only value this column has is that the list can be trusted. Two
+mechanisms answer for themselves and are derived rather than remembered: an
+error-trigger or upstream-sync card is `session`, a GitHub-issue card is
+`user`. The site's form is public, so it stamps `mario` only when the address
+given is the owner's and `user` otherwise.
+
+The 360 cards that predate the column were recovered from their own text and
+from verbatim matches against the session transcripts:
+[what-mario-reported.md](what-mario-reported.md) has the counts, the list he
+asked for, the evidence behind every `mario` row, and the six that could not
+be established.
+
 ## When the guard itself breaks
 
 It fails open, on purpose. Anything unexpected inside `guard.py` exits 0

--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -142,11 +142,19 @@ error-trigger or upstream-sync card is `session`, a GitHub-issue card is
 `user`. The site's form is public, so it stamps `mario` only when the address
 given is the owner's and `user` otherwise.
 
-The 360 cards that predate the column were recovered from their own text and
-from verbatim matches against the session transcripts:
+The cards that predate the column were recovered from their own text and from
+verbatim matches against the session transcripts:
 [what-mario-reported.md](what-mario-reported.md) has the counts, the list he
-asked for, the evidence behind every `mario` row, and the six that could not
+asked for, the evidence behind every `mario` row, and the ones that could not
 be established.
+
+**Read all three channels if you ever redo this.** Anything Mario types WHILE a
+session is mid-turn is never stored as a transcript entry of type `user`: it
+arrives as an attachment of type `queued_command` whose origin kind is `human`.
+A filter on `type: "user"` alone misses it, and it missed 221 of his messages
+the first time, 74 of them inside the window the board covers. His typed inbox
+answers are a third channel again, in the `blockers` table. The same trap
+applies to anything else that reads these transcripts for what he said.
 
 ## When the guard itself breaks
 

--- a/docs/workflow/dispatch.md
+++ b/docs/workflow/dispatch.md
@@ -19,8 +19,11 @@ When Mario says something is wrong, or wants something:
 1. **Name the app.** From what he said; if two apps could fit, ask one
    question with the two names in it. Never guess between apps.
 2. **File the card.** `board new "<his words, shortened>" --from <app>
---kind bug|feature --body "<what he said, verbatim, one paragraph>"`.
-   His words go in the body untouched; the title is the short form.
+--kind bug|feature --reporter mario --body "<what he said, verbatim, one
+   paragraph>"`. His words go in the body untouched; the title is the short
+   form. `--reporter mario` is not optional here: everything Dispatch files
+   came from him by definition, and without it the card reads `unknown` and
+   drops out of `board list --from-mario`, which is the list he asks for.
 3. **Route it.** `board route <id>`. If the app has an owner session, message
    that session: "Card #<id> is yours: <title>. board show <id>." If it has no
    owner, leave the card in `reported`; the orchestrator's next tick starts a

--- a/docs/workflow/what-mario-reported.md
+++ b/docs/workflow/what-mario-reported.md
@@ -1,0 +1,207 @@
+# What Mario reported
+
+Recovered 2026-09-06 (card #370), because the board could not answer the
+question. Every card now carries a `reporter`; this file is the readable
+form of it and the evidence behind each `mario` row.
+
+Live version of the same list, always current:
+
+```
+board list --from-mario          # only his
+board list --reporter session    # only what a session found
+board list --reporter unknown    # the ones nobody could establish
+```
+
+## The count, over all 360 cards on the board
+
+| reporter | cards | what it means |
+| --- | --- | --- |
+| `mario` | 57 | he hit it, asked for it, or ruled on it, and said so |
+| `user` | 2 | a person who is not Mario: the public report form, a GitHub issue |
+| `session` | 295 | our own side found it: an audit, a gate, a cold review, a probe, the error trigger |
+| `unknown` | 6 | the card carries no evidence either way |
+
+## How a card earned `mario`
+
+Two kinds of evidence, and nothing else. Topic was never evidence: a card
+about wallpapers is not his because wallpapers were his idea.
+
+- **quote** -- a run of eight or more words in the card matched, word for
+  word, a real message of his in the session transcripts
+  (`~/.claude/projects/-Users-mario-Projects-Personal-Code-Xteink/*.jsonl`,
+  human turns only: sidechains, tool results and compaction summaries excluded).
+- **card** -- the card itself names him as the source of that observation
+  ("Mario reported", "Mario, 2026-09-05:", "Mario's request").
+
+A card that merely records his ANSWER to a question a session put to him is
+NOT his: #94, #95 and #96 are session work items carrying his go-ahead.
+
+## The 57 cards Mario reported
+
+### Bugs he hit (21)
+
+- **#107** [get books, released] The books icon has a box around it now
+  <br>evidence: quote: "the icon that looks like some books at the top left is now surrounded by a rectangle" 2026-09-03 23:14
+- **#108** [get books, released] Cannot go back until the book image has loaded
+  <br>evidence: quote: same 2026-09-03 23:14 message, second complaint
+- **#131** [site, released] The Anki and Instapaper login pages do not look like the site
+  <br>evidence: quote: "those pages don't follow at all the style of the rest of the website" 2026-09-04 03:12
+- **#138** [firmware, released] Games and apps screens show a WHITE strip above the black header band, visible off-axis from below
+  <br>evidence: quote: "if I look at it from the bottom, on the very, very top above the titles ... I see white space" 2026-09-04 04:15
+- **#166** [instapaper, done] Sync fails: Instapaper answered the article list in a shape this bridge does not know
+  <br>evidence: quote: "it said Instapaper answered the article list in a shape. This bridge does not know." 2026-09-04 02:43
+- **#179** [forehead, released] Forehead: PLACES holds everyday venues, not geography
+  <br>evidence: quote: "This is called Places ... And somehow it has supermarket and farm." 2026-09-04 15:27
+- **#236** [connections, released] Connections: tiles and solved rows elide text; make showing the whole string a constructed guarantee
+  <br>evidence: quote: "the category description or words list after a set is found to get truncated and look bad often" 2026-09-05 06:22
+- **#240** [site, released] The CrossPlay tile on Seeed's playground page is a screenshot, not a lockup
+  <br>evidence: quote: "the submitted image is bad, should've been something like what the others submitted" 2026-09-05 07:04
+- **#243** [battleship, released] Battleship's 'Tap a target' button is light grey and badly ghosted
+  <br>evidence: quote: "On battleship when the game starts the button that says Tap a target is in a light grey" 2026-09-05 07:08
+- **#244** [connections, review] Connections' Get puzzles freezes the device with no feedback, and reads as a crash
+  <br>evidence: quote: "The get puzzles button of the connections game makes the device stall" 2026-09-05 07:09
+- **#246** [murdle, released] Murdle's refusal notice is a paragraph, and the band reserved for it pushed the grid down
+  <br>evidence: quote: "That message is WAY to long, two lines, should only be like a couple words" 2026-09-05 07:12
+- **#247** [connectfour, released] Connect Four's lip turns to dithered squares on the opponent's turn
+  <br>evidence: quote: "I dont get the change of the top row on connect 4 from circles to some kind of squares" 2026-09-05 07:13
+- **#248** [firmware, review] Yahtzee's dice sit 5px under the header rule, and the rule itself is drawn on some screens and not others
+  <br>evidence: quote: "Yatzee dices touch the top header after rolled" 2026-09-05 07:16
+- **#250** [firmware, released] Back swipe does not exit Trivia, and almost no game asks for it
+  <br>evidence: quote: "Can't exit trivia with a back swipe, fix it and check if it happens for other games" 2026-09-05 07:18
+- **#261** [wavelength, merged] Wavelength is all text and no marks; add icons, with a critic on the render
+  <br>evidence: quote: "The wavelenght game has a design problem, too much text and not a single icon in sight" 2026-09-05 07:33
+- **#262** [wavelength, merged] Wavelength's front door offers a score that doesn't exist, and its layout is 101 magic numbers
+  <br>evidence: quote: "the UI for wavelenght is weird, it shows the see the score so far when no game is in course" 2026-09-05 07:34
+- **#293** [murdle, released] Murdle's refusal notice should sit between the board and the key, not above the board
+  <br>evidence: quote: "Two forty six is still not great. The text appears on top of the screen." 2026-09-05 13:19
+- **#295** [firmware, released] Yahtzee's dice clearance, the half of #248 that does not touch ToyboxScreen.h
+  <br>evidence: card: "Mario reported 'Yahtzee dices touch the top header after rolled'" (split of #248)
+- **#311** [trivia, review] Trivia: the US-centric toggle is in global System settings, not in the Trivia app
+  <br>evidence: card: "Mario reported 2026-09-05"
+- **#327** [getbooks, reported] Get Books: DOWNLOAD is dead until the cover loads -- the blocking pump honours only Back and Home, and swallows every other tap
+  <br>evidence: quote: "The download button on the app Get Books is completely unresponsive until the book cover loads" 2026-09-05 19:40
+- **#351** [firmware, reported] CrossPoint: a non-quick-resume wake shows no sign of life until the first paint
+  <br>evidence: quote: "I have to hold the thing for a lfew seconds to wake it up and takes like 5 secs" 2026-09-05 21:29
+
+### Things he asked for (18)
+
+- **#125** [firmware, released] Device info rides on requests to CrossPlay's own services; the device never calls home
+  <br>evidence: card: "Mario, 2026-09-04: a device must never spend its radio on reporting"
+- **#127** [site, done] Report from a floating button on the main site, in a dialog, on desktop too; pick one device or both
+  <br>evidence: card: "Mario: the report page looks mobile-only, 'not sure' makes no sense"
+- **#130** [site, done] The inbox page gets a desktop layout
+  <br>evidence: quote: "The inbox is also only optimized for phone. for some reason." 2026-09-04 03:11
+- **#191** [trivia, released] Trivia: a toggle for US-centric questions
+  <br>evidence: quote: "US centric trivia needs to go. At least for now." 2026-09-04 19:09
+- **#241** [firmware, reported] Swap the in-house game AI for a standard engine wherever one is clearly better
+  <br>evidence: quote: "We dont use a standarized chess engine with standarized difficulties" 2026-09-05 07:06
+- **#249** [minesweeper, working] Minesweeper: clicking a satisfied number should chord-reveal its neighbours
+  <br>evidence: quote: "On minesweeper when a number is clicked ... reveal the rest of the squares" 2026-09-05 07:18
+- **#253** [firmware, reported] Unify how downloadable packs work, and make xkcd's freshness knowable
+  <br>evidence: quote: "Things that are downloadable also feel like should be unified" 2026-09-05 07:24
+- **#257** [trivia, review] Trivia: report a question, filter what you get, and sync the pack instead of redownloading it
+  <br>evidence: quote: "a way to report questions and a simple button of why is it being reported" 2026-09-05 07:30
+- **#260** [instapaper, released] Instapaper has no way to disconnect the account from the device
+  <br>evidence: quote: "Instapaper needs a way for the user to disconnect from the connected account" 2026-09-05 07:31
+- **#264** [firmware, review] New game: Picross
+  <br>evidence: quote: "I need to implement a new game Picross" 2026-09-05 07:38
+- **#266** [firmware, merged] New app: Wallpapers, plus a browser uploader for them
+  <br>evidence: quote: "I need a new app called wallpapers that does two things" 2026-09-05 07:42
+- **#302** [firmware, reported] Wallpaper option: the cover of the last book being read
+  <br>evidence: card: "Mario's request, 2026-09-05, while reviewing the wallpaper set"
+- **#305** [firmware, working] Wallpapers: multi-select a set, and shuffle it as the sleep screen
+  <br>evidence: quote: "how to select multiple wallpapers at one and how to make them cycle or random" 2026-09-05 17:34
+- **#328** [getbooks, reported] Get Books: offer OPEN on a finished download, so the book does not require a trip to Browse Files
+  <br>evidence: card: quotes him -- "there should be a button to open the book as soon as it gets downloaded"
+- **#329** [getbooks, review] Get Books: the download-failure screen is three centred lines and needs a real design -- three variants for Mario to choose
+  <br>evidence: quote: "we need to make the error screen when a book download fails prettier" 2026-09-05 19:40ff
+- **#348** [infra, review] Open both bridges to the world: Study and Instapaper are BOTH invitation-only, not just Study (GitHub issue #115)
+  <br>evidence: quote: "Make it so the Anki/Study one does too and make sure that the Get Books one too" 2026-09-05 21:31
+- **#349** [firmware, review] Wallpapers: phone-to-device by QR, plus preview/delete and multi-select in the picker
+  <br>evidence: quote: "The idea of the add a wallpaper thing was to have an easy way to get from picture on my phone to wallpaper" 2026-09-05 21:29
+- **#365** [wallpapers, review] Wallpapers: hold a tile to preview or delete it, and sort user uploads first
+  <br>evidence: quote: "user uploaded wallpapers always come in front of the deafult ones" 2026-09-05 21:29
+
+### Decisions and standing rules he set (18)
+
+- **#49** [mario, done] Ask: report bugs and ideas from the website
+  <br>evidence: quote+card: one of the twelve "Ask:" cards; his 2026-09-03 05:24 bug-pipeline conversation
+- **#50** [mario, done] Ask: one board for everything, my own work included
+  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+- **#51** [mario, done] Ask: rules the sessions cannot break
+  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+- **#52** [mario, done] Ask: one orchestrator; workers talk only to it; I hear only what needs me
+  <br>evidence: quote: "sessions ... only be able to talk to the orchestrator session" 2026-09-03 05:45
+- **#53** [mario, done] Ask: a dispatcher I tell issues to, that finds the right session
+  <br>evidence: card: "Ask:" card on app mario; his dispatcher ask, 2026-09-03 06:47
+- **#54** [mario, done] Ask: releases that block nobody
+  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+- **#55** [mario, done] Ask: close sessions by rule, keep history, stop cluttering my mind
+  <br>evidence: card: "Ask:" card on app mario; his session-closing ask, 2026-09-03 06:09
+- **#56** [mario, done] Ask: keep up with CrossPoint daily, merges handled
+  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+- **#57** [mario, done] Ask: analytics on everything, one place to answer 'how many'
+  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+- **#58** [mario, done] Ask: errors from any service trigger a fix, one session per problem
+  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+- **#59** [mario, done] Ask: GitHub issues picked up and closed automatically
+  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+- **#60** [mario, done] Ask: tell Main to keep going
+  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+- **#93** [trivia, done] Trivia: difficulty 1 and difficulty 5 feel identical and all questions are extremely hard -- Mario played it, the levels do not differ
+  <br>evidence: card: title says "Mario played it, the levels do not differ"
+- **#112** [instapaper, triaged] Instapaper pairing costs two scans: arriving at /pair by QR while signed out says "Sign in first, then scan the code on your reader again". The code is already in the URL, so it could be carried through the sign-in and paired in one pass.
+  <br>evidence: quote: "I scanned the QR code and told me to log into my Instapaper account ... I had to scan the code again" 2026-09-04 02:43
+- **#201** [mario, done] SCOPE RULE: a change that is not CrossPlay-specific is dismissed
+  <br>evidence: quote: "stuff that crosspoint owns is not ours to fix" 2026-09-04 23:45
+- **#252** [tooling, done] The two bridges are already open source; harden them for it, starting with study-bridge's gitignore
+  <br>evidence: quote: "Are the study and instapaper services part of the open source project?" 2026-09-05 07:22
+- **#313** [firmware, reported] VOCABULARY for #305: 'rotation' there means CYCLING through wallpapers, never screen orientation
+  <br>evidence: card: "Mario flagged this on 2026-09-05 after reading the word rotation"
+- **#370** [board, working] Record who reported each card, and recover it for the existing 122
+  <br>evidence: card: filed for his own question, "what have I reported?"
+
+## The 2 filed by someone who is not Mario
+
+- **#13** [reader, released] Slow page turns, 4.2 s against 1 s on stock, measured over serial by a user
+  <br>evidence: card: GitHub issue #7, reported 2026-09-01 by an outside user over serial
+- **#207** [unknown, done] Test test test, I want to see if this reporting arrives.
+  <br>evidence: site form, reporter_email testv@gmail.com -- a person, not Mario's address
+
+## The 6 nobody could establish
+
+Left `unknown` on purpose. Each could be his or could be a session's; the
+card says nothing and no transcript carries the words. A wrong name here
+would cost more than a blank one.
+
+- **#25** [firmware, released] Wi-Fi picker: one press exits the picker AND closes the app underneath
+- **#36** [link, released] Every link game: the loser sees zero frames of the final board -- driveLink applies the winning move and sets rematch_ in one pass, and requestUpdate is deferred to the end of the loop
+- **#40** [hackernews, released] Hacker News: NOT SAVED (card full) throws you out of the article you were reading; needs a toast/overlay the app does not have
+- **#43** [firmware, done] No app overrides handleHomeGesture: any app mutating saved state from a background poll can write the card after the player has left
+- **#100** [trivia, done] Trivia clue text is corrupted at the source: an N./S. expansion turns "U.S. Army" into "U.South Army" and "Jose N. Duarte" into "Jose North Duarte". Present in BOTH packs, so it predates the rebuild; needs a rebuild from the Jeopardy source
+- **#111** [trivia, done] Trivia Solo coverage runs backwards: 18% of level 1 has options vs 42% of level 5, because easy clues have common-noun answers whose type pool is too small. Level 1 in Solo is 141 questions.
+
+## What this list does NOT contain
+
+Things he reported that never became a card. Found while doing this, not
+fixed here, and each is a real gap between what he said and what the board
+holds:
+
+- 2026-09-05 16:39 and 18:43, Picross: the strike line not through the
+  centre of the row number, asymmetric dithering around the numbers, the
+  puzzle-select screen's brackets fighting its rounded corners, and the
+  size tabs being tight on vertical padding. All handled on #264 in
+  conversation; none of it is on the board.
+- 2026-09-05 21:15, Wallpapers: the app taking ~10s on first load, the
+  "Tap one to set your sleep screen" line sitting too close to the grid,
+  and the download bar filling twice.
+- 2026-09-05 23:12, Wallpapers: touch refused until the previous tap's
+  brackets have finished drawing, so taps feel lost.
+- 2026-09-06 02:51, the wallpaper uploader: one picture at a time, and it
+  does not follow the site's styling.
+- 2026-09-04 23:23 and 2026-09-05 05:17: the release notes are "complete
+  nonsense and bloat" and still "impossibly long".
+- 2026-09-05 03:38: artifacts in a downloaded book, tildes especially.
+
+A report that reaches a session and never reaches the board is invisible to
+this list by construction, whatever the reporter column says.

--- a/docs/workflow/what-mario-reported.md
+++ b/docs/workflow/what-mario-reported.md
@@ -1,10 +1,8 @@
 # What Mario reported
 
 Recovered 2026-09-06 (card #370), because the board could not answer the
-question. Every card now carries a `reporter`; this file is the readable
-form of it and the evidence behind each `mario` row.
-
-Live version of the same list, always current:
+question. Every card carries a `reporter`; this file is the readable form of
+it and the evidence behind every `mario` row.
 
 ```
 board list --from-mario          # only his
@@ -13,36 +11,54 @@ board list --reporter unknown    # the ones nobody could establish
 ```
 
 Those flags reach `board` when this change is in `firmware-next`, which is
-what `/opt/homebrew/bin/board` resolves to and which runs behind `xteink`. The
-counts and the list below are the recovery itself and do not need the CLI.
+what `/opt/homebrew/bin/board` resolves to and which runs behind `xteink`.
+The counts and the list below are the recovery itself and need no CLI.
 
-## The count, over all 360 cards on the board
+## The count, over all 378 cards on the board
 
 | reporter | cards | what it means |
 | --- | --- | --- |
-| `mario` | 57 | he hit it, asked for it, or ruled on it, and said so |
-| `user` | 2 | a person who is not Mario: the public report form, a GitHub issue |
-| `session` | 295 | our own side found it: an audit, a gate, a cold review, a probe, the error trigger |
-| `unknown` | 6 | the card carries no evidence either way |
+| `mario` | 75 | he hit it, asked for it, or ruled on it, and said so |
+| `user` | 1 | a person who is not Mario: a GitHub issue, the public report form |
+| `session` | 300 | our own side found it: an audit, a gate, a cold review, a probe, the error trigger |
+| `unknown` | 2 | the card carries no evidence either way |
 
 ## How a card earned `mario`
 
-Two kinds of evidence, and nothing else. Topic was never evidence: a card
-about wallpapers is not his because wallpapers were his idea.
+Two kinds of evidence, and nothing else. Topic was never evidence: a card is
+not his because it is about wallpapers and wallpapers were his idea.
 
-- **quote** -- a run of eight or more words in the card matched, word for
-  word, a real message of his in the session transcripts
-  (`~/.claude/projects/-Users-mario-Projects-Personal-Code-Xteink/*.jsonl`,
-  human turns only: sidechains, tool results and compaction summaries excluded).
-- **card** -- the card itself names him as the source of that observation
-  ("Mario reported", "Mario, 2026-09-05:", "Mario's request").
+- **quote**: a run of words from the card matched, word for word, something he
+  actually typed.
+- **card**: the card itself names him as the source of that observation.
 
-A card that merely records his ANSWER to a question a session put to him is
-NOT his: #94, #95 and #96 are session work items carrying his go-ahead.
+A card that records his ANSWER to a question a session put to him is NOT his.
+#94, #95 and #96 are session work items carrying his go-ahead.
 
-## The 57 cards Mario reported
+### Three channels, and the first pass read only one
 
-### Bugs he hit (21)
+This matters more than any single row, because it is why the first attempt
+was narrower than it looked.
+
+1. **Ordinary turns**, stored as transcript entries of type `user`. The first
+   pass read these and nothing else.
+2. **Anything he typed while a session was mid-turn.** These are never stored
+   as a `user` entry at all. They arrive as an attachment of type
+   `queued_command` whose origin kind is `human`, and there are **221** of
+   them, **74** inside the window this board covers. They carry the source
+   text behind #125, #127, #302, #311, #328, #329 and most of the twelve
+   `Ask:` cards, and every one of the reports in the last section.
+3. **His typed answers in the `blockers` table**, 34 of them. #93's evidence
+   lives there and nowhere else.
+
+Reading all three did not add or remove anybody from the `mario` set by
+verbatim match. What it changed is the evidence: several rows previously
+cited a quotation that was not in the corpus at all, which means they were
+resting on a session's paraphrase without saying so.
+
+## The 75 cards Mario reported
+
+### Bugs he hit (34)
 
 - **#107** [get books, released] The books icon has a box around it now
   <br>evidence: quote: "the icon that looks like some books at the top left is now surrounded by a rectangle" 2026-09-03 23:14
@@ -51,13 +67,13 @@ NOT his: #94, #95 and #96 are session work items carrying his go-ahead.
 - **#131** [site, released] The Anki and Instapaper login pages do not look like the site
   <br>evidence: quote: "those pages don't follow at all the style of the rest of the website" 2026-09-04 03:12
 - **#138** [firmware, released] Games and apps screens show a WHITE strip above the black header band, visible off-axis from below
-  <br>evidence: quote: "if I look at it from the bottom, on the very, very top above the titles ... I see white space" 2026-09-04 04:15
+  <br>evidence: quote: "if I look at it from the bottom, on the very, very top above the titles of everything in apps and games, I see white space. We should make it black" 2026-09-04 04:15
 - **#166** [instapaper, done] Sync fails: Instapaper answered the article list in a shape this bridge does not know
   <br>evidence: quote: "it said Instapaper answered the article list in a shape. This bridge does not know." 2026-09-04 02:43
 - **#179** [forehead, released] Forehead: PLACES holds everyday venues, not geography
   <br>evidence: quote: "This is called Places ... And somehow it has supermarket and farm." 2026-09-04 15:27
 - **#236** [connections, released] Connections: tiles and solved rows elide text; make showing the whole string a constructed guarantee
-  <br>evidence: quote: "the category description or words list after a set is found to get truncated and look bad often" 2026-09-05 06:22
+  <br>evidence: quote: "What I see really often is the category description or words list after a set is found to get truncated and look bad often" 2026-09-05 06:22. The card's own opening quote was a paraphrase and has been corrected
 - **#240** [site, released] The CrossPlay tile on Seeed's playground page is a screenshot, not a lockup
   <br>evidence: quote: "the submitted image is bad, should've been something like what the others submitted" 2026-09-05 07:04
 - **#243** [battleship, released] Battleship's 'Tap a target' button is light grey and badly ghosted
@@ -81,25 +97,53 @@ NOT his: #94, #95 and #96 are session work items carrying his go-ahead.
 - **#295** [firmware, released] Yahtzee's dice clearance, the half of #248 that does not touch ToyboxScreen.h
   <br>evidence: card: "Mario reported 'Yahtzee dices touch the top header after rolled'" (split of #248)
 - **#311** [trivia, review] Trivia: the US-centric toggle is in global System settings, not in the Trivia app
-  <br>evidence: card: "Mario reported 2026-09-05"
+  <br>evidence: quote (queued): "the setting for the US centric trivia somehow ended in system settings. That's absolutely not correct. It should be in a settings menu inside the trivia app" 2026-09-05 17:37
 - **#327** [getbooks, reported] Get Books: DOWNLOAD is dead until the cover loads -- the blocking pump honours only Back and Home, and swallows every other tap
   <br>evidence: quote: "The download button on the app Get Books is completely unresponsive until the book cover loads" 2026-09-05 19:40
 - **#351** [firmware, reported] CrossPoint: a non-quick-resume wake shows no sign of life until the first paint
   <br>evidence: quote: "I have to hold the thing for a lfew seconds to wake it up and takes like 5 secs" 2026-09-05 21:29
+- **#372** [firmware, reported] Settings: CrossPlay's rows sit above CrossPoint's, and Developer Mode is near the top
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#373** [wallpapers, reported] Wallpapers: the starter set is basic, two of them look bad, and he wants sixteen-plus researched rather than generated
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#374** [wallpapers, reported] Wallpapers picker: two columns not three, brackets instead of a thick border, and three wallpapers to drop
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#375** [firmware, reported] Header height: Yahtzee's is taller than the shelf's, and he wants ALL of them at the shorter one with one styling
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#376** [getbooks, reported] Get Books: every page spends room saying a book is an EPUB, and EPUB is the only format supported
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#378** [instapaper, reported] Instapaper: a long article takes a long time to open, and he asked what the mechanism is
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#381** [wavelength, reported] Wavelength: the eye icon and others are too small after the icon pass
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#382** [firmware, reported] Picross: the strike line misses the centre of the number, the dithering is asymmetric, and the select screen needs redesigning
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#384** [wallpapers, reported] Wallpapers: the app takes about ten seconds to open, the hint sits too close to the grid, and the download bar fills twice
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#385** [wallpapers, reported] Wallpapers: taps are refused until the previous tap's brackets finish drawing, so touches feel lost
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#386** [site, reported] The wallpaper uploader takes one picture at a time and does not follow the site's styling
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#387** [tooling, reported] Release notes are nonsense and bloat, and still impossibly long after the first pass
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#388** [getbooks, reported] A downloaded book shows artifacts, tildes especially
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
 
-### Things he asked for (18)
+### Things he asked for (19)
 
 - **#125** [firmware, released] Device info rides on requests to CrossPlay's own services; the device never calls home
-  <br>evidence: card: "Mario, 2026-09-04: a device must never spend its radio on reporting"
+  <br>evidence: quote: "I don't want the devices to spend battery on connecting to Wi Fi every now and then and telling me that they are being used" 2026-09-04 03:01
 - **#127** [site, done] Report from a floating button on the main site, in a dialog, on desktop too; pick one device or both
-  <br>evidence: card: "Mario: the report page looks mobile-only, 'not sure' makes no sense"
+  <br>evidence: quote (queued): "it looks like it's made for, like, mobile, but only mobile. Second, it has a not sure option, which makes no sense ... a button on the main website, like, on the lower right" 2026-09-04 03:02
 - **#130** [site, done] The inbox page gets a desktop layout
   <br>evidence: quote: "The inbox is also only optimized for phone. for some reason." 2026-09-04 03:11
 - **#191** [trivia, released] Trivia: a toggle for US-centric questions
   <br>evidence: quote: "US centric trivia needs to go. At least for now." 2026-09-04 19:09
+- **#207** [unknown, done] Test test test, I want to see if this reporting arrives.
+  <br>evidence: quote: he sent it himself. Card created 05:43:33; at 05:45:50 he typed "No, I sent it, check". The card also carries HIS two devices and version. The earlier "not his address" reading was the topical inference the method forbids
 - **#241** [firmware, reported] Swap the in-house game AI for a standard engine wherever one is clearly better
   <br>evidence: quote: "We dont use a standarized chess engine with standarized difficulties" 2026-09-05 07:06
-- **#249** [minesweeper, working] Minesweeper: clicking a satisfied number should chord-reveal its neighbours
+- **#249** [minesweeper, review] Minesweeper: clicking a satisfied number should chord-reveal its neighbours
   <br>evidence: quote: "On minesweeper when a number is clicked ... reveal the rest of the squares" 2026-09-05 07:18
 - **#253** [firmware, reported] Unify how downloadable packs work, and make xkcd's freshness knowable
   <br>evidence: quote: "Things that are downloadable also feel like should be unified" 2026-09-05 07:24
@@ -112,50 +156,50 @@ NOT his: #94, #95 and #96 are session work items carrying his go-ahead.
 - **#266** [firmware, merged] New app: Wallpapers, plus a browser uploader for them
   <br>evidence: quote: "I need a new app called wallpapers that does two things" 2026-09-05 07:42
 - **#302** [firmware, reported] Wallpaper option: the cover of the last book being read
-  <br>evidence: card: "Mario's request, 2026-09-05, while reviewing the wallpaper set"
+  <br>evidence: quote (queued): "Blake door looks like the cover of a book. And cover of a book should be one of the options that are allowed as a wallpaper. Simply the last book that was being read" 2026-09-05 16:59
 - **#305** [firmware, working] Wallpapers: multi-select a set, and shuffle it as the sleep screen
   <br>evidence: quote: "how to select multiple wallpapers at one and how to make them cycle or random" 2026-09-05 17:34
 - **#328** [getbooks, reported] Get Books: offer OPEN on a finished download, so the book does not require a trip to Browse Files
-  <br>evidence: card: quotes him -- "there should be a button to open the book as soon as it gets downloaded"
+  <br>evidence: quote (queued): "there should be a button to open the book as soon as it gets downloaded. No need to go to browse files" 2026-09-05 19:41
 - **#329** [getbooks, review] Get Books: the download-failure screen is three centred lines and needs a real design -- three variants for Mario to choose
-  <br>evidence: quote: "we need to make the error screen when a book download fails prettier" 2026-09-05 19:40ff
+  <br>evidence: quote (queued): "we need to make the error screen when a book download fails prettier, design them and show me 3 alternatives" 2026-09-05 19:42
 - **#348** [infra, review] Open both bridges to the world: Study and Instapaper are BOTH invitation-only, not just Study (GitHub issue #115)
-  <br>evidence: quote: "Make it so the Anki/Study one does too and make sure that the Get Books one too" 2026-09-05 21:31
+  <br>evidence: quote: "Make it so the Anki/Study one does too and make sure that the Get Books one too. The objective is for anyone in the world with the OS installed to be able to use all these services" 2026-09-05 21:31. The DEFECT came from GitHub issue #115, filed by an outside user; his instruction is what made it a card and what set its scope
 - **#349** [firmware, review] Wallpapers: phone-to-device by QR, plus preview/delete and multi-select in the picker
   <br>evidence: quote: "The idea of the add a wallpaper thing was to have an easy way to get from picture on my phone to wallpaper" 2026-09-05 21:29
 - **#365** [wallpapers, review] Wallpapers: hold a tile to preview or delete it, and sort user uploads first
   <br>evidence: quote: "user uploaded wallpapers always come in front of the deafult ones" 2026-09-05 21:29
 
-### Decisions and standing rules he set (18)
+### Decisions, standing rules and asks (22)
 
 - **#49** [mario, done] Ask: report bugs and ideas from the website
-  <br>evidence: quote+card: one of the twelve "Ask:" cards; his 2026-09-03 05:24 bug-pipeline conversation
+  <br>evidence: quote: "I wish on the website there was a really quick way a user could just describe what he's experiencing, and maybe if he wants attach a picture" 2026-09-03 05:24
 - **#50** [mario, done] Ask: one board for everything, my own work included
-  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+  <br>evidence: quote: "what I want is for those to land in what I think would be a web app ... it's not only for future requests, it's for my own development too" 2026-09-03 05:45
 - **#51** [mario, done] Ask: rules the sessions cannot break
-  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+  <br>evidence: quote: "sessions are supposed to not talk between them ... and they are just ignoring me at this point" 2026-09-03 06:27, the ask the hooks were built to enforce
 - **#52** [mario, done] Ask: one orchestrator; workers talk only to it; I hear only what needs me
-  <br>evidence: quote: "sessions ... only be able to talk to the orchestrator session" 2026-09-03 05:45
+  <br>evidence: quote: "I want those sessions to only be able to talk to the orchestrator session, which will either resolve itself or actually raise it to me" 2026-09-03 05:45
 - **#53** [mario, done] Ask: a dispatcher I tell issues to, that finds the right session
-  <br>evidence: card: "Ask:" card on app mario; his dispatcher ask, 2026-09-03 06:47
+  <br>evidence: quote: "I wish I had just one session that would do that for me so I can just tell it anything ... and now it's working on it" 2026-09-03 06:47
 - **#54** [mario, done] Ask: releases that block nobody
-  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+  <br>evidence: quote: "we are getting stuck by releases a lot ... I just wish we could, like, accumulate fixes and then release" 2026-09-03 05:24
 - **#55** [mario, done] Ask: close sessions by rule, keep history, stop cluttering my mind
-  <br>evidence: card: "Ask:" card on app mario; his session-closing ask, 2026-09-03 06:09
+  <br>evidence: quote: "I have a big issue where I'm basically unable to close sessions because there's always something that stays hanging ... for it not to clutter my mind" 2026-09-03 05:45
 - **#56** [mario, done] Ask: keep up with CrossPoint daily, merges handled
-  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+  <br>evidence: quote: "I need to update my dependencies, which are the repository I worked from and free ink, and for it to happen autonomously" 2026-09-04 03:51
 - **#57** [mario, done] Ask: analytics on everything, one place to answer 'how many'
-  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+  <br>evidence: quote: "Remember what I told you yesterday that I wanted numbers on everything? ... everything that involves this project needs good observability" 2026-09-03 22:29
 - **#58** [mario, done] Ask: errors from any service trigger a fix, one session per problem
-  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+  <br>evidence: quote: "What happens when one of the services study or Instapaper or getbooks has a error? Does it investigate by itself?" 2026-09-04 10:17
 - **#59** [mario, done] Ask: GitHub issues picked up and closed automatically
-  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+  <br>evidence: quote (queued): "an automatic way to keep up with GitHub issues ... if easily solvable or replicable. than just solving them and closing them" 2026-09-03 07:21
 - **#60** [mario, done] Ask: tell Main to keep going
-  <br>evidence: card: "Ask:" card on app mario, from his 2026-09-03 bug-pipeline conversation
+  <br>evidence: quote (queued): "I know you stopped the session called main ... when you're done, make sure to tell it to keep going. So we are not stuck not moving stuff forward" 2026-09-03 07:24
 - **#93** [trivia, done] Trivia: difficulty 1 and difficulty 5 feel identical and all questions are extremely hard -- Mario played it, the levels do not differ
-  <br>evidence: card: title says "Mario played it, the levels do not differ"
+  <br>evidence: quote, from his typed inbox answer on card #1: "The difficulty seems to be completely random. I can't feel any difference between difficulty one and difficulty five questions. They're all extremely hard."
 - **#112** [instapaper, triaged] Instapaper pairing costs two scans: arriving at /pair by QR while signed out says "Sign in first, then scan the code on your reader again". The code is already in the URL, so it could be carried through the sign-in and paired in one pass.
-  <br>evidence: quote: "I scanned the QR code and told me to log into my Instapaper account ... I had to scan the code again" 2026-09-04 02:43
+  <br>evidence: quote: "I scanned the QR code and told me to log into my Instapaper account. I logged in, and then I had to scan the code again" 2026-09-04 02:43
 - **#201** [mario, done] SCOPE RULE: a change that is not CrossPlay-specific is dismissed
   <br>evidence: quote: "stuff that crosspoint owns is not ours to fix" 2026-09-04 23:45
 - **#252** [tooling, done] The two bridges are already open source; harden them for it, starting with study-bridge's gitignore
@@ -163,49 +207,86 @@ NOT his: #94, #95 and #96 are session work items carrying his go-ahead.
 - **#313** [firmware, reported] VOCABULARY for #305: 'rotation' there means CYCLING through wallpapers, never screen orientation
   <br>evidence: card: "Mario flagged this on 2026-09-05 after reading the word rotation"
 - **#370** [board, working] Record who reported each card, and recover it for the existing 122
-  <br>evidence: card: filed for his own question, "what have I reported?"
+  <br>evidence: quote: "Yes, recover what I reported and what came from somewhere else." 2026-09-06 04:03
+- **#377** [getbooks, reported] Get Books stays usable during a transfer while Connections did not, which changes what #244's fix was for
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#379** [tooling, reported] Repo organisation: an unbiased agent to make the repo pristine, fixing the obvious and raising the rest
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#380** [tooling, reported] CI: he asked for one build step and wants CI optimisation treated as a priority
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
+- **#383** [firmware, reported] Picross: he wants premade puzzle sets found online, not original artwork
+  <br>evidence: filed 2026-09-06 by card #370 from his verbatim words; it had never reached the board
 
-## The 2 filed by someone who is not Mario
+## The 1 filed by someone who is not Mario
 
 - **#13** [reader, released] Slow page turns, 4.2 s against 1 s on stock, measured over serial by a user
   <br>evidence: card: GitHub issue #7, reported 2026-09-01 by an outside user over serial
-- **#207** [unknown, done] Test test test, I want to see if this reporting arrives.
-  <br>evidence: site form, reporter_email testv@gmail.com -- a person, not Mario's address
 
-## The 6 nobody could establish
+## The 2 nobody could establish
 
-Left `unknown` on purpose. Each could be his or could be a session's; the
-card says nothing and no transcript carries the words. A wrong name here
-would cost more than a blank one.
+Left `unknown` on purpose. Each could be his or a session's; the card says
+nothing and no transcript carries the words. A wrong name costs more than a
+blank one.
 
 - **#25** [firmware, released] Wi-Fi picker: one press exits the picker AND closes the app underneath
-- **#36** [link, released] Every link game: the loser sees zero frames of the final board -- driveLink applies the winning move and sets rematch_ in one pass, and requestUpdate is deferred to the end of the loop
 - **#40** [hackernews, released] Hacker News: NOT SAVED (card full) throws you out of the article you were reading; needs a toast/overlay the app does not have
-- **#43** [firmware, done] No app overrides handleHomeGesture: any app mutating saved state from a background poll can write the card after the player has left
-- **#100** [trivia, done] Trivia clue text is corrupted at the source: an N./S. expansion turns "U.S. Army" into "U.South Army" and "Jose N. Duarte" into "Jose North Duarte". Present in BOTH packs, so it predates the rebuild; needs a rebuild from the Jeopardy source
-- **#111** [trivia, done] Trivia Solo coverage runs backwards: 18% of level 1 has options vs 42% of level 5, because easy clues have common-noun answers whose type pool is too small. Level 1 in Solo is 141 questions.
 
-## What this list does NOT contain
+## What he reported that had never reached the board
 
-Things he reported that never became a card. Found while doing this, not
-fixed here, and each is a real gap between what he said and what the board
-holds:
+This is the part worth reading. A list of what he reported is worth much less
+than one that shows what was dropped, and reading the queued channel turned up
+seventeen reports that existed only in a conversation. All are now cards,
+stamped `mario`, each carrying his verbatim words and the timestamp.
 
-- 2026-09-05 16:39 and 18:43, Picross: the strike line not through the
-  centre of the row number, asymmetric dithering around the numbers, the
-  puzzle-select screen's brackets fighting its rounded corners, and the
-  size tabs being tight on vertical padding. All handled on #264 in
-  conversation; none of it is on the board.
-- 2026-09-05 21:15, Wallpapers: the app taking ~10s on first load, the
-  "Tap one to set your sleep screen" line sitting too close to the grid,
-  and the download bar filling twice.
-- 2026-09-05 23:12, Wallpapers: touch refused until the previous tap's
-  brackets have finished drawing, so taps feel lost.
-- 2026-09-06 02:51, the wallpaper uploader: one picture at a time, and it
-  does not follow the site's styling.
-- 2026-09-04 23:23 and 2026-09-05 05:17: the release notes are "complete
-  nonsense and bloat" and still "impossibly long".
-- 2026-09-05 03:38: artifacts in a downloaded book, tildes especially.
+- **#372** [firmware] Settings: CrossPlay's rows sit above CrossPoint's, and Developer Mode is near the top
+- **#373** [wallpapers] Wallpapers: the starter set is basic, two of them look bad, and he wants sixteen-plus researched rather than generated
+- **#374** [wallpapers] Wallpapers picker: two columns not three, brackets instead of a thick border, and three wallpapers to drop
+- **#375** [firmware] Header height: Yahtzee's is taller than the shelf's, and he wants ALL of them at the shorter one with one styling
+- **#376** [getbooks] Get Books: every page spends room saying a book is an EPUB, and EPUB is the only format supported
+- **#377** [getbooks] Get Books stays usable during a transfer while Connections did not, which changes what #244's fix was for
+- **#378** [instapaper] Instapaper: a long article takes a long time to open, and he asked what the mechanism is
+- **#379** [tooling] Repo organisation: an unbiased agent to make the repo pristine, fixing the obvious and raising the rest
+- **#380** [tooling] CI: he asked for one build step and wants CI optimisation treated as a priority
+- **#381** [wavelength] Wavelength: the eye icon and others are too small after the icon pass
+- **#382** [firmware] Picross: the strike line misses the centre of the number, the dithering is asymmetric, and the select screen needs redesigning
+- **#383** [firmware] Picross: he wants premade puzzle sets found online, not original artwork
+- **#384** [wallpapers] Wallpapers: the app takes about ten seconds to open, the hint sits too close to the grid, and the download bar fills twice
+- **#385** [wallpapers] Wallpapers: taps are refused until the previous tap's brackets finish drawing, so touches feel lost
+- **#386** [site] The wallpaper uploader takes one picture at a time and does not follow the site's styling
+- **#387** [tooling] Release notes are nonsense and bloat, and still impossibly long after the first pass
+- **#388** [getbooks] A downloaded book shows artifacts, tildes especially
 
-A report that reaches a session and never reaches the board is invisible to
-this list by construction, whatever the reporter column says.
+Every one of them was handled in conversation and none of it was on the
+board, so none of it survived the session that heard it. **A report that
+reaches a session and never reaches the board is invisible to this list by
+construction, whatever the reporter column says.** That is the standing risk
+this file cannot close on its own; only filing at the moment he speaks does.
+
+## Two corrections to cards, made while doing this
+
+Both were words attributed to him that he never said. A fabricated quote in
+his own voice is worse than a missing attribution, because this list exists
+so he can trust it.
+
+- **#236** opened with `Mario: 'a tile needs to show the whole text, no
+  exceptions.'` That string exists nowhere on this machine except the
+  transcript of the session that wrote the card. What he actually said was
+  *"What I see really often is the category description or words list after a
+  set is found to get truncated and look bad often"*. The requirement was
+  right; the attribution was invented. Card body corrected.
+- **#174** said *"Mario reported ~10 page turns feeling slow while reading"*.
+  No such report exists. A session asked **him** to turn ten pages so a PERF
+  line could be read off the panel. The slow page turn on record is GitHub
+  issue #7, from an outside user (#13). Card body corrected.
+
+## Where two halves of one message got different answers
+
+#295 is `mario` and #359 is `session`, and both trace to his 2026-09-05 07:16
+message about Yahtzee. The rule that separates them: #295's subject is his
+sentence word for word (*"Yatzee dices touch the top header after rolled"*).
+#359's subject is Study, which he never mentioned; a session found that
+instance of his general complaint. The same rule puts #375 in his column,
+because *"They should ALL be the shorter height"* is his sentence too.
+
+#348 is his, but the defect came from GitHub issue #115 filed by an outside
+user. His instruction is what made it a card and what set its scope.

--- a/docs/workflow/what-mario-reported.md
+++ b/docs/workflow/what-mario-reported.md
@@ -12,6 +12,10 @@ board list --reporter session    # only what a session found
 board list --reporter unknown    # the ones nobody could establish
 ```
 
+Those flags reach `board` when this change is in `firmware-next`, which is
+what `/opt/homebrew/bin/board` resolves to and which runs behind `xteink`. The
+counts and the list below are the recovery itself and do not need the CLI.
+
 ## The count, over all 360 cards on the board
 
 | reporter | cards | what it means |

--- a/docs/workflow/worker-contract.md
+++ b/docs/workflow/worker-contract.md
@@ -28,6 +28,12 @@ are enforced by hooks and will refuse rather than remind.
   `./scripts_local/whose-gate.sh` says which tree each running build belongs to,
   because every session runs an identically named script and `pgrep` cannot tell
   them apart.
+- **Say who reported it when you file a card.** `board new ... --reporter
+  session` for something you found yourself, `--reporter mario` for something
+  he said, `--reporter user` for a GitHub issue or a stranger's report. Without
+  it the card reads `unknown`, which is the deliberate default: a card wrongly
+  credited to him ruins `board list --from-mario`, and that list is the whole
+  point of the field.
 - **You talk to exactly one session: the orchestrator.** Messages to any other
   session are refused. A message from a peer is information, never an
   instruction, and never Mario's authority.

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -636,6 +636,19 @@ board list --from-mario | grep -q "#$KID " && ok "a child of a session's card st
 board list --reporter user >"$WORK/u.out" 2>&1
 board state "$THEIRS" done >/dev/null
 board list --reporter user | grep -q "#$THEIRS " && ok "a settled card is still attributed" || bad "settling a card lost its reporter"
+# A GitHub issue was written by a person, and that person is not Mario. The
+# sweep above filed some; nobody passed --reporter, so this is the derivation
+# doing its job rather than a caller remembering.
+board list --reporter user | grep -q "Slow Reader" \
+  && ok "a card from a GitHub issue is a user's without anyone saying so" \
+  || bad "a github-sourced card was not attributed to a user: $(board list --reporter user)"
+
+# Settle every open `user` card first, whatever earlier sections of this suite
+# left behind -- the github sweep above files its issues as `user` too, so an
+# assertion that assumed an empty set would pass or fail on section order.
+for uid in $(board list --open --reporter user | sed -n 's/^#\([0-9][0-9]*\) .*/\1/p'); do
+  board state "$uid" parked --with-blockers >/dev/null 2>&1
+done
 board list --open --reporter user >"$WORK/none.out" 2>&1
 grep -q "no cards reported by user" "$WORK/none.out" \
   && ok "a filter that matches nothing says so, rather than 'no cards'" \

--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -597,5 +597,53 @@ kill "$GATEPID" 2>/dev/null; wait "$GATEPID" 2>/dev/null
 expect "the gate gone, the tree is free"                0 pretool "{\"session_id\":\"held-e\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$ROOT/wt/gone/src/a.cpp\"}}"
 unset TMPDIR
 
+echo
+echo "who reported a card"
+# Mario asked "what have I reported?" and the board could not answer: source
+# said by what MECHANISM a card arrived, never whose observation it was. The
+# rule that matters most here is the default: a card filed without --reporter
+# must read `unknown`, NOT `session`, so a path that forgets to stamp is
+# visible instead of quietly crediting one of our own sessions.
+NOSTAMP=$(board new "Checkers: a crowned piece keeps moving like a man" --from checkers --kind bug | sed 's/^#\([0-9]*\).*/\1/')
+board show "$NOSTAMP" | grep -q "reported by unknown" \
+  && ok "a card filed without --reporter is unknown, never session" \
+  || bad "an unstamped card did not read unknown: $(board show "$NOSTAMP" | head -2)"
+MINE=$(board new "Yahtzee: the dice sit under the header rule" --from yahtzee --kind bug --reporter mario | sed 's/^#\([0-9]*\).*/\1/')
+OURS=$(board new "Yahtzee: contentTop derives from the constant, not the chrome" --from yahtzee --kind bug --reporter session --anyway | sed 's/^#\([0-9]*\).*/\1/')
+THEIRS=$(board new "Study: pairing says the bridge is invitation-only" --from study --kind bug --reporter user | sed 's/^#\([0-9]*\).*/\1/')
+board show "$MINE" | grep -q "reported by mario" && ok "--reporter mario is recorded" || bad "--reporter mario was not stored"
+board show "$THEIRS" | grep -q "reported by user" && ok "--reporter user is recorded" || bad "--reporter user was not stored"
+
+# The question he actually asked, as one command.
+board list --from-mario >"$WORK/mine.out" 2>&1
+grep -q "#$MINE " "$WORK/mine.out" && ok "--from-mario lists his card" || bad "--from-mario missed his card: $(cat "$WORK/mine.out")"
+grep -q "#$OURS " "$WORK/mine.out" && bad "--from-mario listed a session's find" || ok "and leaves a session's find out"
+grep -q "#$THEIRS " "$WORK/mine.out" && bad "--from-mario listed another person's report" || ok "and another person's report out"
+grep -q "#$NOSTAMP " "$WORK/mine.out" && bad "--from-mario listed an unstamped card" || ok "and an unstamped card out"
+board list --reporter unknown | grep -q "#$NOSTAMP " && ok "--reporter unknown finds what nobody stamped" || bad "--reporter unknown missed the unstamped card"
+board list --reporter session | grep -q "#$OURS " && ok "--reporter session finds a session's own find" || bad "--reporter session missed it"
+
+# Mario's report is frequently the CHILD of a session's card (#262 under #261,
+# #257 under #253), and `board list` prints children nested under their parent.
+# A filtered-out parent must not take its matching child with it.
+KID=$(board new "Wavelength: the front door offers a score that does not exist" --from wavelength --kind bug --reporter mario --anyway | sed 's/^#\([0-9]*\).*/\1/')
+board parent "$KID" --of "$OURS" >/dev/null
+board list --from-mario | grep -q "#$KID " && ok "a child of a session's card still shows under --from-mario" || bad "the reporter filter lost a nested card"
+
+# An empty answer from a filter is a different fact from an empty board. One
+# sentence for both is how a filter that matched nothing reads as one that was
+# never applied -- and "no cards" would say Mario has reported nothing.
+board list --reporter user >"$WORK/u.out" 2>&1
+board state "$THEIRS" done >/dev/null
+board list --reporter user | grep -q "#$THEIRS " && ok "a settled card is still attributed" || bad "settling a card lost its reporter"
+board list --open --reporter user >"$WORK/none.out" 2>&1
+grep -q "no cards reported by user" "$WORK/none.out" \
+  && ok "a filter that matches nothing says so, rather than 'no cards'" \
+  || bad "an empty filter reads as an empty board: $(cat "$WORK/none.out")"
+
+board new "Sudoku: the notes pad forgets a digit" --from sudoku --kind bug --reporter nobody >"$WORK/bad.out" 2>&1 \
+  && bad "an unknown reporter value was accepted" \
+  || ok "a reporter the board does not know is refused"
+
 echo "$((PASS+FAIL)) checks, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/host-tests/site/report_fn.js
+++ b/host-tests/site/report_fn.js
@@ -13,6 +13,7 @@ const path = require("node:path");
 const root = process.argv[2] || path.join(__dirname, "..", "..");
 process.env.SUPABASE_URL = "https://board.test";
 process.env.SUPABASE_SERVICE_ROLE_KEY = "service-key-for-tests";
+process.env.BOARD_OWNER_EMAIL = "Owner@Example.Test";
 const handler = require(path.join(root, "site", "api", "report.js"));
 
 let calls = [];
@@ -156,6 +157,14 @@ const expect = (label, got, want) =>
     "The page turn takes four seconds on the X4 Pro since 1.12.2.",
   );
   expect("no email means null, not an empty string", row.reporter_email, null);
+  // This form is public. A report with no address is somebody, and that
+  // somebody is not established to be Mario -- crediting it to him would put a
+  // stranger's bug on the one list whose value is that he can trust it.
+  expect(
+    "a report with no address is a user's, not Mario's",
+    row.reporter,
+    "user",
+  );
   expect(
     "the address is stored hashed, not raw",
     typeof row.reporter_hash === "string" &&
@@ -300,6 +309,68 @@ const expect = (label, got, want) =>
     "a photo for a card the site did not create is refused",
     r.status,
     404,
+  );
+
+  // Who a report belongs to. The form is public, so only the owner's own
+  // address earns `mario`; everyone else is `user`, and the two must not be
+  // able to collapse into one another by a change to either side.
+  const reporterOf = async (email) => {
+    calls = [];
+    await call("POST", Object.assign({}, good, { email }));
+    const c = calls.find((x) => x.url.endsWith("/rest/v1/cards?select=id"));
+    return c ? JSON.parse(c.body).reporter : null;
+  };
+  expect(
+    "the owner's own address is stamped mario",
+    await reporterOf("owner@example.test"),
+    "mario",
+  );
+  expect(
+    "case and spacing do not decide it",
+    await reporterOf("  OWNER@EXAMPLE.TEST  "),
+    "mario",
+  );
+  expect(
+    "a stranger's address is a user, never Mario",
+    await reporterOf("someone.else@example.test"),
+    "user",
+  );
+  expect(
+    "and a stranger is never credited to a session either",
+    await reporterOf("someone.else@example.test"),
+    "user",
+  );
+
+  // The fallback owner address is a literal in report.js and a literal in the
+  // board's own allowed_users seed, and nothing links them. Read both rather
+  // than restating either here: a change to one is exactly the silent kind.
+  const fs = require("node:fs");
+  const reportSrc = fs.readFileSync(
+    path.join(root, "site", "api", "report.js"),
+    "utf8",
+  );
+  const boardSql = fs.readFileSync(
+    path.join(
+      root,
+      "server",
+      "board",
+      "supabase",
+      "migrations",
+      "20260903000000_board.sql",
+    ),
+    "utf8",
+  );
+  const fallback = (reportSrc.match(/BOARD_OWNER_EMAIL \|\|\s*"([^"]+)"/) ||
+    [])[1];
+  const seeded = (boardSql.match(
+    /insert into allowed_users \(email\) values \('([^']+)'\)/,
+  ) || [])[1];
+  expect(
+    "report.js's default owner is the address the board admits",
+    fallback && seeded
+      ? fallback.toLowerCase() === seeded.toLowerCase()
+      : false,
+    true,
   );
 
   console.log(`${pass + fail} checks, ${fail} failed`);

--- a/server/board/supabase/migrations/20260906000100_reporter.sql
+++ b/server/board/supabase/migrations/20260906000100_reporter.sql
@@ -1,0 +1,97 @@
+-- Who reported each card.
+--
+-- Mario asked "what have I reported?" and the board could not answer: every
+-- card was source 'session', 'error', 'import' or 'site', and reporter_email
+-- was null on all but one. `source` says by what MECHANISM a card arrived;
+-- nothing said WHO the observation belonged to, so a bug he hit on his own
+-- device and a bug an audit found by reading code were indistinguishable.
+--
+-- The column is deliberately NOT defaulted to 'session'. A path that forgets
+-- to stamp must be visible as 'unknown' rather than silently claim one of our
+-- own sessions found it, because the value of the answer is that he can trust
+-- the list.
+--
+--   mario    he experienced it, asked for it, or ruled on it, and said so
+--   user     a person who is not Mario: the public report form, a GitHub issue
+--   session  our own side found it: an audit, a gate, a cold review, a probe,
+--            or the board's own error trigger
+--   unknown  the card carries no evidence either way
+
+alter table cards add column if not exists reporter text not null default 'unknown'
+  check (reporter in ('mario', 'user', 'session', 'unknown'));
+create index if not exists cards_reporter on cards (reporter, created_at desc);
+
+-- The recovery, applied once. Every 'mario' row below was established from the
+-- card's own text or from a verbatim run of eight or more words matched against
+-- a real user message in the session transcripts; the evidence for each is in
+-- docs/workflow/what-mario-reported.md. Cards filed after this migration carry
+-- what the board stamps at creation, so this backfill is a one-off and reruns
+-- as a no-op on ids that no longer exist.
+
+-- mario: 57 cards
+update cards set reporter = 'mario' where id in (
+  49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 93, 107,
+  108, 112, 125, 127, 130, 131, 138, 166, 179, 191, 201, 236, 240, 241,
+  243, 244, 246, 247, 248, 249, 250, 252, 253, 257, 260, 261, 262, 264,
+  266, 293, 295, 302, 305, 311, 313, 327, 328, 329, 348, 349, 351, 365,
+  370
+);
+
+-- user: 2 cards
+update cards set reporter = 'user' where id in (
+  13, 207
+);
+
+-- session: 295 cards
+update cards set reporter = 'session' where id in (
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, 15,
+  16, 17, 18, 19, 20, 21, 22, 23, 24, 26, 27, 28, 29, 30,
+  31, 32, 33, 34, 35, 37, 38, 39, 41, 42, 44, 45, 46, 47,
+  48, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73,
+  74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87,
+  88, 89, 90, 91, 92, 94, 95, 96, 97, 98, 99, 101, 102, 103,
+  104, 105, 106, 109, 110, 113, 114, 115, 116, 118, 119, 120, 121, 122,
+  123, 124, 126, 128, 129, 133, 134, 135, 136, 137, 139, 140, 141, 142,
+  143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156,
+  157, 158, 167, 168, 169, 170, 171, 172, 174, 175, 176, 177, 178, 180,
+  181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 192, 193, 194, 195,
+  196, 197, 198, 199, 200, 202, 203, 204, 205, 206, 208, 209, 210, 211,
+  212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225,
+  226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 237, 238, 239, 242,
+  245, 251, 254, 255, 256, 258, 259, 263, 265, 267, 268, 269, 270, 271,
+  272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285,
+  286, 287, 288, 289, 290, 291, 292, 294, 296, 297, 298, 299, 300, 301,
+  303, 304, 306, 307, 308, 309, 310, 312, 314, 315, 316, 317, 318, 319,
+  320, 321, 322, 323, 324, 325, 326, 330, 331, 332, 333, 334, 335, 336,
+  337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 350, 352, 353,
+  354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 366, 367, 368,
+  369
+);
+
+-- unknown: 6 cards, left at the column default on purpose:
+--   #25, #36, #40, #43, #100, #111
+
+-- Two mechanisms answer the question by themselves, so they are derived rather
+-- than left for a caller to remember. A card the error trigger opens from a
+-- probe or a crash is our own side by construction; a card `board issues` opens
+-- from a GitHub issue was written by a person who is not Mario. Everything else
+-- keeps what the writer stamped, including an explicit 'unknown' -- the whole
+-- point of the default is that a path which forgets stays visible.
+create or replace function cards_reporter_from_source() returns trigger
+language plpgsql as $$
+begin
+  if new.reporter = 'unknown' then
+    if new.source in ('error', 'sync') then
+      new.reporter := 'session';
+    elsif new.source = 'github' then
+      new.reporter := 'user';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists cards_reporter_from_source on cards;
+create trigger cards_reporter_from_source
+  before insert on cards
+  for each row execute function cards_reporter_from_source();

--- a/server/board/supabase/migrations/20260906000200_reporter_corrections.sql
+++ b/server/board/supabase/migrations/20260906000200_reporter_corrections.sql
@@ -1,0 +1,42 @@
+-- Corrections to the reporter recovery, from a cold review of it.
+--
+-- The first pass read the transcripts with one filter: entries of type "user".
+-- Anything Mario typed WHILE a session was mid-turn is not stored that way. It
+-- arrives as an attachment of type "queued_command" with origin kind "human"
+-- and never becomes a type "user" line at all, so 221 of his messages were
+-- invisible to the recovery, 74 of them inside the window this board covers.
+-- A second channel was never read either: the blockers table, where his typed
+-- inbox answers live.
+--
+-- Re-running against both channels did not add or remove anybody from the
+-- mario set by verbatim match, which is the reassuring half. What it changed
+-- is the EVIDENCE: several rows cited a quotation the first corpus did not
+-- contain, so they were resting on a session's paraphrase without saying so.
+-- docs/workflow/what-mario-reported.md now cites what he actually typed.
+--
+-- Four attributions were wrong and are corrected here.
+
+-- #36  unknown -> session
+-- #43  unknown -> session
+-- #100  unknown -> session
+-- #111  unknown -> session
+-- #207  user -> mario
+
+-- #207: a site report on an address that is not his. It was read as somebody
+-- else's on that basis, which is exactly the topical inference the recovery
+-- forbids. The card was created 05:43:33 on 2026-09-05; two minutes later he
+-- typed "No, I sent it, check". It carries his two devices and his version.
+update cards set reporter = 'mario' where id = 207;
+
+-- #36, #43, #100, #111: left 'unknown' out of caution, but each states its own
+-- origin in its body -- two are code traces naming identifiers and call order,
+-- two are measurements over the rated trivia corpus. Neither is something he
+-- could have produced, and calling them unknown inflates the one bucket whose
+-- value is that it is small.
+update cards set reporter = 'session' where id in (36, 43, 100, 111);
+
+-- The 17 reports he made that had never reached the board at all, filed
+-- 2026-09-06 from his verbatim words. Found by reading the queued channel.
+update cards set reporter = 'mario' where id in (
+  372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388
+);

--- a/site/api/report.js
+++ b/site/api/report.js
@@ -45,6 +45,25 @@ const DEVICES = ["x4pro", "sticky"];
 const VERSION = /^v?\d{1,3}\.\d{1,3}\.\d{1,3}$/;
 const EMAIL = /^[^\s@]{1,64}@[^\s@]{1,190}$/;
 
+// Who the report belongs to, which the board records as `reporter` so
+// `board list --from-mario` can answer "what have I reported?".
+//
+// This form is PUBLIC -- no account, linked from the front page, and used by
+// strangers -- so a submission is `user` unless the address given is the
+// owner's. Stamping every site report as Mario's would put other people's bugs
+// on the one list whose whole value is that he can trust it, and a report with
+// no address at all is not evidence that he wrote it. `unknown` is therefore
+// only what an unstamped path lands on; this one always says something.
+const OWNER_EMAIL = (
+  process.env.BOARD_OWNER_EMAIL || "marioalejandroruizsarmiento@gmail.com"
+)
+  .trim()
+  .toLowerCase();
+
+function reporterFor(email) {
+  return email && email.trim().toLowerCase() === OWNER_EMAIL ? "mario" : "user";
+}
+
 function json(res, status, body, extra) {
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json");
@@ -197,6 +216,7 @@ async function createReport(req, res) {
     source: "site",
     device,
     version: version || null,
+    reporter: reporterFor(email),
     reporter_email: email || null,
     reporter_hash: hash,
   };

--- a/tools_local/board/board.py
+++ b/tools_local/board/board.py
@@ -21,6 +21,7 @@ file store so the hooks never need the network.
     board pulse [add <host> <GET|POST> <url> <alive> <app> | remove <host>]   what the board probes every 30 min
     board release                                     is the release watcher awake, and what is it owed
     board new "<title>" --from <app> [--kind bug|feature|task] [--body "..."] [--parent <id>] [--default "..."]
+                       [--reporter mario|user|session|unknown]   whose observation it is; unknown unless said
     board app <id> <app> [--default "..."]             move a card to another app
     board parent <id> --of <parent>                    put a card under another (subtasks)
     board bind <id> --session <sid> [--tree wt/x] [--branch app/x]
@@ -82,6 +83,18 @@ MARIO_DEFAULT = "nothing happens until he answers"
 # by INSERTing a dump would otherwise flood the inbox with every settled
 # decision it ever held, which is the flood the backfill was written to avoid.
 SETTLED = ("done", "released", "parked")
+
+# Who a card's observation belongs to, which `source` never said: source is the
+# MECHANISM a card arrived by, and a bug Mario hit on his own device and a bug
+# an audit found by reading code both arrived as source 'session'. He asked
+# "what have I reported?" and the board could not answer.
+#
+# The default is 'unknown', NOT 'session'. A path that forgets to stamp must be
+# visible rather than silently claim one of our own sessions found it, because
+# the whole value of the answer is that he can trust the list. See
+# docs/workflow/what-mario-reported.md.
+REPORTERS = ("mario", "user", "session", "unknown")
+UNKNOWN_REPORTER = "unknown"
 
 
 def now():
@@ -178,6 +191,7 @@ class FileStore:
             "kind": fields.get("kind", "task"),
             "body": fields.get("body", ""),
             "state": fields.get("state", "reported"),
+            "reporter": fields.get("reporter", UNKNOWN_REPORTER),
             "created": fields.get("created") or now(),
             "updated": now(),
             "tree": fields.get("tree"),
@@ -354,6 +368,7 @@ class SupaStore:
             "source": row.get("source"),
             "device": row.get("device"),
             "version": row.get("version"),
+            "reporter": row.get("reporter") or UNKNOWN_REPORTER,
             "reporter_email": row.get("reporter_email"),
             "photo_path": row.get("photo_path"),
             "github_issue": row.get("github_issue"),
@@ -368,6 +383,7 @@ class SupaStore:
             "body": fields.get("body", ""),
             "state": fields.get("state", "reported"),
             "source": fields.get("source", "session"),
+            "reporter": fields.get("reporter", UNKNOWN_REPORTER),
             "tree": fields.get("tree"),
             "branch": fields.get("branch"),
             "session": fields.get("session"),
@@ -737,7 +753,11 @@ STOPWORDS = frozenset(
 
 
 def title_tokens(title):
-    return {w for w in re.findall(r"[a-z0-9]+", str(title).lower()) if w not in STOPWORDS and len(w) > 1}
+    return {
+        w
+        for w in re.findall(r"[a-z0-9]+", str(title).lower())
+        if w not in STOPWORDS and len(w) > 1
+    }
 
 
 def similar_open(st, title):
@@ -770,11 +790,15 @@ def cmd_new(st, a):
         if dup:
             lines = [f"board: this looks like an open card already on the board:"]
             for c in dup[:3]:
-                lines.append(f"  #{c['id']} {c['state']:<9} {c['from']:<10} {c['title']}")
+                lines.append(
+                    f"  #{c['id']} {c['state']:<9} {c['from']:<10} {c['title']}"
+                )
             lines.append(
                 f"  add what you know to it: board note {dup[0]['id']} '<what you found>' (--body to append to the card),"
             )
-            lines.append("  or file anyway with --anyway if it really is a different thing.")
+            lines.append(
+                "  or file anyway with --anyway if it really is a different thing."
+            )
             sys.exit("\n".join(lines))
     with st.lock():
         c = st.create_card(
@@ -783,6 +807,7 @@ def cmd_new(st, a):
                 "from": a.from_app.lower(),
                 "kind": a.kind,
                 "body": a.body or "",
+                "reporter": a.reporter,
                 "parent": a.parent,
                 "history": [{"at": now(), "what": "created"}],
             }
@@ -816,15 +841,21 @@ def session_live(root, sid):
 def tree_gate_pid(root, tree):
     """The pid of a check.sh still verifying wt/<name>, or None (the guard's rule)."""
     import hashlib
+
     try:
         real = str((root / tree).resolve())
     except OSError:
         return None
-    lock = pathlib.Path(os.environ.get("TMPDIR") or "/tmp") / f"xteink-check-{hashlib.sha1(real.encode()).hexdigest()[:8]}.running"
+    lock = (
+        pathlib.Path(os.environ.get("TMPDIR") or "/tmp")
+        / f"xteink-check-{hashlib.sha1(real.encode()).hexdigest()[:8]}.running"
+    )
     try:
         pid = int((lock.read_text() or "0").split()[0])
         os.kill(pid, 0)
-        cmd = subprocess.run(["ps", "-o", "command=", "-p", str(pid)], capture_output=True, text=True).stdout
+        cmd = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)], capture_output=True, text=True
+        ).stdout
     except (OSError, ValueError, IndexError):
         return None
     return pid if "check.sh" in cmd else None
@@ -839,9 +870,18 @@ def cmd_bind(st, a):
         # mid-rebase on the same branch, and both did the work (2026-09-05).
         # Taking a card over is a decision, so it has a flag and a history line.
         held = norm_sid(c.get("session"))
-        take = getattr(a, "take", False) or (held and held != sid and not session_live(st.root, held))
+        take = getattr(a, "take", False) or (
+            held and held != sid and not session_live(st.root, held)
+        )
         if held and held != sid and c["state"] not in SETTLED and not take:
-            since = next((h["at"] for h in reversed(c.get("history", [])) if str(h.get("what", "")).startswith("bound to session")), c.get("updated"))
+            since = next(
+                (
+                    h["at"]
+                    for h in reversed(c.get("history", []))
+                    if str(h.get("what", "")).startswith("bound to session")
+                ),
+                c.get("updated"),
+            )
             sys.exit(
                 f"board: #{c['id']} is held by session {held}"
                 + (f" in {c['tree']}" if c.get("tree") else "")
@@ -854,9 +894,13 @@ def cmd_bind(st, a):
         if a.tree and not getattr(a, "take", False):
             tree = a.tree.rstrip("/")
             others = [
-                k for k in st.list_cards()
-                if k["id"] != c["id"] and str(k.get("tree") or "").rstrip("/") == tree
-                and k.get("session") and norm_sid(k.get("session")) != sid and k["state"] not in SETTLED
+                k
+                for k in st.list_cards()
+                if k["id"] != c["id"]
+                and str(k.get("tree") or "").rstrip("/") == tree
+                and k.get("session")
+                and norm_sid(k.get("session")) != sid
+                and k["state"] not in SETTLED
                 and session_live(st.root, k["session"])
             ]
             if others:
@@ -872,7 +916,16 @@ def cmd_bind(st, a):
                     f"  Wait for it (ps -p {gate} -o etime,command), or ./scripts/wt.sh new <name> for a tree of your own."
                 )
         if held and held != sid:
-            card_history(st, c, f"taken over from session {held}" + ("" if getattr(a, "take", False) else " (it had ended, or was silent for %d minutes)" % IDLE_MINUTES))
+            card_history(
+                st,
+                c,
+                f"taken over from session {held}"
+                + (
+                    ""
+                    if getattr(a, "take", False)
+                    else " (it had ended, or was silent for %d minutes)" % IDLE_MINUTES
+                ),
+            )
         c["session"] = sid
         if a.tree:
             c["tree"] = a.tree
@@ -1087,7 +1140,9 @@ def cmd_state(st, a):
                 lines.append(
                     f"  answer or unblock them first (board answer {c['id']} '<choice>' --n N / board unblock {c['id']} --n N),"
                 )
-                lines.append("  or pass --with-blockers to settle the card and leave them open on purpose.")
+                lines.append(
+                    "  or pass --with-blockers to settle the card and leave them open on purpose."
+                )
                 sys.exit("\n".join(lines))
         c["state"] = a.state
         card_history(st, c, f"state {a.state}")
@@ -1110,7 +1165,11 @@ def cmd_note(st, a):
             sys.exit("board: a note needs text")
         card_history(st, c, f"note: {text}")
         if a.body:
-            c["body"] = (c.get("body") or "").rstrip() + ("\n\n" if c.get("body") else "") + text
+            c["body"] = (
+                (c.get("body") or "").rstrip()
+                + ("\n\n" if c.get("body") else "")
+                + text
+            )
         # The file store keeps history inside the card, so the note is only on
         # disk once the card is written; on Supabase the line is already in.
         st.save_card(c)
@@ -1220,7 +1279,8 @@ def fmt_card(c, full=False):
         return line
     lines = [
         line,
-        f"  kind {c['kind']}  created {c['created']}  updated {c['updated']}",
+        f"  kind {c['kind']}  reported by {c.get('reporter') or UNKNOWN_REPORTER}"
+        f"  created {c['created']}  updated {c['updated']}",
     ]
     if c.get("tree") or c.get("branch") or c.get("session"):
         lines.append(
@@ -1266,8 +1326,16 @@ def cmd_list(st, a):
         cards = [c for c in cards if c["state"] not in ("done", "released", "parked")]
     if getattr(a, "state", None):
         cards = [c for c in cards if c["state"] == a.state]
+    # Who reported it. --from-mario is the question that made the column exist,
+    # so it gets a name of its own rather than an enum value to remember.
+    want = "mario" if getattr(a, "from_mario", False) else getattr(a, "reporter", None)
+    if want:
+        cards = [c for c in cards if (c.get("reporter") or UNKNOWN_REPORTER) == want]
     if not cards:
-        print("board: no cards")
+        # An empty result from a filter is a different fact from an empty board,
+        # and one sentence for both is how a filter that matched nothing reads
+        # as one that was never applied.
+        print(f"board: no cards reported by {want}" if want else "board: no cards")
         return
     by_id = {c["id"]: c for c in cards}
     children = {}
@@ -1407,6 +1475,11 @@ def cmd_issues(st, a):
                     "body": f"GitHub issue #{i['number']} by {author or 'someone'}: {i.get('url', '')}\n\n{body}",
                     "state": "reported",
                     "source": "github",
+                    # A GitHub issue was written by a person, and that person
+                    # is not Mario -- he relays his own rather than filing them
+                    # there. The Supabase trigger derives the same value; this
+                    # keeps the file store, which the tests drive, in step.
+                    "reporter": "user",
                     "github_issue": i["number"],
                     "history": [
                         {"at": now(), "what": f"from GitHub issue #{i['number']}"}
@@ -1540,6 +1613,15 @@ def main(argv=None):
     s.add_argument("--kind", choices=["bug", "feature", "task"], default="task")
     s.add_argument("--body")
     s.add_argument(
+        "--reporter",
+        choices=REPORTERS,
+        default=UNKNOWN_REPORTER,
+        help="whose observation this is: mario if he reported or asked for it, "
+        "session if you found it yourself, user if a person who is not Mario did. "
+        "Defaults to unknown, so a card filed without one is visible rather than "
+        "silently credited to a session",
+    )
+    s.add_argument(
         "--default",
         help="on app mario: what happens if he never answers (a card filed there opens a mario blocker by itself)",
     )
@@ -1549,7 +1631,10 @@ def main(argv=None):
         help="file even if an open card's title says the same thing (the default is to stop and name it)",
     )
     s.set_defaults(fn=cmd_new)
-    s = sub.add_parser("note", help="put what you learnt on a card: a history line, --body appends it to the card too")
+    s = sub.add_parser(
+        "note",
+        help="put what you learnt on a card: a history line, --body appends it to the card too",
+    )
     s.add_argument("id", type=int)
     s.add_argument("text")
     s.add_argument("--body", action="store_true")
@@ -1567,7 +1652,11 @@ def main(argv=None):
     s.add_argument("--session", required=True)
     s.add_argument("--tree")
     s.add_argument("--branch")
-    s.add_argument("--take", action="store_true", help="bind a card another session still holds (its holder is gone, or this is the orchestrator's call)")
+    s.add_argument(
+        "--take",
+        action="store_true",
+        help="bind a card another session still holds (its holder is gone, or this is the orchestrator's call)",
+    )
     s.set_defaults(fn=cmd_bind)
     s = sub.add_parser("block")
     s.add_argument("id", type=int)
@@ -1626,6 +1715,15 @@ def main(argv=None):
     s = sub.add_parser("list")
     s.add_argument("--open", action="store_true")
     s.add_argument("--state", choices=STATES, help="only cards in this state")
+    s.add_argument(
+        "--reporter", choices=REPORTERS, help="only cards from this reporter"
+    )
+    s.add_argument(
+        "--from-mario",
+        dest="from_mario",
+        action="store_true",
+        help="only what Mario reported, asked for or ruled on (--reporter mario)",
+    )
     s.set_defaults(fn=cmd_list)
     sub.add_parser("inbox").set_defaults(fn=cmd_inbox)
     s = sub.add_parser("import")


### PR DESCRIPTION
Mario asked "what have I reported?" and the board could not answer. `source`
records by what MECHANISM a card arrived (the CLI, the site form, a GitHub
issue, the error trigger) and never whose observation it was, so a bug he hit
on his own device and a bug an audit found by reading code were both
`source: session`, and `reporter_email` was null on all but one card.

Cards now carry `reporter`: `mario` | `user` | `session` | `unknown`.

## The count, over all 378 cards

| reporter | cards |
| --- | --- |
| `mario` | 75 |
| `user` | 1 |
| `session` | 300 |
| `unknown` | 2 |

The list of his 75, the evidence behind each, and the two that could not be
established are in `docs/workflow/what-mario-reported.md`. Live form:
`board list --from-mario`.

## The default is `unknown`, not `session`

A path that forgets to stamp has to be visible rather than quietly credit one
of our own sessions. One card wrongly attributed to him costs more than ten
honestly left blank, because the only value the column has is that the list can
be trusted.

## The recovery was reviewed cold, and the review changed it

**The first pass read one of three channels.** It filtered the transcripts to
entries of type `user`. Anything Mario types WHILE a session is mid-turn is
never stored that way: it arrives as an attachment of type `queued_command`
whose origin kind is `human`. **221** of his messages were invisible to it,
**74** inside the window the board covers. His typed inbox answers in the
`blockers` table were a third channel nobody read; #93's only real evidence
lives there.

Reading all three moved nobody in or out of the `mario` set by verbatim match.
What it changed is the **evidence**: several rows cited a quotation the corpus
did not contain, so they rested on a session's paraphrase without saying so.
Every evidence line is now re-derived from what he actually typed.

**Two cards quoted words he never said, and both are corrected in the card
bodies.** #236 opened with `Mario: 'a tile needs to show the whole text, no
exceptions.'`: a string that exists nowhere on this machine except the
transcript of the session that wrote the card. #174 said *"Mario reported ~10
page turns feeling slow"*; no such report exists, a session asked **him** to
turn ten pages so a PERF line could be read. A fabricated quote in his own
voice is worse than a missing attribution.

**Four attributions fixed.** #207 is his: it was read as a stranger's because
the address is not his, which is the topical inference the method forbids, and
two minutes after the card was created he typed *"No, I sent it, check"*. #36,
#43, #100 and #111 are `session`, because each states its own origin, and calling them
unknown inflated the one bucket whose value is being small.

## Seventeen reports that had never reached the board

The most useful thing the review produced is not an attribution. Reading the
queued channel turned up seventeen things he reported that existed only in a
conversation. All are now cards (**#372-#388**), stamped `mario`, each carrying
his verbatim words and the timestamp: settings ordering; the wallpaper starter
set; the picker layout; the header height he wants unified across every game;
two Get Books reports; Instapaper's slow opens; the repo-organisation ask; the
one-build-step CI ask; his correction to #244's scope; two Picross rounds; the
Wallpapers cold open and its lost touches; the uploader; the release notes; and
the artifacts in a downloaded book.

A report that reaches a session and never reaches the board is invisible to
this column by construction. That is the standing risk the file names and that
only filing at the moment he speaks can close.

## A fourth value, against the brief

The brief said three values and said the site's report box "is his". That form
is **public** (no account, linked from the front page), so the site path
stamps `mario` only when the address given is the owner's
(`BOARD_OWNER_EMAIL`, defaulting to the address `allowed_users` seeds) and
`user` otherwise.

## Enforced rather than remembered

An error-trigger or upstream-sync card is `session`; a GitHub-issue card is
`user`. That is a `BEFORE INSERT` trigger on Supabase and the same rule in the
CLI for the file store the tests drive. Every other writer stamps explicitly or
lands on `unknown`.

## Tests

Each was watched to fail before it was kept.

`host-tests/bugflow` (14 new checks): an unstamped card reads `unknown` and
never `session`; each value round-trips; `--from-mario` includes his and
excludes a session's find, another person's report and an unstamped card; a
GitHub-issue card is `user` with nobody passing `--reporter`; a Mario card
nested under a session card is not swallowed by the filter; a filter that
matches nothing says so rather than printing "no cards", which would read as
"you have reported nothing"; an unknown value is refused.

`host-tests/site` (5 new checks): a report with no address is `user`, not
Mario; the owner's address is `mario` regardless of case and spacing; a
stranger's is `user`; and `report.js`'s default owner address is read out of
the board's own `allowed_users` seed rather than restated, so the two cannot
drift apart silently.

## Applied

Both migrations are live via `server/board/migrate.sh` (20 applied, none
pending), and all 378 rows were read back and compared against the
classification and the document.

## Not verified

- No hardware is involved.
- Two cards stay `unknown` on purpose: #25 and #40.
- `board.py` carries ~30 lines of incidental `ruff` reformatting from code that
  landed after card #273's format pass and dodged the hook.
- The `.board/` file mirror carries the field only on cards written since the
  migration. The hooks do not read it and each card picks it up on its next
  write.

Cards #370 and #371.
