### PR TITLE
Wallpapers: choose several wallpapers, and let them take turns

### DIFF
--- a/docs/apps/wallpapers-shuffle.md
+++ b/docs/apps/wallpapers-shuffle.md
@@ -1,0 +1,287 @@
+# Wallpapers: choosing a set, and letting it take turns
+
+Card #305. Mario asked twice: *"didn't we agree to have a way to select multiple
+ones at the same time and for them to cycle?"*
+
+This is the design, written before the code, revised by a cold critic before a
+line was written, and corrected afterwards where the critic proved it wrong.
+Vocabulary note (#313): **rotation here means cycling through wallpapers**,
+never screen orientation.
+
+## What the platform already does
+
+Nothing here schedules anything. `SleepActivity::renderCustomSleepScreen`
+(UPSTREAM, `src/activities/boot_sleep/SleepActivity.cpp:552`, not ours to
+change) already:
+
+1. draws `/sleep.bmp` if its headers parse -- **this wins outright**;
+2. otherwise picks a random valid image from `/.sleep`;
+3. otherwise picks a random valid image from `/sleep`;
+4. otherwise draws the default screen.
+
+The sleep screen is drawn during a wake from deep sleep, which is a full chip
+reset. Everything the feature needs therefore lives on the card and nothing in
+RAM: `/sleep.bmp`, `/.sleep/*.bmp`, `/wallpapers/.active`. No new persistence.
+
+### It takes turns; it does not shuffle, and the word matters
+
+`selectRandomSleepFile` excludes the last `min(recentFill, N - 1)` images
+(`SleepActivity.cpp:430`), and `APP_STATE.recentSleepFill` climbs to 16 and is
+never reset. So for any set up to seventeen wallpapers **every member but one is
+excluded**, and the order is a strict cycle: a two-set alternates, a three-set
+round-robins. Calling that "shuffle" or "random" on screen would be a promise
+the platform does not keep, so no user-facing string in this app says either
+word. `host-tests/wallpapers` asserts that as a property of every sentence
+rather than trusting anyone to remember it.
+
+Two upstream behaviours we inherit and do not fix, both worth knowing when a
+report arrives:
+
+- the recent-window ring stores **directory indices, not names**, and it
+  persists across the deep-sleep reset. Remove a member and add another and the
+  new file can land on the freed index and arrive already marked "recently
+  shown". "The one I just added never comes up" is that.
+- the same ring is shared with `/sleep` (both are `SleepRecentKind::Standard`).
+
+## The invariant, and why it is a convergence rather than a guarantee
+
+> `/sleep.bmp` holds a file **iff** exactly one wallpaper is chosen.
+> `/.sleep` holds files **iff** two or more are chosen.
+> Never both.
+
+`wallpapers::cardShapeFor(n)` is that rule as a function, and
+`WallpapersActivity::commitSelection` is its only enforcer -- the single writer
+of all three paths.
+
+| chosen | `/sleep.bmp` | `/.sleep` | what the glass shows |
+| --- | --- | --- | --- |
+| 0 | deleted | emptied | the user's own `/sleep`, if they have one; else the default screen |
+| 1 | that wallpaper | emptied | that wallpaper, every sleep |
+| N >= 2 | deleted | exactly those N | a different one each sleep, in a cycle |
+
+An emptied `/.sleep` does not shadow: `selectRandomSleepFile` returns false on a
+directory with no valid image (`fileCount == 0`) and upstream falls through. The
+directory itself may stay.
+
+**Rows 1 and N >= 2 shadow the user's own `/sleep` folder**, which is upstream's
+own documented rotation directory. That is the same silent precedence this
+design exists to prevent, one level down, and it is unavoidable: `/sleep.bmp`
+and `/.sleep` are both checked before `/sleep` by code we do not own. The app
+does not manage `/sleep` and does not delete it; choosing nothing restores it.
+
+**This app is not the only writer of these paths.** `BmpViewerActivity` copies
+any browsed BMP straight to `/sleep.bmp` (`src/activities/util/BmpViewerActivity.cpp:200`)
+and the File Transfer page can drop one at the card root. A power cut in the
+middle of a one-to-many transition leaves one behind too. So "never both" is
+what the app **converges to**, not something it can promise about a card it did
+not have to itself. `loadSelection()` therefore reconciles on every entry rather
+than assuming:
+
+- `/sleep.bmp` present is reported as the chosen single, because that is what
+  the glass shows;
+- files in `/.sleep` behind it are **not deleted** -- they are the user's, and
+  the hint strip says `One wallpaper is hiding a set.` instead;
+- the next commit normalises, which is the user's own act and by then an
+  announced one.
+
+The commit order inside each branch is chosen so a power cut leaves a picture
+the user CHOSE on the glass rather than nothing: the winning slot is written
+before the losing one is cleared.
+
+### Where the truth lives, and what `.active` becomes
+
+The picker never reports a set from a hint file. It reports what is **on the
+card**, because a second source is a second thing to be wrong (#354 was exactly
+that shape):
+
+- **N >= 2**: membership is `/.sleep` listed directly. There is no hint to
+  disagree with, because the directory the picker reads *is* the directory the
+  sleep screen reads.
+- **exactly 1**: `/sleep.bmp` is a copy and carries no provenance, so which
+  library file it came from is unknowable from the file itself. That is what
+  `/wallpapers/.active` is for, and it keeps exactly today's meaning.
+- **`.active` is deleted whenever the selection is a set.** A stale name beside
+  a set is the disagreeing second source; deleting it is cheaper than
+  reconciling it.
+
+Names are matched case-insensitively (`wallpapers::sameFileName`). The card is
+FAT: long names keep their case, the filesystem matches without it, and a card
+that has been on a PC can hand a name back in a different case. A
+case-sensitive test would draw no marker for a wallpaper that is in the set.
+
+### Two members the picker counts and cannot show
+
+- **A wallpaper deleted from the library while it is in the set** keeps showing.
+  The files in `/.sleep` are copies, exactly as `/sleep.bmp` is a copy, and the
+  app already promises that. It has one fewer tile to mark, and the count still
+  counts it, because the count has to describe what the sleep screen does.
+- **Files the user put in `/.sleep` themselves** are adopted for the same
+  reason: they are what the sleep screen shows. They are never deleted to
+  satisfy the invariant -- only by the user unchoosing them, or by their
+  choosing a single wallpaper, which is what "set your sleep screen" means.
+
+The gap this leaves: a member whose BMP headers do not parse is skipped by
+`findNextValidSleepImage` and still counted here. Everything the app itself
+writes is size-checked at `kWallpaperFileBytes` on the way in, so that can only
+be a file somebody put on the card by hand.
+
+## The interaction
+
+### No gesture is a hold
+
+`InputManager::wasTouchTap` has **no duration gate**, and an app may only pump
+`mappedInput.update()` when it blocked the loop, so a hold on a screen that
+repaints slowly arrives as an ordinary tap. A feature whose entry gesture is a
+hold is a feature that intermittently does not exist. Nothing here uses one.
+
+### Two grid modes, and the chip that switches them
+
+`choosing_` is a plain bool, RAM only, reset on `onEnter`.
+
+**Normal (`choosing_ == false`)**
+
+- header: `WALLPAPERS`, the page or count label, and an outline chip **`CHOOSE`**;
+- 0 or 1 chosen: a tap on a tile pins that one -- today's behaviour, unchanged;
+- **2 or more chosen: a tap on a tile opens the set for editing with that tile
+  toggled.** It does not collapse the set. That was the first design and it was
+  wrong: one stray tap undid six taps of work, silently, under the very pixel
+  that had meant "add to the set" one chip-press earlier. That is
+  same-pixel-different-action with a destructive outcome. Getting back to one
+  wallpaper is unchoosing the rest, which normalises to a plain pin at the last
+  one.
+
+**Choosing (`choosing_ == true`)**
+
+- header: `CHOOSE A SET`, `N CHOSEN`, and the chip reading **`DONE`**;
+- a tap on a tile toggles membership, **committed to the card immediately**;
+- Back leaves choosing and stays in the app.
+
+`DONE` and `Back` do the same thing, which is the point: there is no commit/
+cancel ambiguity to get wrong, because there is nothing uncommitted.
+
+**The count is in the header, not in the marks.** Four tiles fit a page and the
+built-in library is six pages, so at most four marks can ever be on screen and
+usually zero or one. Someone building a five-wallpaper set would otherwise be
+paging blind.
+
+**The chrome tiles keep their meaning in both modes.** `+ Add a wallpaper` and
+`GET THE N BUILT-INS` still do what they say, and they leave choosing mode
+because they leave the grid -- nothing is lost, since the set is already on the
+card. A Notice raised by a failed toggle does **not** leave choosing mode: the
+notice was about one file, and the user was in the middle of building a set.
+The chip is drawn by `buildGridChrome` alone, so Offer, Fetching, Notice and
+Help never carry it.
+
+**The mode costs one tap on entry and one on exit.** `surfaceMeaning()` now
+mixes in `choosing_`, because the mode changes what a *cell* does, so a tile tap
+that arrives before the new frame is on the glass is refused -- 0.3 to 2s on
+this panel. That is the correct answer (the tap was aimed at the previous
+screen) and it is a real cost, named here rather than discovered on hardware.
+`activeIndex_` stays out of the meaning, for the reason it was taken out.
+
+### Why every toggle commits immediately
+
+The alternative -- hold the set in RAM and write it all on `DONE` -- buys a
+cancel and costs the two things a cancel cannot pay for:
+
+- **A card that fills at wallpaper 4 of 5** leaves `/.sleep` half written and
+  the sleep screen cycling a partial set with nothing saying so. Committing a
+  tap at a time means the adds happen one file ahead of the removes, so a copy
+  that fails leaves the set exactly as it was.
+- **Two exits that mean different things.** On a panel this slow, `DONE` and
+  `Back` disagreeing about whether the last twenty seconds counted is a bug
+  factory. With nothing uncommitted they cannot disagree.
+
+The cost is one ~48KB copy per tap, which is what a pin costs today, and small
+beside the repaint the tap already causes. Two transitions cost more than one
+copy and it is worth saying so plainly: 1 -> 2 copies both wallpapers into
+`/.sleep` and then deletes the pin, and 2 -> 1 copies the survivor to
+`/sleep.bmp` and then empties `/.sleep`. Neither intermediate state shows
+nothing, and neither shows a picture the user did not choose; both are the
+"pin plus set" state that `loadSelection()` already reconciles and reports.
+
+### The free-space precondition
+
+`HalStorage::freeBytes()` walks the FAT cluster chain -- seconds on a large
+card, cached 20s -- and running it from a tap is how this app got its ten
+seconds of blank screen. So the walk stays in `loop()`, after the paint, on the
+existing `warningPending_` machinery; it now keeps its **raw** answer, and each
+add applies `wallpapers::roomFor` at `kAddFloorBytes` (the 12MB floor that
+protects Study's review log, plus the one file this tap writes) with no second
+walk. Every add re-arms the walk so the number refreshes behind the next paint.
+
+`Unknown` **proceeds** here, unlike the download's precondition, and the
+difference is the reason rather than an exception to it: that doctrine says
+proceeding on Unknown costs the user whose card is already in trouble, and this
+write is transactional -- `.part`, size-checked, renamed -- so a card that
+cannot take it loses nothing and says so on screen. Refusing on a card whose
+free-space walk merely failed would make the picker unusable on it.
+
+The `.part` discipline is not optional and the reason is the opposite of the
+obvious one: `findNextValidSleepImage` **accepts** a truncated BMP.
+`Bitmap::parseHeaders` seeks to `bfOffBits` and never checks that the pixel data
+is complete, so a half-written 480x800 image is a *valid* sleep image and gets
+drawn, half-rendered, on every sleep. The rename is the only thing between a
+failed copy and a permanently broken sleep screen. `sweepPartFiles` now clears
+them from all three places this app writes one: the library, `/.sleep`, and the
+card root beside the pin -- it only ever swept the library, so
+`/sleep.bmp.part` has been an orphan on any power cut mid-pin since the app
+shipped.
+
+### Honesty: a count is the last thing the strip says
+
+`wallpapers::reachOfPinnedSleep` decides whether the settings let the sleep
+system draw what this app wrote. Verified line by line against
+`SleepActivity::onEnter`: it is **the same predicate for a set**, because every
+gate applies before upstream ever chooses between `/sleep.bmp` and `/.sleep`.
+Quick resume and the timeout flag short-circuit above the mode switch;
+`TRANSPARENT_CUSTOM` returns earlier and draws overlays, never `/.sleep`;
+`CUSTOM` and `COVER_CUSTOM` both land in `renderCustomSleepScreen`; and
+`COVER_CUSTOM` from inside a book keeps its conservative `false` for the same
+reason it does for a single file.
+
+But reach is a pure function of two SETTINGS values, and a set has one more way
+to be blocked that no setting can see -- a `/sleep.bmp` shadowing it. So the
+strip is ordered, and `host-tests/wallpapers` asserts the ordering by coverage
+over every combination rather than by matching words:
+
+1. a settings caveat (`reachHint`) -- nothing of the user's can appear at all;
+2. what the last selection changed behind their back
+   (`stripLineAfterSelection`, which carries any caveat with it);
+3. `One wallpaper is hiding a set.`;
+4. the mode's own line, with a count only when nothing above applied.
+
+**A number never appears while anything is stopping those files reaching the
+glass.** That is the assertion, and it is what "shuffling 5 wallpapers" would
+otherwise be a lie about.
+
+## Fixed in passing
+
+`pageCount()` counted **one** chrome tile while `drawGrid` and the tap handler
+both counted `specialTiles()`, which is two while the built-in set is
+incomplete. Three wallpapers plus two chrome tiles is five tiles, which is two
+pages and was reported as one, so `clampPage()` forbade the page holding the
+last wallpaper and it could not be reached. That is the "two halves disagree
+about what is in a cell" failure the comment above `specialTiles()` names as
+this fork's most repeated bug, and this design adds paging pressure to it. The
+arithmetic is now `wallpapersui::pageCountFor`, freestanding and walked over
+every combination in `host-tests/wallcaption`.
+
+## Composing with PR #147 (`app/wallhold`, hold a tile to preview or delete)
+
+Deliberately built on `xteink` rather than merged into #147, so each lands on
+its own. They do not fight for a gesture: #147 owns the **hold**, this owns the
+**tap** and one chip. The resolution when the second of the two merges:
+
+1. In choosing mode a hold must **not** open the sheet. The sheet offers a
+   delete, and a delete behind a gesture whose classifier misses
+   (`tapWasHeldLong`) must never be reachable from a mode whose taps mean
+   something else.
+2. `saysOnSleepScreen(isMarked, reach)` from #147 answers for a set too, with
+   `isMarked` meaning "in the chosen set" -- but it must also take the
+   shadowed-set fact, for the same reason `shuffleStripLine` does: the sheet
+   asserts "This one is on your sleep screen now.", and behind a stray
+   `/sleep.bmp` that is false for every member but one.
+3. Both edit the tap branch of `WallpapersActivity::loop()` and the chrome
+   model; the conflicts are additive and named here so the resolver does not
+   have to rediscover them.

--- a/host-tests/wallcaption/test_wallcaption.cpp
+++ b/host-tests/wallcaption/test_wallcaption.cpp
@@ -291,25 +291,29 @@ int main() {
   // The things that DO remap a cell still have to gate, or a tap during a page
   // turn opens whatever slid under the finger. Both halves are asserted.
   {
-    const uint32_t base = wallpapersui::gridMeaning(0, 0, 21, 1);
-    check(wallpapersui::gridMeaning(0, 0, 21, 1) == base, "gridMeaning is not stable for identical inputs");
+    const uint32_t base = wallpapersui::gridMeaning(0, 0, 21, 1, false);
+    check(wallpapersui::gridMeaning(0, 0, 21, 1, false) == base, "gridMeaning is not stable for identical inputs");
 
     // Changing the page, the view, the library size or the chrome-tile count
     // REMAPS cells, so each must change the meaning.
-    check(wallpapersui::gridMeaning(1, 0, 21, 1) != base, "a page turn does not gate taps");
-    check(wallpapersui::gridMeaning(0, 1, 21, 1) != base, "a view change does not gate taps");
-    check(wallpapersui::gridMeaning(0, 0, 22, 1) != base, "a library change does not gate taps");
-    check(wallpapersui::gridMeaning(0, 0, 21, 2) != base, "a chrome-tile change does not gate taps");
+    check(wallpapersui::gridMeaning(1, 0, 21, 1, false) != base, "a page turn does not gate taps");
+    check(wallpapersui::gridMeaning(0, 1, 21, 1, false) != base, "a view change does not gate taps");
+    check(wallpapersui::gridMeaning(0, 0, 22, 1, false) != base, "a library change does not gate taps");
+    check(wallpapersui::gridMeaning(0, 0, 21, 2, false) != base, "a chrome-tile change does not gate taps");
+    // Choose-a-set mode changes what a CELL does -- pin one, or toggle its
+    // membership -- so a tap left against the previous frame must not act on
+    // the new meaning.
+    check(wallpapersui::gridMeaning(0, 0, 21, 1, true) != base, "choose-a-set mode does not gate taps");
 
     // And the signature that mattered: nothing in gridMeaning takes the
     // selection, so there is no argument by which it could gate. Asserted by
     // walking every selection a 21-wallpaper library can have and confirming the
     // meaning for that page never moves.
     for (int page = 0; page < 6; ++page) {
-      const uint32_t forPage = wallpapersui::gridMeaning(page, 0, 21, 1);
+      const uint32_t forPage = wallpapersui::gridMeaning(page, 0, 21, 1, false);
       for (int selected = -1; selected < 21; ++selected) {
         // The old meaning mixed (selected + 1) in here; the new one cannot.
-        check(wallpapersui::gridMeaning(page, 0, 21, 1) == forPage,
+        check(wallpapersui::gridMeaning(page, 0, 21, 1, false) == forPage,
               "the selection moved the surface meaning, so taps will be refused mid-paint (page " +
                   std::to_string(page) + ", selected " + std::to_string(selected) + ")");
       }
@@ -400,11 +404,31 @@ int main() {
         if (note.text != nullptr) lines.emplace_back(note.text);
       }
     }
+    // Every set sentence, walked off its own arguments the same way. The count
+    // ones are measured WITH the widest number this app can put in front of
+    // them: kMaxLibrary is 256, so three digits and a space, and a sentence
+    // that fits bare and not with "256 " on it is a sentence the panel cuts on
+    // the one card that has the most wallpapers on it.
+    for (uint8_t mode = 0; mode < wallpapers::kSleepModeCount; ++mode) {
+      for (int qr = 0; qr < 2; ++qr) {
+        const wallpapers::Reach reach = wallpapers::reachOfPinnedSleep(mode, qr != 0);
+        for (int choosing = 0; choosing < 2; ++choosing) {
+          for (int shadowed = 0; shadowed < 2; ++shadowed) {
+            for (int n = 0; n < 4; ++n) {
+              const wallpapers::ShuffleLine set = wallpapers::shuffleStripLine(choosing != 0, n, shadowed != 0, reach);
+              if (set.text == nullptr) continue;
+              lines.emplace_back(set.wantsCount ? std::string("256 ") + set.text : std::string(set.text));
+            }
+          }
+        }
+      }
+    }
     // And the two the strip already carried, so this check covers the strip
     // rather than only the new arrivals.
     lines.emplace_back("Tap one to set your sleep screen.");
     lines.emplace_back("Card is low on space. Saves may fail.");
     lines.emplace_back("Could not check card space.");
+    lines.emplace_back(wallpapersui::chooseHint());
 
     int widestHint = 0;
     std::string widestHintText;
@@ -421,6 +445,55 @@ int main() {
     }
     std::printf("wallcaption: widest hint \"%s\" = %dpx in a %dpx strip (%dpx spare)\n", widestHintText.c_str(),
                 widestHint, stripWidth, stripWidth - widestHint);
+  }
+
+  // The strip's lowest line tells the user which control opens a set, so it has
+  // to name that control's own word. Rename the chip without renaming the hint
+  // and the sentence points at a word that is not on the screen. This is the
+  // one case where a check that matches the description is the point.
+  {
+    const std::string hint(wallpapersui::chooseHint());
+    const std::string enters(wallpapersui::chooseChipLabel(false));
+    const std::string leaves(wallpapersui::chooseChipLabel(true));
+    check(hint.find(enters) != std::string::npos,
+          "the strip's hint does not name the chip: \"" + hint + "\" vs \"" + enters + "\"");
+    check(enters != leaves, "the chip says the same thing entering and leaving the mode");
+    // No user-facing string in this app promises randomness: upstream's
+    // recent-shown window makes a small set a strict cycle, not a shuffle.
+    for (const std::string& s : {hint, enters, leaves}) {
+      check(s.find("huffl") == std::string::npos && s.find("HUFFL") == std::string::npos,
+            "a user-facing string promises shuffling: \"" + s + "\"");
+      check(s.find("andom") == std::string::npos && s.find("ANDOM") == std::string::npos,
+            "a user-facing string promises randomness: \"" + s + "\"");
+    }
+  }
+
+  // The three readers of "how many tiles are there" have to agree. drawGrid and
+  // the tap handler both count specialTiles() + the library; pageCount() counted
+  // ONE chrome tile, so with the built-in set incomplete (two chrome tiles) a
+  // library that lands exactly on a page boundary had a last wallpaper the grid
+  // drew and clampPage forbade the page for. Walked rather than spot-checked.
+  {
+    for (int per = 1; per <= 8; ++per) {
+      for (int specials = 1; specials <= 2; ++specials) {
+        for (int lib = 0; lib <= 40; ++lib) {
+          const int pages = wallpapersui::pageCountFor(specials, lib, per);
+          const int tiles = specials + lib;
+          check(pages >= 1, "pageCountFor returned no pages at all");
+          // Every tile the grid draws is on a page the picker can reach.
+          check(pages * per >= tiles, "the last tile is on a page pageCountFor does not count (per " +
+                                          std::to_string(per) + ", specials " + std::to_string(specials) +
+                                          ", library " + std::to_string(lib) + ")");
+          // And not one page more than needed, or the picker shows an empty one.
+          check((pages - 1) * per < tiles || tiles == 0,
+                "pageCountFor counts a page with nothing on it (per " + std::to_string(per) + ", specials " +
+                    std::to_string(specials) + ", library " + std::to_string(lib) + ")");
+        }
+      }
+    }
+    // The exact case that was broken: 4 a page, both chrome tiles, three
+    // wallpapers -- five tiles, which is two pages and used to be called one.
+    check(wallpapersui::pageCountFor(2, 3, 4) == 2, "the incomplete-set page boundary is still miscounted");
   }
 
   std::printf("wallcaption: widest caption \"%s\" = %dpx in a %dpx box (%dpx spare)\n", widestName.c_str(), widest,

--- a/host-tests/wallpapers/test_wallpapers.cpp
+++ b/host-tests/wallpapers/test_wallpapers.cpp
@@ -332,6 +332,143 @@ void testStripLineCoversEveryFact() {
   CHECK(reachHint(reachOfPinnedSleep(kSleepCustom, false)) == nullptr);
 }
 
+// The invariant the whole feature rests on: /sleep.bmp is checked FIRST by
+// SleepActivity::renderCustomSleepScreen and shadows /.sleep outright, so a
+// leftover pin beside a set shows one picture forever with nothing on any
+// screen able to explain it. The two slots are derived from ONE count, and this
+// walks every count rather than the two or three anybody would think to try.
+void testCardShapeNeverHasBothSlots() {
+  for (int n = 0; n <= 64; ++n) {
+    const wallpapers::CardShape shape = wallpapers::cardShapeFor(n);
+    CHECK(!(shape.pinned && shape.shuffled));
+    // The set is exactly what was chosen -- not a prefix, not a page of it.
+    CHECK(shape.files == (shape.shuffled ? n : 0));
+    if (n == 0) {
+      CHECK(!shape.pinned && !shape.shuffled);
+    } else if (n == 1) {
+      // One wallpaper stays in the slot it has always used, so a card written
+      // by an older build keeps working and #354's proven path is unchanged.
+      CHECK(shape.pinned && !shape.shuffled);
+    } else {
+      CHECK(shape.shuffled && !shape.pinned);
+    }
+  }
+  // A negative count is a bug upstream of here; it must still not pin anything.
+  CHECK(!wallpapers::cardShapeFor(-1).pinned);
+  CHECK(!wallpapers::cardShapeFor(-1).shuffled);
+}
+
+// A count sentence, a settings caveat and "the card contradicts you" cannot all
+// fit one 30px line, so they have to be ordered -- and the two that displace a
+// count both have to win, every time, or the app says "5 take turns" on a
+// device where none of them can appear.
+//
+// Asserted as COVERAGE rather than by looking for a word: a sentence cannot
+// pass this by mentioning the right thing (a-detector-that-matches-the-
+// description).
+void testShuffleLineNeverPromisesASetThatCannotShow() {
+  for (uint8_t mode = 0; mode < wallpapers::kSleepModeCount; ++mode) {
+    for (int qr = 0; qr < 2; ++qr) {
+      const wallpapers::Reach reach = wallpapers::reachOfPinnedSleep(mode, qr != 0);
+      const bool blocked = reach != wallpapers::Reach::Always;
+      for (int choosing = 0; choosing < 2; ++choosing) {
+        for (int shadowed = 0; shadowed < 2; ++shadowed) {
+          for (int n = 0; n <= 6; ++n) {
+            const wallpapers::ShuffleLine line = wallpapers::shuffleStripLine(choosing != 0, n, shadowed != 0, reach);
+            // A number NEVER appears while anything is stopping those files
+            // reaching the glass. This is the whole assertion.
+            if (blocked || shadowed != 0) CHECK(!line.wantsCount);
+            // With nothing chosen and nothing hidden there is nothing for a
+            // caveat to be about, and saying it would displace the instruction.
+            if (n == 0 && shadowed == 0) {
+              CHECK(!line.saysCaveat && !line.saysShadow && !line.wantsCount);
+              CHECK((line.text != nullptr) == (choosing != 0));
+            } else if (blocked) {
+              CHECK(line.text != nullptr);
+              CHECK(line.saysCaveat);
+              CHECK(!line.saysShadow);  // the settings beat the card: nothing shows either way
+            } else if (shadowed != 0) {
+              CHECK(line.text != nullptr);
+              CHECK(line.saysShadow);
+              CHECK(!line.saysCaveat);
+            } else {
+              CHECK(!line.saysCaveat && !line.saysShadow);
+              // A number only ever appears in a sentence built to carry one,
+              // and never for a count of nothing.
+              if (line.wantsCount) CHECK(line.text != nullptr && n >= 1);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Unblocked and unshadowed, the four states each get their own sentence, and
+  // no two are the same string -- a mode whose screen does not change is a mode
+  // nobody can tell they are in.
+  const wallpapers::Reach ok = wallpapers::Reach::Always;
+  const wallpapers::ShuffleLine none = wallpapers::shuffleStripLine(true, 0, false, ok);
+  const wallpapers::ShuffleLine one = wallpapers::shuffleStripLine(true, 1, false, ok);
+  const wallpapers::ShuffleLine many = wallpapers::shuffleStripLine(true, 3, false, ok);
+  const wallpapers::ShuffleLine live = wallpapers::shuffleStripLine(false, 3, false, ok);
+  CHECK(none.text != nullptr && one.text != nullptr && many.text != nullptr && live.text != nullptr);
+  CHECK(std::strcmp(none.text, one.text) != 0);
+  CHECK(std::strcmp(one.text, many.text) != 0);
+  CHECK(std::strcmp(many.text, live.text) != 0);
+  // Choosing, the count is always on screen from the first pick onwards: it is
+  // the fact four visible tiles cannot carry.
+  CHECK(live.wantsCount && one.wantsCount && many.wantsCount);
+  CHECK(!none.wantsCount);
+
+  // Not choosing, with nothing or one wallpaper chosen, this says nothing: the
+  // single-pin case belongs to reachHint / stripLineAfterSelection, and two
+  // voices on one line is how a caveat got lost in #354.
+  CHECK(wallpapers::shuffleStripLine(false, 0, false, ok).text == nullptr);
+  CHECK(wallpapers::shuffleStripLine(false, 1, false, ok).text == nullptr);
+
+  // And the instruction survives a blocked device while nothing is chosen: the
+  // caveat has nothing to be about yet, and the render showed it taking the
+  // line on a fresh card where Sleep Screen is Dark.
+  for (uint8_t mode = 0; mode < wallpapers::kSleepModeCount; ++mode) {
+    for (int qr = 0; qr < 2; ++qr) {
+      const wallpapers::Reach reach = wallpapers::reachOfPinnedSleep(mode, qr != 0);
+      const wallpapers::ShuffleLine fresh = wallpapers::shuffleStripLine(true, 0, false, reach);
+      CHECK(fresh.text != nullptr);
+      CHECK(std::strcmp(fresh.text, none.text) == 0);
+    }
+  }
+
+  // No user-facing sentence may promise randomness. The recent-shown window
+  // upstream keeps (min(recentFill, N-1), recentFill climbing to 16 and never
+  // reset) makes a set of up to seventeen a strict cycle, and a two-set a
+  // metronome. "Take turns" is what that is.
+  for (int choosing = 0; choosing < 2; ++choosing) {
+    for (int shadowed = 0; shadowed < 2; ++shadowed) {
+      for (uint8_t mode = 0; mode < wallpapers::kSleepModeCount; ++mode) {
+        const wallpapers::ShuffleLine line =
+            wallpapers::shuffleStripLine(choosing != 0, 3, shadowed != 0, wallpapers::reachOfPinnedSleep(mode, false));
+        if (line.text == nullptr) continue;
+        const std::string text(line.text);
+        CHECK(text.find("huffl") == std::string::npos);
+        CHECK(text.find("andom") == std::string::npos);
+      }
+    }
+  }
+}
+
+// FAT keeps the case of a long name but matches without it, so a card that has
+// been on a PC can hand back a name in a different case than it was written in.
+// A case-sensitive membership test would then draw no marker for a wallpaper
+// that is genuinely in the set.
+void testFileNamesMatchWithoutCase() {
+  CHECK(wallpapers::sameFileName("blake.bmp", "BLAKE.BMP"));
+  CHECK(wallpapers::sameFileName("Durer-Eden.bmp", "durer-eden.BMP"));
+  CHECK(wallpapers::sameFileName("", ""));
+  CHECK(!wallpapers::sameFileName("blake.bmp", "blake2.bmp"));
+  CHECK(!wallpapers::sameFileName("blake.bmp", "blak.bmp"));
+  CHECK(!wallpapers::sameFileName("waves.bmp", "rings.bmp"));
+}
+
 }  // namespace
 
 int main() {
@@ -343,6 +480,9 @@ int main() {
   testChoiceReachesTheGlassOnTimeout();
   testChoiceKeepsWhatItCan();
   testStripLineCoversEveryFact();
+  testCardShapeNeverHasBothSlots();
+  testShuffleLineNeverPromisesASetThatCannotShow();
+  testFileNamesMatchWithoutCase();
 
   // Uploads first, then built-ins, each alphabetical. Mario's ask, and the
   // ordering the picker's captions are indexed by -- get it wrong and every

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -2049,7 +2049,12 @@ void WallpapersActivity::render(RenderLock&&) {
     // the count moved to the strip, which has the room for a sentence.
     rightLabel_.clear();
     if (pages > 1 && !choosing_) {
-      char label[16];
+      // 32, not 16: host-tests/fmtwidth sizes a buffer by what the FORMAT can
+      // print, not by what this app's page counts happen to reach. Two ints are
+      // 11 characters each, so "%d / %d" needs 26 -- and a buffer sized by the
+      // value rather than the format is how a truncation ships the day
+      // something upstream of it changes.
+      char label[32];
       snprintf(label, sizeof(label), "%d / %d", page_ + 1, pages);
       rightLabel_ = label;
     }

--- a/src/apps_local/wallpapers/WallpapersActivity.cpp
+++ b/src/apps_local/wallpapers/WallpapersActivity.cpp
@@ -128,7 +128,7 @@ void WallpapersActivity::onEnter() {
   const uint32_t tSweep = millis();
   scanLibrary();
   const uint32_t tScan = millis();
-  loadActive();
+  loadSelection();
   const uint32_t tActive = millis();
   // The free-space probe is NOT here any more. HalStorage::freeBytes() walks the
   // FAT cluster chain (SDCardManager::refreshFreeClusters: "seconds on a large
@@ -141,6 +141,7 @@ void WallpapersActivity::onEnter() {
   // after, in loop(), with content already on the glass.
   warning_.clear();
   selectedThisSession_ = false;
+  choosing_ = false;
   warningPending_ = true;
   LOG_INF("WALL", "onEnter %ums: fonts=%u sweep=%u scan=%u active=%u (free-space deferred)", tActive - tEnter,
           tFonts - tEnter, tSweep - tFonts, tScan - tSweep, tActive - tScan);
@@ -182,29 +183,88 @@ void WallpapersActivity::scanLibrary() {
   builtInsMissing_ = static_cast<int>(wallpapers::builtInCount()) - have;
 }
 
-void WallpapersActivity::loadActive() {
+void WallpapersActivity::listShuffleDir(std::vector<std::string>& out) const {
+  out.clear();
+  auto dir = Storage.open(wallpapers::kShuffleDir);
+  if (!dir || !dir.isDirectory()) return;
+  auto name = makeUniqueNoThrow<char[]>(kNameMax);
+  if (!name) {
+    LOG_ERR("WALL", "OOM: shuffle name buffer");
+    return;
+  }
+  for (auto entry = dir.openNextFile(); entry; entry = dir.openNextFile()) {
+    if (entry.isDirectory()) continue;
+    entry.getName(name.get(), kNameMax);
+    if (!wallpapers::isSupportedWallpaper(std::string_view{name.get()})) continue;
+    out.emplace_back(name.get());
+    if (static_cast<int>(out.size()) >= kMaxLibrary) break;
+  }
+}
+
+// What the CARD says is chosen. Not a remembered intention and not a hint file:
+// /sleep.bmp and /.sleep are what SleepActivity reads, so they are what the
+// picker reports. See docs/apps/wallpapers-shuffle.md.
+void WallpapersActivity::loadSelection() {
   activeIndex_ = -1;
-  // Deliberately NOT gated on sleepScreen == CUSTOM any more (#354). That gate
-  // was wrong in both directions: it hid the marker under COVER_CUSTOM, where
-  // the wallpaper genuinely does show, and it drew the marker at full
-  // confidence under CUSTOM-plus-quick-resume, where it never does. What is
-  // pinned is a fact about the card; whether it reaches the glass is a fact
-  // about two settings, and the hint strip says that in words instead.
-  if (!Storage.exists(wallpapers::kPinnedSleep)) return;
-  char marker[kNameMax] = {};
-  if (Storage.readFileToBuffer(wallpapers::kActiveMarker, marker, sizeof(marker)) == 0) return;
-  for (char* p = marker; *p; ++p) {
-    if (*p == '\n' || *p == '\r') {
-      *p = '\0';
-      break;
+  chosen_.clear();
+  shadowedSet_ = false;
+
+  // The pin is checked FIRST because renderCustomSleepScreen checks it first:
+  // while it is there it is the only thing that shows, whatever else is on the
+  // card. Deliberately NOT gated on sleepScreen == CUSTOM (#354) -- what is
+  // pinned is a fact about the card, and whether it reaches the glass is a fact
+  // about two settings that the hint strip says in words.
+  if (Storage.exists(wallpapers::kPinnedSleep)) {
+    std::vector<std::string> shadowed;
+    listShuffleDir(shadowed);
+    // A set behind a pin. This app is not the only way to get here:
+    // BmpViewerActivity's "set sleep cover" writes /sleep.bmp straight from the
+    // file browser, the File Transfer page can drop one at the root, and a
+    // power cut during a one-to-many transition leaves one behind. Reported
+    // rather than silently repaired: those are the user's files, and the strip
+    // has a sentence for exactly this.
+    shadowedSet_ = !shadowed.empty();
+    char marker[kNameMax] = {};
+    if (Storage.readFileToBuffer(wallpapers::kActiveMarker, marker, sizeof(marker)) == 0) return;
+    for (char* p = marker; *p; ++p) {
+      if (*p == '\n' || *p == '\r') {
+        *p = '\0';
+        break;
+      }
+    }
+    for (int i = 0; i < static_cast<int>(names_.size()); ++i) {
+      if (wallpapers::sameFileName(names_[static_cast<size_t>(i)], marker)) {
+        activeIndex_ = i;
+        chosen_.push_back(names_[static_cast<size_t>(i)]);
+        break;
+      }
+    }
+    return;
+  }
+
+  // No pin: the set IS the directory. Every file counts, including one whose
+  // library original has since been deleted -- that copy still takes its turn
+  // on the glass, and a count that skipped it would understate what the sleep
+  // screen does. Files the user put here themselves are adopted for the same
+  // reason: they are what the sleep screen shows.
+  listShuffleDir(chosen_);
+  if (chosen_.size() == 1) {
+    for (int i = 0; i < static_cast<int>(names_.size()); ++i) {
+      if (wallpapers::sameFileName(names_[static_cast<size_t>(i)], chosen_[0])) {
+        activeIndex_ = i;
+        break;
+      }
     }
   }
-  for (int i = 0; i < static_cast<int>(names_.size()); ++i) {
-    if (names_[i] == marker) {
-      activeIndex_ = i;
-      break;
-    }
+}
+
+bool WallpapersActivity::isChosen(const int index) const {
+  if (index < 0 || index >= static_cast<int>(names_.size())) return false;
+  const std::string& name = names_[static_cast<size_t>(index)];
+  for (const std::string& c : chosen_) {
+    if (wallpapers::sameFileName(c, name)) return true;
   }
+  return false;
 }
 
 wallpapers::Reach WallpapersActivity::sleepReach() const {
@@ -218,15 +278,38 @@ bool WallpapersActivity::sleepBlocked() const {
   return reach == wallpapers::Reach::BlockedByMode || reach == wallpapers::Reach::BlockedByQuickResume;
 }
 
-const char* WallpapersActivity::currentSleepNote() const {
-  // Nothing pinned: the strip already carries "Tap one to set your sleep
-  // screen.", and telling someone their non-existent wallpaper is blocked
-  // would be noise.
-  if (activeIndex_ < 0) return nullptr;
+const char* WallpapersActivity::currentSleepNote() {
   const wallpapers::Reach reach = sleepReach();
-  // After a selection the line must carry BOTH what the tap changed and any
-  // caveat that still applies -- one cannot be allowed to hide the other, which
-  // is what stripLineAfterSelection exists to guarantee.
+  const int chosen = static_cast<int>(chosen_.size());
+
+  // What a selection changed BEHIND the user's back outranks everything below:
+  // it is the only voice that fact has, and stripLineAfterSelection already
+  // carries any standing caveat with it so nothing is lost by letting it win
+  // (#354 was a caveat suppressed by a line that had no room for both).
+  if (selectedThisSession_ && (lastChoice_.tookOverMode || lastChoice_.clearedQuickResume)) {
+    return wallpapers::stripLineAfterSelection(lastChoice_, reach).text;
+  }
+
+  // Choosing, a real set, or a set hidden behind a pin: the set line owns the
+  // strip, and it already orders the caveat and the contradiction ahead of any
+  // count it might otherwise print.
+  if (choosing_ || chosen >= 2 || shadowedSet_) {
+    const wallpapers::ShuffleLine line = wallpapers::shuffleStripLine(choosing_, chosen, shadowedSet_, reach);
+    if (line.text == nullptr) return nullptr;
+    if (!line.wantsCount) return line.text;
+    // The only line that allocates, and it is a member so it outlives the
+    // paint. host-tests/wallcaption measures the sentence with the widest count
+    // this app can produce in front of it.
+    note_ = std::to_string(chosen);
+    note_ += ' ';
+    note_ += line.text;
+    return note_.c_str();
+  }
+
+  // One wallpaper, or none. Nothing pinned: the strip already carries "Tap one
+  // to set your sleep screen.", and telling someone their non-existent
+  // wallpaper is blocked would be noise.
+  if (activeIndex_ < 0) return nullptr;
   if (selectedThisSession_) return wallpapers::stripLineAfterSelection(lastChoice_, reach).text;
   return wallpapers::reachHint(reach);
 }
@@ -235,6 +318,12 @@ void WallpapersActivity::computeWarning() {
   warning_.clear();
   uint64_t free = 0;
   const bool ok = Storage.freeBytes(free);
+  // Kept RAW rather than as a verdict: an add applies the same three-outcome
+  // precondition at its own floor (kAddFloorBytes), and it must not trigger a
+  // second FAT cluster walk to do it -- that walk is what put ten seconds of
+  // blank screen on this app's open path, and a tap is the same input path.
+  freeKnown_ = ok;
+  freeBytes_ = ok ? free : 0;
   switch (wallpapers::roomFor(ok, free, wallpapers::kCardFloorBytes)) {
     case wallpapers::Room::Ok:
       break;
@@ -255,8 +344,13 @@ void WallpapersActivity::computeWarning() {
 int WallpapersActivity::pageCount() const {
   const int per = wallpapersui::gridGeom(toybox::makeTarget(renderer).deviceContext()).perPage;
   if (names_.empty() || per <= 0) return 1;
-  const int total = 1 + static_cast<int>(names_.size());  // the + Add tile plus the wallpapers
-  return (total + per - 1) / per;
+  // specialTiles(), NOT a literal 1. While the built-in set is incomplete there
+  // are TWO chrome tiles, and counting one of them made the last wallpaper of a
+  // page-boundary library unreachable: clampPage forbade the page that would
+  // have held it. The drawing and the hit-test both use specialTiles() already
+  // (drawGrid, and the tap handler), so this was the one half of three that
+  // disagreed -- the exact failure the comment above specialTiles() names.
+  return wallpapersui::pageCountFor(specialTiles(), static_cast<int>(names_.size()), per);
 }
 
 void WallpapersActivity::clampPage() {
@@ -265,23 +359,20 @@ void WallpapersActivity::clampPage() {
   if (page_ >= pages) page_ = pages - 1;
 }
 
-bool WallpapersActivity::setWallpaper(int index) {
-  const uint32_t tSet = millis();
-  if (index < 0 || index >= static_cast<int>(names_.size())) return false;
-  std::string src = std::string(wallpapers::kLibraryDir) + "/" + names_[static_cast<size_t>(index)];
-
-  // Through a .part name, renamed only when the whole file is written.
-  //
-  // Writing straight to /sleep.bmp truncates the user's CURRENT sleep image on
-  // the first byte, so a card that fills (or a power cut) halfway leaves a
-  // short file where a good one used to be. Bitmap::parseHeaders seeks to
-  // bfOffBits and never checks that the pixel data is complete, and
-  // SleepActivity::findNextValidSleepImage accepts a file on exactly that
-  // check -- so a truncated 480x800 image is a VALID sleep image and gets
-  // drawn, half-rendered, on every sleep, with nothing on screen to say why.
-  // The rename is the only thing between a failed copy and a permanently
-  // broken sleep screen.
-  const std::string part = std::string(wallpapers::kPinnedSleep) + ".part";
+// Copy one wallpaper onto the card, through a .part name renamed only when the
+// whole file is written.
+//
+// Writing straight to the destination truncates whatever was there on the first
+// byte, so a card that fills (or a power cut) halfway leaves a SHORT file where
+// a good one used to be. That is not a file the sleep screen skips:
+// Bitmap::parseHeaders seeks to bfOffBits and never checks that the pixel data
+// is complete, and SleepActivity::findNextValidSleepImage accepts a file on
+// exactly that check -- so a truncated 480x800 image is a VALID sleep image and
+// gets drawn, half-rendered, on every sleep, with nothing on screen to say why.
+// The rename is the only thing between a failed copy and a permanently broken
+// sleep screen.
+bool WallpapersActivity::copyWallpaper(const std::string& src, const std::string& dst) const {
+  const std::string part = dst + ".part";
   Storage.remove(part.c_str());
 
   HalFile in;
@@ -311,7 +402,7 @@ bool WallpapersActivity::setWallpaper(int index) {
     }
     if (got == 0) break;
     if (out.write(buffer.get(), static_cast<size_t>(got)) != static_cast<size_t>(got)) {
-      LOG_ERR("WALL", "Write error pinning wallpaper (card full?)");
+      LOG_ERR("WALL", "Write error copying wallpaper (card full?)");
       out.close();
       in.close();
       Storage.remove(part.c_str());
@@ -325,55 +416,196 @@ bool WallpapersActivity::setWallpaper(int index) {
   // The size is knowable and exact, so check it rather than trusting that the
   // writes returned what they claimed.
   if (copied != wallpapers::kWallpaperFileBytes) {
-    LOG_ERR("WALL", "Pinned wallpaper is %u bytes, expected %u -- not swapping it in", static_cast<unsigned>(copied),
+    LOG_ERR("WALL", "Copied wallpaper is %u bytes, expected %u -- not swapping it in", static_cast<unsigned>(copied),
             static_cast<unsigned>(wallpapers::kWallpaperFileBytes));
     Storage.remove(part.c_str());
     return false;
   }
 
-  Storage.remove(wallpapers::kPinnedSleep);
-  if (!Storage.rename(part.c_str(), wallpapers::kPinnedSleep)) {
-    LOG_ERR("WALL", "Card refused the final rename of %s", wallpapers::kPinnedSleep);
+  Storage.remove(dst.c_str());
+  if (!Storage.rename(part.c_str(), dst.c_str())) {
+    LOG_ERR("WALL", "Card refused the final rename of %s", dst.c_str());
     Storage.remove(part.c_str());
     return false;
   }
+  return true;
+}
 
-  // The two settings that decide whether /sleep.bmp is ever drawn, set together
-  // (#354). Keeping the timeout quick-resume flag ON used to be this app's way
-  // of not making wake slower, and the price was the whole feature: while that
-  // flag is on, the IDLE sleep -- the ordinary one -- short-circuits above the
-  // sleep-screen switch and no wallpaper can appear. The user tapped a picture;
-  // the picture wins, and the picker says what that cost.
-  //
-  // The rule and its consequences are proved in host-tests/wallpapers, which is
-  // where they can be walked over all eight modes rather than reasoned about.
+// Where a chosen name can be read from. The library first; a member whose
+// library original was deleted is still on the card as its own copy, and that
+// copy is what keeps it in the rotation.
+std::string WallpapersActivity::sourcePathFor(const std::string& name) const {
+  const std::string inLibrary = std::string(wallpapers::kLibraryDir) + "/" + name;
+  if (Storage.exists(inLibrary.c_str())) return inLibrary;
+  return std::string(wallpapers::kShuffleDir) + "/" + name;
+}
+
+void WallpapersActivity::clearShuffleDir() {
+  std::vector<std::string> have;
+  listShuffleDir(have);
+  for (const std::string& n : have) {
+    const std::string path = std::string(wallpapers::kShuffleDir) + "/" + n;
+    Storage.remove(path.c_str());
+    LOG_INF("WALL", "Removed from the set: %s", n.c_str());
+  }
+}
+
+// Make /.sleep hold exactly `want`. ADDS first, so a copy that fails leaves the
+// set exactly as it was rather than as a shorter one nobody chose.
+bool WallpapersActivity::fillShuffleDir(const std::vector<std::string>& want) {
+  Storage.mkdir(wallpapers::kShuffleDir);
+  std::vector<std::string> have;
+  listShuffleDir(have);
+  const auto holds = [](const std::vector<std::string>& list, const std::string& n) {
+    for (const std::string& s : list) {
+      if (wallpapers::sameFileName(s, n)) return true;
+    }
+    return false;
+  };
+  for (const std::string& n : want) {
+    if (holds(have, n)) continue;
+    if (!copyWallpaper(sourcePathFor(n), std::string(wallpapers::kShuffleDir) + "/" + n)) return false;
+  }
+  for (const std::string& n : have) {
+    if (holds(want, n)) continue;
+    Storage.remove((std::string(wallpapers::kShuffleDir) + "/" + n).c_str());
+  }
+  return true;
+}
+
+// The two settings that decide whether the sleep system ever draws what this
+// app wrote (#354). Both slots -- the pin and the set -- are reached through
+// renderCustomSleepScreen, so one rule covers them.
+//
+// Keeping the timeout quick-resume flag ON used to be this app's way of not
+// making wake slower, and the price was the whole feature: while that flag is
+// on, the IDLE sleep -- the ordinary one -- short-circuits above the
+// sleep-screen switch and no wallpaper can appear. The user tapped a picture;
+// the picture wins, and the picker says what that cost.
+//
+// The rule and its consequences are proved in host-tests/wallpapers, which is
+// where they can be walked over all eight modes rather than reasoned about.
+void WallpapersActivity::applySleepSettings() {
   const bool quickResumeOnTimeout =
       SETTINGS.quickResumeSleepScreen == CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT;
   const wallpapers::SleepChoice choice = wallpapers::choiceForSetWallpaper(SETTINGS.sleepScreen, quickResumeOnTimeout);
-  SETTINGS.sleepScreen = choice.sleepScreenMode;
-  SETTINGS.quickResumeSleepScreen = choice.quickResumeAfterTimeout
-                                        ? CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT
-                                        : CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_NEVER;
-  SETTINGS.saveToFile();
-  lastChoice_ = choice;
-  selectedThisSession_ = true;
-  if (choice.tookOverMode || choice.clearedQuickResume) {
+  // Written only when it actually moves. The set is committed one tap at a
+  // time, and an unconditional SETTINGS.saveToFile() would put a JSON write on
+  // every one of them for a value that has not changed since the first.
+  if (SETTINGS.sleepScreen != choice.sleepScreenMode || quickResumeOnTimeout != choice.quickResumeAfterTimeout) {
+    SETTINGS.sleepScreen = choice.sleepScreenMode;
+    SETTINGS.quickResumeSleepScreen = choice.quickResumeAfterTimeout
+                                          ? CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT
+                                          : CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_NEVER;
+    SETTINGS.saveToFile();
     LOG_INF("WALL", "sleep settings changed by a selection: mode %s -> %s, quick resume on timeout %d -> %d",
             wallpapers::sleepScreenModeName(choice.previousMode),
             wallpapers::sleepScreenModeName(choice.sleepScreenMode), quickResumeOnTimeout ? 1 : 0,
             choice.quickResumeAfterTimeout ? 1 : 0);
   }
+  lastChoice_ = choice;
+  selectedThisSession_ = true;
+}
 
-  HalFile marker;
-  if (Storage.openFileForWrite("WALL", wallpapers::kActiveMarker, marker)) {
-    const std::string& n = names_[static_cast<size_t>(index)];
-    marker.write(reinterpret_cast<const uint8_t*>(n.c_str()), n.size());
-    marker.close();
+// Put the card into the ONE shape cardShapeFor() names for this many
+// wallpapers. The only writer of /sleep.bmp, /.sleep and /wallpapers/.active,
+// so "the pin and the set are never both live" has one place to hold.
+//
+// The order inside each branch is chosen so that a power cut mid-commit leaves
+// a picture the user CHOSE on the glass rather than nothing: the slot that wins
+// is written before the slot that loses is cleared. That can leave both
+// populated for an instant, which is the same state BmpViewerActivity can
+// create at any time, and loadSelection() reports it in words either way.
+bool WallpapersActivity::commitSelection(const std::vector<std::string>& want) {
+  const wallpapers::CardShape shape = wallpapers::cardShapeFor(static_cast<int>(want.size()));
+
+  if (shape.pinned) {
+    if (!copyWallpaper(sourcePathFor(want[0]), wallpapers::kPinnedSleep)) return false;
+    clearShuffleDir();
+    HalFile marker;
+    if (Storage.openFileForWrite("WALL", wallpapers::kActiveMarker, marker)) {
+      marker.write(reinterpret_cast<const uint8_t*>(want[0].c_str()), want[0].size());
+      marker.close();
+    }
+  } else if (shape.shuffled) {
+    if (!fillShuffleDir(want)) return false;
+    Storage.remove(wallpapers::kPinnedSleep);
+    // The hint has nothing left to name, and a stale name beside a set is the
+    // second source that can disagree with the directory. Deleting it is
+    // cheaper than reconciling it.
+    Storage.remove(wallpapers::kActiveMarker);
+  } else {
+    Storage.remove(wallpapers::kPinnedSleep);
+    clearShuffleDir();
+    Storage.remove(wallpapers::kActiveMarker);
   }
-  activeIndex_ = index;
-  LOG_INF("WALL", "Set sleep wallpaper: %s (copy+settings took %ums)", names_[static_cast<size_t>(index)].c_str(),
-          millis() - tSet);
+
+  // Nothing chosen leaves the sleep mode alone. It is still CUSTOM with no file,
+  // which falls through to the user's own /sleep and then to the default screen
+  // -- and reverting a mode the user may have set deliberately, because they
+  // unchecked their last wallpaper, would be the app deciding more than it was
+  // asked to.
+  if (!want.empty()) applySleepSettings();
+  loadSelection();
+  LOG_INF("WALL", "selection committed: %d chosen (pin=%d set=%d)", static_cast<int>(want.size()), shape.pinned ? 1 : 0,
+          shape.files);
   return true;
+}
+
+bool WallpapersActivity::setWallpaper(const int index) {
+  if (index < 0 || index >= static_cast<int>(names_.size())) return false;
+  return commitSelection({names_[static_cast<size_t>(index)]});
+}
+
+// A tap on a tile while choosing: add or remove one wallpaper, committed to the
+// card before the function returns. There is nothing held in RAM to lose, and
+// no cancel to get wrong -- DONE and Back therefore mean the same thing.
+void WallpapersActivity::toggleChosen(const int index) {
+  if (index < 0 || index >= static_cast<int>(names_.size())) return;
+  const std::string& name = names_[static_cast<size_t>(index)];
+
+  std::vector<std::string> want;
+  want.reserve(chosen_.size() + 1);
+  bool removing = false;
+  for (const std::string& c : chosen_) {
+    if (wallpapers::sameFileName(c, name)) {
+      removing = true;
+      continue;
+    }
+    want.push_back(c);
+  }
+  if (!removing) {
+    // The three-outcome precondition, at the floor for the ONE file this tap
+    // writes. Read from the LAST walk rather than a fresh one: freeBytes()
+    // walks the FAT cluster chain, and this is the input path.
+    //
+    // Unknown proceeds here rather than refusing, unlike the download's
+    // precondition. The doctrine's premise is that proceeding on Unknown costs
+    // the user whose card is already in trouble -- and this write is
+    // transactional (.part, size-checked, renamed), so a card that cannot take
+    // it loses nothing and says so. Refusing on a card whose free-space walk
+    // merely failed would make the picker unusable on it.
+    if (freeKnown_ && wallpapers::roomFor(true, freeBytes_, wallpapers::kAddFloorBytes) == wallpapers::Room::TooFull) {
+      showNotice("NOT ENOUGH ROOM",
+                 "Your set was not changed. Free some space on the card and try again -- each wallpaper is about "
+                 "48 KB.",
+                 "OK", wallpapersui::ActionDismiss);
+      return;
+    }
+    want.push_back(name);
+  }
+
+  if (!commitSelection(want)) {
+    warningPending_ = true;
+    showNotice("COULD NOT CHANGE THE SET",
+               "Your sleep screen is unchanged. The card may be full, or the file may be damaged.", "OK",
+               wallpapersui::ActionDismiss);
+    return;
+  }
+  // The free number moved. Re-armed rather than re-walked: loop() runs it after
+  // the next paint is on the glass.
+  warningPending_ = true;
+  requestUpdate();
 }
 
 WallpapersActivity::Thumb WallpapersActivity::decodeThumb(const std::string& path, int16_t cellW, int16_t cellH) const {
@@ -613,7 +845,7 @@ void WallpapersActivity::drawGrid(const wallpapersui::GridGeom& geom) {
     // A hairline on every cell so a mostly-white wallpaper still reads as a
     // framed tile. This is not the selection signal: it is on every cell.
     renderer.drawRect(th.x, th.y, th.width, th.height, 1, true);
-    if (idx == activeIndex_) drawMarker(th);
+    if (isChosen(idx)) drawMarker(th);
 
     // Caption (variants with one): the file name, fitted so it never truncates
     // into a missing glyph.
@@ -762,8 +994,23 @@ uint64_t fileSizeOf(const std::string& path) {
 // ours and unambiguously incomplete, so they go on entry. Nothing else is
 // touched: a .bmp of an unexpected length might be a wallpaper the user made
 // elsewhere, and deleting a user's file to tidy up is not this app's call.
+// Incomplete copies left by a power cut. Swept from EVERY place this app writes
+// one, which is three: the library (the download's unpack), the set directory,
+// and the card root beside the pinned file. A .part is skipped by
+// findNextValidSleepImage on its extension, so one is inert rather than
+// dangerous -- but it is 48KB of a card whose free space this app warns about.
 void WallpapersActivity::sweepPartFiles() {
-  auto dir = Storage.open(wallpapers::kLibraryDir);
+  const std::string rootPart = std::string(wallpapers::kPinnedSleep) + ".part";
+  if (Storage.exists(rootPart.c_str())) {
+    Storage.remove(rootPart.c_str());
+    LOG_INF("WALL", "Swept incomplete %s", rootPart.c_str());
+  }
+  sweepPartFilesIn(wallpapers::kShuffleDir);
+  sweepPartFilesIn(wallpapers::kLibraryDir);
+}
+
+void WallpapersActivity::sweepPartFilesIn(const char* dirPath) {
+  auto dir = Storage.open(dirPath);
   if (!dir) return;
   std::vector<std::string> stale;
   for (;;) {
@@ -777,9 +1024,9 @@ void WallpapersActivity::sweepPartFiles() {
   }
   dir.close();
   for (const std::string& name : stale) {
-    const std::string path = std::string(wallpapers::kLibraryDir) + "/" + name;
+    const std::string path = std::string(dirPath) + "/" + name;
     Storage.remove(path.c_str());
-    LOG_INF("WALL", "Swept incomplete %s", name.c_str());
+    LOG_INF("WALL", "Swept incomplete %s", path.c_str());
   }
 }
 
@@ -925,7 +1172,7 @@ void WallpapersActivity::runSetDownload() {
   Storage.remove(kPackPart);
   scanLibrary();
   prewarmThumbs();
-  loadActive();
+  loadSelection();
   computeWarning();
   page_ = 0;
   cachedPage_ = -1;
@@ -1054,6 +1301,15 @@ void WallpapersActivity::loop() {
       requestUpdate();
       return;
     }
+    // Back and DONE do the same thing, and that is the point: every toggle is
+    // already on the card, so there is no uncommitted set for the two exits to
+    // disagree about. A modal whose two ways out mean different things is the
+    // ambiguity this design does not have.
+    if (choosing_) {
+      choosing_ = false;
+      requestUpdate();
+      return;
+    }
     shelf::leave(renderer, mappedInput);
     return;
   }
@@ -1107,6 +1363,29 @@ void WallpapersActivity::loop() {
   int tapY = 0;
   if (!mappedInput.wasScreenTapped(tapX, tapY) || !interactionsReady_) return;
 
+  // The header chip is the only hit region the grid registers; everything below
+  // it is geometry. Routed FIRST so a tap on the band cannot fall through to a
+  // cell, and gated on the surface like every cell is: the chip is the one
+  // control on this screen whose label changes, so a tap that left the finger
+  // against the previous frame must not act on the new one.
+  {
+    fui::InputSnapshot chipInput{};
+    chipInput.touchReleased = true;
+    chipInput.touchX = static_cast<int16_t>(tapX);
+    chipInput.touchY = static_cast<int16_t>(tapY);
+    if (interactions_.route(chipInput).action == wallpapersui::ActionChoose) {
+      if (!surfaceRevealed()) {
+        LOG_INF("WALL", "chip tap refused: surface not yet seen");
+        return;
+      }
+      choosing_ = !choosing_;
+      LOG_INF("WALL", "choose-a-set mode %s with %d chosen", choosing_ ? "on" : "off",
+              static_cast<int>(chosen_.size()));
+      requestUpdate();
+      return;
+    }
+  }
+
   const wallpapersui::GridGeom geom = wallpapersui::gridGeom(toybox::makeTarget(renderer).deviceContext());
 
   // A page dot?
@@ -1143,21 +1422,46 @@ void WallpapersActivity::loop() {
   const int specials = specialTiles();
   const int total = specials + static_cast<int>(names_.size());
   if (combined >= total) return;
+  // The chrome tiles keep their meaning in BOTH modes -- a big black "+" that
+  // does nothing because of a mode you are in is worse than one that works --
+  // and they leave choose-a-set behind, because they leave the grid. Nothing is
+  // lost by that: the set is already on the card.
   if (combined == 0) {
+    choosing_ = false;
     view_ = View::Help;
     requestUpdate();
     return;
   }
   if (specials > 1 && combined == 1) {
+    choosing_ = false;
     startSetDownload();
     return;
   }
   const int idx = combined - specials;
+  if (choosing_) {
+    toggleChosen(idx);
+    return;
+  }
+  // A live set is never collapsed by one stray tap. Before this, a tap here
+  // replaced the whole set with the one wallpaper touched -- six taps of work
+  // undone in one, with nothing said, under the very pixel that meant "add to
+  // the set" one chip-press earlier. That is same-pixel-different-action with a
+  // destructive outcome, which is the case that memory exists for.
+  //
+  // So with a set live the tap opens the set for editing instead, with the
+  // wallpaper it landed on toggled: the strip has already said "Tap to change."
+  // Getting back to one wallpaper is unchoosing the rest, which normalises to a
+  // plain pin at the last one.
+  if (chosen_.size() >= 2) {
+    choosing_ = true;
+    toggleChosen(idx);
+    return;
+  }
   // "Already the sleep screen" is only true when it can actually BE the sleep
   // screen. When the settings block it, tapping the marked wallpaper again is
   // exactly what a person does after nothing happened, and it now repairs the
   // settings instead of being swallowed (#354).
-  if (idx == activeIndex_ && !sleepBlocked()) return;
+  if (idx == activeIndex_ && !sleepBlocked() && !shadowedSet_) return;
   if (setWallpaper(idx)) {
     requestUpdate();
     return;
@@ -1223,23 +1527,31 @@ void WallpapersActivity::render(RenderLock&&) {
   } else {
     const wallpapersui::GridGeom geom = wallpapersui::gridGeom(device);
     const int pages = pageCount();
-    if (pages > 1) {
-      char label[40];
-      snprintf(label, sizeof(label), "PAGE %d / %d", page_ + 1, pages);
-      rightLabel_ = label;
-    } else {
-      char label[40];
-      snprintf(label, sizeof(label), "%d SAVED", static_cast<int>(names_.size()));
+    // "1 / 6", not "PAGE 1 / 6", and "21 SAVED" is gone. The band now carries a
+    // third thing -- the chip -- and headerTitleWidth subtracts every one of
+    // them from the title's room: at the display cut the long forms cut
+    // "WALLPAPERS" to "WALLPAPE...", which the render showed and no assertion
+    // would have. The page dots under the grid say the same thing again, and
+    // the count moved to the strip, which has the room for a sentence.
+    rightLabel_.clear();
+    if (pages > 1 && !choosing_) {
+      char label[16];
+      snprintf(label, sizeof(label), "%d / %d", page_ + 1, pages);
       rightLabel_ = label;
     }
     wallpapersui::GridChromeModel model;
-    model.rightLabel = rightLabel_.c_str();
+    model.rightLabel = rightLabel_.empty() ? nullptr : rightLabel_.c_str();
     model.warning = warning_.empty() ? nullptr : warning_.c_str();
-    model.hasActive = activeIndex_ >= 0;
-    // Rebuilt from SETTINGS every paint rather than cached at selection time.
-    // The reach half is only knowable from the live settings, and the pointer
-    // is always a string literal out of WallpapersCore, so nothing here
-    // outlives the paint or allocates on it.
+    // A live SET counts as active. Without this the grid draws "Tap one to set
+    // your sleep screen." beside five marked wallpapers that already are it.
+    model.hasActive = !chosen_.empty();
+    model.choosing = choosing_;
+    // Rebuilt from SETTINGS and the card every paint rather than cached at
+    // selection time: the reach half is only knowable from the live settings,
+    // and a cached sentence is how #354's caveat came to be suppressed for a
+    // whole app session. The pointer is a literal out of WallpapersCore except
+    // for the one line that carries a count, which is built into note_ -- a
+    // member, so it outlives the paint.
     model.note = currentSleepNote();
     wallpapersui::buildGridChrome(surface, model);
 
@@ -1265,5 +1577,13 @@ uint32_t WallpapersActivity::surfaceMeaning() const {
   // activeIndex_ is NOT in here. See wallpapersui::gridMeaning: the selection
   // does not remap a single cell, so gating taps on it made the picker deaf for
   // a whole refresh after every tap -- Mario's "touches get lost".
-  return wallpapersui::gridMeaning(page_, static_cast<int>(view_), static_cast<int>(names_.size()), specialTiles());
+  //
+  // choosing_ IS, because it changes what a cell DOES. The cost is real and
+  // named: the first tile tap after the chip is refused until the new frame is
+  // on the glass, which on this panel is 0.3-2s. That is the correct answer --
+  // the tap was aimed at the screen before the mode changed -- but it is a tap
+  // a person will feel, so it is written down here and in the pull request
+  // rather than discovered on hardware.
+  return wallpapersui::gridMeaning(page_, static_cast<int>(view_), static_cast<int>(names_.size()), specialTiles(),
+                                   choosing_);
 }

--- a/src/apps_local/wallpapers/WallpapersActivity.h
+++ b/src/apps_local/wallpapers/WallpapersActivity.h
@@ -56,14 +56,30 @@ class WallpapersActivity final : public Activity {
   void scanLibrary();
   int builtInsPresent() const;  // how many of the built-in set are on the card
   void pickView();              // Grid or Offer, from the card alone
-  void sweepPartFiles();        // drop incomplete unpacks left by a power cut
-  void startSetDownload();      // ask for WiFi, then queue the fetch
+  void sweepPartFiles();        // drop incomplete copies left by a power cut
+  void sweepPartFilesIn(const char* dirPath);
+  void startSetDownload();  // ask for WiFi, then queue the fetch
   void onWifiChosen(bool connected);
   void runSetDownload();  // blocking: fetch the pack, then unpack it
   bool unpackSet();       // pack -> individual .bmp files, resumable
   void prewarmThumbs();   // build the thumbnail cache while the bar is still up
   void showNotice(const char* headline, const char* body, const char* actionLabel, freeink::ui::ActionId action);
-  void loadActive();
+  // What the CARD says is chosen, re-read after every commit. Never a
+  // remembered intention: /sleep.bmp and /.sleep are what the sleep screen
+  // reads, so they are what the picker reports (see docs/apps/wallpapers-shuffle.md).
+  void loadSelection();
+  bool isChosen(int index) const;
+  void listShuffleDir(std::vector<std::string>& out) const;
+  // Put the card into the one shape cardShapeFor() names for this many
+  // wallpapers. The ONLY writer of /sleep.bmp, /.sleep and /wallpapers/.active,
+  // so the invariant that they are never both live has one place to hold.
+  bool commitSelection(const std::vector<std::string>& want);
+  bool copyWallpaper(const std::string& src, const std::string& dst) const;
+  std::string sourcePathFor(const std::string& name) const;
+  bool fillShuffleDir(const std::vector<std::string>& want);
+  void clearShuffleDir();
+  void applySleepSettings();
+  void toggleChosen(int index);  // a tap on a tile while choosing
   void computeWarning();
   // Whether the pinned wallpaper can reach the sleep screen under the settings
   // as they are RIGHT NOW, and the one line that says so. Both read SETTINGS
@@ -71,8 +87,10 @@ class WallpapersActivity final : public Activity {
   // and the web settings page) while this app is not looking. See #354.
   wallpapers::Reach sleepReach() const;
   bool sleepBlocked() const;
-  const char* currentSleepNote() const;
-  bool setWallpaper(int index);  // copy /wallpapers/<index> -> /sleep.bmp
+  // Not const: a line carrying a count is built into note_, which has to
+  // outlive the paint. Every other line is a literal out of WallpapersCore.
+  const char* currentSleepNote();
+  bool setWallpaper(int index);  // choose exactly this one
   int pageCount() const;         // over the whole library
   void clampPage();
   void ensureThumbsForPage();  // decode this page's cells if not cached
@@ -87,10 +105,16 @@ class WallpapersActivity final : public Activity {
   void drawMarker(const freeink::ui::Rect& th) const;
 
   std::vector<std::string> names_;  // library file names, sorted
-  int activeIndex_ = -1;            // which name is pinned, or -1
-  int builtInsMissing_ = 0;         // how many of the built-in set are not on the card
-  bool warningPending_ = false;     // the free-space walk, deferred until after the first paint
-  bool painted_ = false;            // the panel has shown something at least once
+  // The chosen set, as it is on the card. Holds the pinned name when one
+  // wallpaper is chosen and the contents of /.sleep when several are -- INCLUDING
+  // any whose library file has since been deleted, because those copies still
+  // take their turn on the glass and a count that skipped them would understate
+  // what the sleep screen does.
+  std::vector<std::string> chosen_;
+  int activeIndex_ = -1;         // which name is pinned, or -1
+  int builtInsMissing_ = 0;      // how many of the built-in set are not on the card
+  bool warningPending_ = false;  // the free-space walk, deferred until after the first paint
+  bool painted_ = false;         // the panel has shown something at least once
   int page_ = 0;
   int fetchDone_ = 0;
   int fetchTotal_ = 0;
@@ -110,6 +134,20 @@ class WallpapersActivity final : public Activity {
   // suppress a caveat for a whole app session (#354, twice over).
   bool selectedThisSession_ = false;
   wallpapers::SleepChoice lastChoice_;
+  // Choose-a-set mode: what a tap on a tile means. RAM only and reset on every
+  // onEnter, because it is a mode the user is in, not a fact about the card --
+  // an invisible saved value that decides what a tap does is how a reproducible
+  // screen becomes a nondeterministic one.
+  bool choosing_ = false;
+  // /sleep.bmp present while /.sleep also holds files: one picture is showing
+  // and a set is inert behind it. Read off the card on entry, because nothing
+  // in SETTINGS can see it and this app is not its only cause.
+  bool shadowedSet_ = false;
+  // The last free-space walk's raw answer, so an add can apply the precondition
+  // at its own floor without a second FAT cluster walk on the input path.
+  bool freeKnown_ = false;
+  uint64_t freeBytes_ = 0;
+  std::string note_;  // the hint strip's line, when it carries a number
 
   // The current page's thumbnails, one per on-page slot (perPage entries;
   // trailing empty slots have ok = false).

--- a/src/apps_local/wallpapers/WallpapersCore.cpp
+++ b/src/apps_local/wallpapers/WallpapersCore.cpp
@@ -272,6 +272,94 @@ StripLine stripLineAfterSelection(const SleepChoice& choice, const Reach reach) 
   return line;
 }
 
+CardShape cardShapeFor(const int chosenCount) {
+  CardShape shape;
+  if (chosenCount <= 0) return shape;
+  if (chosenCount == 1) {
+    shape.pinned = true;
+    return shape;
+  }
+  shape.shuffled = true;
+  shape.files = chosenCount;
+  return shape;
+}
+
+ShuffleLine shuffleStripLine(const bool choosing, const int chosenCount, const bool shadowedSet, const Reach reach) {
+  ShuffleLine line;
+
+  // Nothing chosen and nothing hidden: there is nothing for a caveat to be
+  // ABOUT. Telling someone on a fresh device that Sleep Screen is not set to
+  // Custom, before they have picked anything and while their first pick is
+  // about to set it, displaces the one sentence that says what to do. Same rule
+  // the single-pin path has always had (currentSleepNote returns nothing when
+  // nothing is pinned).
+  const bool somethingToSpeakFor = chosenCount > 0 || shadowedSet;
+
+  // Otherwise the settings caveat wins the line outright: one 30px strip, and a
+  // sentence about which of the user's pictures appear is worth nothing on a
+  // device where none of them can.
+  if (somethingToSpeakFor && reach != Reach::Always) {
+    line.text = reachHint(reach);
+    line.saysCaveat = line.text != nullptr;
+    return line;
+  }
+
+  // Then the card's own contradiction. Said before any count, because the count
+  // would be a lie while it holds: the files are there and none of them shows.
+  if (shadowedSet) {
+    line.text = "One wallpaper is hiding a set.";
+    line.saysShadow = true;
+    return line;
+  }
+
+  if (choosing) {
+    // Naming the OTHER half of the gesture matters more than the count, which
+    // the header carries: a mode whose taps toggle is a mode whose taps must be
+    // seen to un-toggle, or the first mistap reads as a set you cannot escape.
+    if (chosenCount <= 0) {
+      line.text = "Tap wallpapers to build a set.";
+      return line;
+    }
+    // The count is HERE rather than in the band, and the render is why: the
+    // header holds the app name, the chip and one label, and at the display cut
+    // the third of those cut "WALLPAPERS" to "WALLPAPE...". The strip has the
+    // room and the count has to be somewhere -- four tiles fit a page and the
+    // library is six pages, so the marks alone cannot say how many are chosen.
+    if (chosenCount == 1) {
+      line.text = "chosen. Pick another.";
+      line.wantsCount = true;
+      return line;
+    }
+    line.text = "chosen. Tap again to remove.";
+    line.wantsCount = true;
+    return line;
+  }
+
+  // Not choosing. Only a real set is worth a line -- one pinned wallpaper is
+  // what reachHint and stripLineAfterSelection already speak for.
+  //
+  // "Take turns", never "shuffle" or "random", and the word is load-bearing.
+  // selectRandomSleepFile excludes the last `min(recentFill, N-1)` images, and
+  // recentFill climbs to 16 and never resets, so for any set up to seventeen
+  // every member but one is excluded and the order is a strict cycle. A two-set
+  // alternates. Calling that shuffling would be a promise the platform does not
+  // keep.
+  if (chosenCount >= 2) {
+    line.text = "take turns. Tap to change.";
+    line.wantsCount = true;
+    return line;
+  }
+  return line;
+}
+
+bool sameFileName(const std::string_view a, const std::string_view b) {
+  if (a.size() != b.size()) return false;
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(a[i])) != std::tolower(static_cast<unsigned char>(b[i]))) return false;
+  }
+  return true;
+}
+
 Room roomFor(bool queryOk, uint64_t freeBytes, uint64_t floorBytes) {
   if (!queryOk) return Room::Unknown;
   return freeBytes >= floorBytes ? Room::Ok : Room::TooFull;

--- a/src/apps_local/wallpapers/WallpapersCore.h
+++ b/src/apps_local/wallpapers/WallpapersCore.h
@@ -26,15 +26,28 @@ inline constexpr char kLibraryDir[] = "/wallpapers";
 // library.
 inline constexpr char kPinnedSleep[] = "/sleep.bmp";
 
+// The shuffle set's directory. Upstream's renderCustomSleepScreen tries
+// "/.sleep" before "/sleep", and BOTH after "/sleep.bmp" -- so a set lives here
+// and the pinned single above SHADOWS it silently. That shadow is the whole
+// reason cardShapeFor() exists: the two are never allowed to be populated at
+// once. Dotted, unlike the library: it is upstream's own path, the user did not
+// put these files here, and they are copies rather than originals.
+inline constexpr char kShuffleDir[] = "/.sleep";
+
 // Which library file is currently pinned, so the picker can mark it. A hint,
 // not the source of truth: the source of truth is /sleep.bmp, and this is only
 // trusted when that file exists and the sleep mode is CUSTOM.
 inline constexpr char kActiveMarker[] = "/wallpapers/.active";
 
-// A wallpaper file is a plain `.bmp` whose name does not start with '.'. This
-// matches the sleep system's own findNextValidSleepImage filter exactly, so a
-// file this app offers is a file the sleep screen will accept -- the two
-// filters cannot drift, because they are the same rule.
+// A wallpaper file is a plain `.bmp` whose name does not start with '.'. That
+// is the NAME half of the sleep system's own findNextValidSleepImage filter,
+// and the two are not the same rule: upstream also parses each candidate's BMP
+// headers and skips the ones that fail, which a name cannot see. So this is a
+// necessary condition, not a sufficient one -- everything it rejects the sleep
+// screen rejects, and a file it accepts can still be skipped for being
+// unreadable. Everything this app itself writes is size-checked at
+// kWallpaperFileBytes on the way in, so the gap is only ever a file somebody
+// put on the card by hand.
 bool isSupportedWallpaper(std::string_view name);
 
 // The free-space precondition. The device cannot measure free space reliably
@@ -183,6 +196,71 @@ struct StripLine {
 };
 StripLine stripLineAfterSelection(const SleepChoice& choice, Reach reach);
 
+// ---------------------------------------------------------------------------
+// One selection, of size 0, 1 or many -- and the shape the card must be left in
+// for it.
+//
+// A pinned single and a shuffle set are not two features. They are the N == 1
+// and N >= 2 cases of ONE chosen set, which is what keeps the grid's marker
+// meaning exactly one thing ("this is on your sleep screen") instead of two.
+//
+// The card's two slots are not symmetric: renderCustomSleepScreen draws
+// /sleep.bmp if it parses AT ALL and only then looks in /.sleep, so a leftover
+// pin makes a five-wallpaper set show one picture forever with nothing on any
+// screen saying why. Both slots are therefore derived from the count HERE, in
+// one place, and host-tests/wallpapers walks every count asserting they are
+// never both live.
+//
+// An emptied /.sleep does not shadow anything: selectRandomSleepFile returns
+// false for a directory with no valid image and upstream falls through to
+// /sleep and then to the default screen. So "empty it" is enough; the directory
+// itself may stay.
+struct CardShape {
+  bool pinned = false;    // /sleep.bmp must hold the one chosen wallpaper
+  bool shuffled = false;  // /.sleep must hold exactly the chosen wallpapers
+  int files = 0;          // how many files /.sleep must hold (0 unless shuffled)
+};
+CardShape cardShapeFor(int chosenCount);
+
+// The strip's line while a set is involved, and what it covers.
+//
+// Same shape as StripLine above and for the same reason: a sentence that has to
+// carry a caveat AND a count cannot be checked by looking for a word in it, so
+// it declares what it says and host-tests/wallpapers asserts the coverage
+// equals the facts present.
+//
+// `count` is spoken by the CALLER (the strip is a std::string when a number is
+// in it), so what comes back here is the sentence WITHOUT the number plus a
+// flag saying a number belongs in front of it. Keeping the number out of this
+// function is what lets host-tests/wallcaption measure the sentence in the face
+// the strip resolves; the caller measures the longest number it can produce.
+struct ShuffleLine {
+  const char* text = nullptr;
+  bool wantsCount = false;  // the caller prefixes "<n> "
+  bool saysCaveat = false;
+  bool saysShadow = false;
+};
+// `choosing` is the picker's choose-a-set mode; `chosenCount` is how many
+// wallpapers are in the set right now; `shadowedSet` is the state only the CARD
+// can report -- /sleep.bmp present while /.sleep also holds files, so one
+// picture is showing and a set the user built is inert behind it.
+//
+// That state is not hypothetical and this app is not its only cause:
+// BmpViewerActivity's "set sleep cover" writes /sleep.bmp straight from the
+// file browser, the File Transfer page can drop one at the card root, and a
+// power cut halfway through a 1 <-> 2 transition leaves one behind. Reach
+// cannot see any of it -- it is a pure function of two SETTINGS values -- so
+// the card's own answer is a separate argument here rather than something the
+// predicate is asked to know.
+ShuffleLine shuffleStripLine(bool choosing, int chosenCount, bool shadowedSet, Reach reach);
+
+// Do two file names name the same file? Case-insensitively, because the card is
+// FAT: long names keep their case but the filesystem matches without it, and a
+// card mounted on a PC can hand back "BLAKE.BMP" for a file written as
+// "blake.bmp". A case-sensitive membership test would then draw no marker for a
+// wallpaper that is in the set.
+bool sameFileName(std::string_view a, std::string_view b);
+
 enum class Room : uint8_t { Ok, TooFull, Unknown };
 Room roomFor(bool queryOk, uint64_t freeBytes, uint64_t floorBytes);
 
@@ -206,5 +284,13 @@ inline constexpr uint64_t builtInPackBytes() { return kWallpaperFileBytes * kBui
 // other apps plus the whole set, not one file -- the download writes all of
 // them, and checking for one would pass on a card that fills at wallpaper 9.
 inline constexpr uint64_t kPackFloorBytes = kCardFloorBytes + builtInPackBytes();
+
+// What the card must have free before ADDING one wallpaper to the shuffle set.
+// Derived from the file size rather than typed, like every other figure here.
+//
+// One file, not N, because the set is committed a tap at a time: there is never
+// a batch of N in flight, so there is never a partly written set to size a
+// precondition for. See docs/apps/wallpapers-shuffle.md.
+inline constexpr uint64_t kAddFloorBytes = kCardFloorBytes + kWallpaperFileBytes;
 
 }  // namespace wallpapers

--- a/src/apps_local/wallpapers/WallpapersScreens.cpp
+++ b/src/apps_local/wallpapers/WallpapersScreens.cpp
@@ -157,9 +157,39 @@ void paintTruchet(fui::DrawTarget& t, const fui::Rect& r, const int cell) {
   }
 }
 
-void chrome(toybox::Screen& screen, const char* title, const char* rightLabel) {
+// The chip's style, re-derived against a BLACK ground rather than borrowed from
+// the paper pair. toybox::invertedStyles() is a solid black fill, which on this
+// band IS the band and leaves only a floating glyph; rowStyles() is a white
+// fill whose black hairline vanishes. HackerNews' save chip carries the same
+// pair for the same reason (the-black-band-swaps-your-styles). This chip is an
+// ACTION rather than a state, so it only ever needs the outline half: a filled
+// chip would read as "already on".
+fui::StyleSet bandOutlineStyles() {
+  fui::StyleSet styles;
+  styles.explicitlySet = true;
+  styles.normal.background = fui::Paint::solid(fui::Color::Black);
+  styles.normal.foreground = fui::Paint::solid(fui::Color::White);
+  styles.normal.border = fui::Paint::solid(fui::Color::White);
+  styles.normal.borderWidth = toybox::kHairline;
+  styles.selected = styles.normal;
+  styles.focused = styles.normal;
+  styles.active = styles.normal;
+  styles.disabled = styles.normal;
+  return styles;
+}
+
+void chrome(toybox::Screen& screen, const char* title, const char* rightLabel, const bool showChip = false,
+            const bool choosing = false) {
   fui::HeaderProps header;
   header.title = title;
+  if (showChip) {
+    header.trailingLabel = chooseChipLabel(choosing);
+    header.trailingAction = ActionChoose;
+    header.trailingStyles = bandOutlineStyles();
+    header.trailingText = screen.theme().smallText;
+    header.trailingText.color = fui::Color::White;
+    header.trailingRadius = toybox::kPillRadius / 2;
+  }
   header.rightLabel = rightLabel;
   header.borderEdges = fui::EdgesNone;
   if (rightLabel != nullptr) {
@@ -241,12 +271,27 @@ int cellAt(const GridGeom& g, int x, int y) {
   return -1;
 }
 
+int pageCountFor(const int specialTiles, const int libraryCount, const int perPage) {
+  if (perPage <= 0) return 1;
+  const int tiles = (specialTiles < 0 ? 0 : specialTiles) + (libraryCount < 0 ? 0 : libraryCount);
+  if (tiles <= 0) return 1;
+  return (tiles + perPage - 1) / perPage;
+}
+
 int16_t hintTextWidth(const fui::Rect& safe) { return static_cast<int16_t>(safe.width - toybox::kMargin * 2); }
 
 int16_t hintStripHeight() { return kHintH; }
 
+const char* chooseChipLabel(const bool choosing) { return choosing ? "DONE" : "CHOOSE"; }
+
+const char* chooseHint() { return "Tap CHOOSE to pick several."; }
+
 void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model) {
-  chrome(screen, model.title, model.rightLabel);
+  // The title says which mode this is, in the biggest type on the screen. The
+  // chip alone could not: it reads DONE in one mode and SHUFFLE in the other,
+  // and a person who has not been watching cannot tell a verb they may press
+  // from a verb they already pressed.
+  chrome(screen, model.choosing ? "CHOOSE A SET" : model.title, model.rightLabel, true, model.choosing);
 
   // The hint strip, at a fixed place so the grid below it never moves. One
   // line, and three things want it; the order is settled just below.
@@ -272,6 +317,12 @@ void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model) {
     // Short enough to fit the hint strip at the grid's cut. The longer form
     // ("Tap a wallpaper to set it as your sleep screen.") was cut mid-phrase.
     line = "Tap one to set your sleep screen.";
+  } else if (!model.choosing) {
+    // Something IS set, nothing is wrong, and the strip would otherwise be
+    // blank -- which is where the one affordance nobody would guess belongs.
+    // Four tiles fit a page, so a chip in the band is the only thing on this
+    // screen that says a set is possible at all.
+    line = chooseHint();
   }
   if (line != nullptr) {
     const fui::Rect rect =
@@ -427,11 +478,13 @@ void buildOffer(toybox::Screen& screen, const OfferModel& model) {
 // DOWNLOADING. Painted from inside the blocking fetch, so it says what is
 // happening, how far along, and that Back stops it -- the three things a person
 // staring at a frozen-looking panel needs (a-silent-screen-reads-as-a-crash).
-uint32_t gridMeaning(const int page, const int view, const int libraryCount, const int specialTiles) {
+uint32_t gridMeaning(const int page, const int view, const int libraryCount, const int specialTiles,
+                     const bool choosing) {
   uint32_t m = paintclock::mixMeaning(paintclock::kMeaningSeed, static_cast<uint32_t>(page));
   m = paintclock::mixMeaning(m, static_cast<uint32_t>(view));
   m = paintclock::mixMeaning(m, static_cast<uint32_t>(libraryCount));
-  return paintclock::mixMeaning(m, static_cast<uint32_t>(specialTiles));
+  m = paintclock::mixMeaning(m, static_cast<uint32_t>(specialTiles));
+  return paintclock::mixMeaning(m, choosing ? 1u : 0u);
 }
 
 BarSpan fetchBarSpan(const FetchingModel& model) {

--- a/src/apps_local/wallpapers/WallpapersScreens.h
+++ b/src/apps_local/wallpapers/WallpapersScreens.h
@@ -50,6 +50,13 @@ fui::Rect captionRect(const GridGeom& g, int slot);
 // Activity draws into.
 int cellAt(const GridGeom& g, int x, int y);
 
+// How many pages the grid spans. Freestanding because the drawing, the
+// hit-test and the page count are three readers of one number, and the one that
+// disagreed made the last wallpaper of a page-boundary library unreachable:
+// pageCount() counted ONE chrome tile while the other two counted
+// specialTiles(), which is two while the built-in set is incomplete.
+int pageCountFor(int specialTiles, int libraryCount, int perPage);
+
 // The selection marker: four corner brackets drawn in the cell's PADDING, so
 // they touch neither the artwork nor the caption. It lives here rather than in
 // the Activity because "does the mark collide with the label" is a question
@@ -73,6 +80,7 @@ enum : fui::ActionId {
   ActionAddOwn = 2,   // the "make your own in a browser" card
   ActionRetry = 3,    // try the fetch again after a failure
   ActionDismiss = 4,  // acknowledge a notice and go back to whatever is on the card
+  ActionChoose = 5,   // the header chip: enter or leave choose-a-set mode
 };
 
 // The BEFORE state: the built-in set is not on the card. This screen has to sell
@@ -127,7 +135,12 @@ BarSpan fetchBarSpan(const FetchingModel& model);
 //
 // Including the selection made every tap deaf for the length of one refresh
 // after every tap, which is what "touches get lost" was.
-uint32_t gridMeaning(int page, int view, int libraryCount, int specialTiles);
+// `choosing` IS in here, unlike the selection, and the difference is the point:
+// the selection does not change what a cell does, and choose-a-set mode does --
+// a tile tap pins one wallpaper outside it and toggles membership inside it. A
+// tap that left the finger against the previous frame must not act on the new
+// meaning (same-pixel-different-action).
+uint32_t gridMeaning(int page, int view, int libraryCount, int specialTiles, bool choosing);
 
 // The FAILED state, and every other "something happened, here is what" screen.
 // Always carries an action: a screen that reports a failure and gives you
@@ -155,7 +168,31 @@ struct GridChromeModel {
   // wallpapers::stripLineAfterSelection / reachHint, which are what guarantee
   // one cannot hide the other. Wins the strip -- see buildGridChrome.
   const char* note = nullptr;
+  // Choose-a-set mode. Changes the title and the chip's label, and nothing
+  // else: the grid below is the same grid, because the wallpapers are what the
+  // user is choosing between in both modes. The chip is the ONLY way in and the
+  // only way out besides Back, and it is a tap rather than a hold -- a hold on
+  // this panel arrives as a tap often enough that a feature behind one
+  // intermittently does not exist (MappedInputManager, InputManager::wasTouchTap).
+  bool choosing = false;
 };
+
+// What the header chip says. One place, because the width the title is fitted
+// to comes out of this string's measured width, and a second copy is a second
+// thing to edit alone (the same rule as HackerNews' save chip).
+const char* chooseChipLabel(bool choosing);
+
+// The lowest-priority line on the strip: how you get to a set at all.
+//
+// It names the chip's own word, so the two cannot drift -- host-tests/wallpapers
+// asserts the sentence CONTAINS chooseChipLabel(false), which is the one case
+// where matching the description is the point rather than the bug: rename the
+// chip and this must be renamed with it (derived-facts-written-as-literals).
+//
+// It sits BELOW the free-space advisory deliberately. It is chrome, not news,
+// and a permanent hint that outranked a filling card would suppress that
+// warning forever.
+const char* chooseHint();
 
 void buildGridChrome(toybox::Screen& screen, const GridChromeModel& model);
 


### PR DESCRIPTION
Card #305. Mario, twice: *"didn't we agree to have a way to select multiple ones at the same time and for them to cycle?"*

A **CHOOSE** chip in the grid's header opens choose-a-set mode: the title becomes `CHOOSE A SET`, a tap on a tile toggles that wallpaper's membership, and `DONE` or `Back` leaves. Two or more chosen and the sleep screen shows a different one each time.

Nothing here schedules anything. `SleepActivity::renderCustomSleepScreen` (UPSTREAM, untouched) already draws `/sleep.bmp` first and otherwise picks from `/.sleep`, so a set is a populated directory and the whole feature is file management plus a picker that tells the truth about it.

## The trap the card named

`/sleep.bmp` shadows `/.sleep` silently. So there is **one** selection of size 0, 1 or many, and `wallpapers::cardShapeFor(n)` says which slot it lives in -- exactly one, never both. `commitSelection` is the only writer of `/sleep.bmp`, `/.sleep` and `/wallpapers/.active`.

| chosen | `/sleep.bmp` | `/.sleep` | the glass shows |
| --- | --- | --- | --- |
| 0 | deleted | emptied | the user's own `/sleep`, else the default |
| 1 | that one | emptied | that wallpaper, every sleep |
| N >= 2 | deleted | those N | a different one each sleep, in a cycle |

It is a **convergence, not a guarantee**: `BmpViewerActivity` writes `/sleep.bmp` straight from the file browser, the File Transfer page can drop one at the root, and a power cut mid-transition leaves one behind. `loadSelection()` reconciles on every entry, reports the pin (what the glass shows), never deletes the set behind it, and the strip says `One wallpaper is hiding a set.`

`.active` is deleted whenever the selection is a set: for N >= 2 the directory the picker reads *is* the directory the sleep screen reads, so there is no second source to disagree with.

## Nothing destructive moved

The first design let a tap in normal mode collapse a live set to one wallpaper -- six taps of work undone in one, silently, under the pixel that meant "add to the set" one chip-press earlier. That is same-pixel-different-action with a destructive outcome. **With a set live, a tap now opens the set for editing with that tile toggled.** Getting back to one wallpaper is unchoosing the rest, which normalises to a plain pin at the last one.

Every toggle commits to the card immediately, so `DONE` and `Back` mean the same thing and there is no cancel to get wrong. A copy that fails leaves the set exactly as it was: adds happen one file ahead of removes, through `.part` + rename + a size check.

## It takes turns; it does not shuffle

`selectRandomSleepFile` excludes the last `min(recentFill, N-1)` images and `recentFill` climbs to 16 and never resets, so a set up to seventeen is a **strict cycle** and a two-set alternates. No user-facing string says "shuffle" or "random", asserted over every sentence rather than remembered.

## Honesty

`reachOfPinnedSleep` is the same predicate for a set (verified line by line against `SleepActivity::onEnter`), but it is a pure function of two SETTINGS values and a set has one more way to be blocked -- a stray pin. So the strip is ordered *caveat > what-the-tap-changed > shadow > count*, and `host-tests/wallpapers` asserts **by coverage** that a number never appears while anything stops those files reaching the glass. It also stays quiet with nothing chosen: the render showed the caveat taking the line on a fresh card, where there is nothing for it to be about.

## What the merge with #143 and #147 settled

Both landed while this was being built, so the composition stopped being a plan and became a resolution.

1. **`cellAction` grew this card's half** rather than gaining early returns beside it. It now takes `choosing`, `chosenCount` and `shadowedSet` as well as `heldLong` and `sleepBlocked`, and the host suite walks every combination of all seven arguments: a hold always opens the sheet, a plain tap never does, choosing always toggles, a live set is never collapsed, and a blocked-or-shadowed mark still re-commits on a tap. Three rules from three cards left as adjacent early returns is how one of them silently wins.
2. **The hold sheet asks `isChosen(index)`**, not `index == activeIndex_`. A member of a live set genuinely is on the sleep screen -- it just takes its turn -- so the pinned index would under-claim for every member of every set, on the screen that is about to delete one.
3. **The hold now works in choose-a-set mode too.** The design said it must not; that was wrong on inspection. The delete is behind a confirm that names the file, and the classifier's failure runs the safe way here (a missed hold arrives as a tap, which toggles membership, which is one tap to undo).

The `check.sh` undo guard fired on the merge (160 lines of trunk "removed"). Every removal was enumerated and every one is a deliberate replacement by a superset -- `loadActive` -> `loadSelection`, `setWallpaper`'s body -> `copyWallpaper` + `applySleepSettings` + `commitSelection`, `pageCount`'s inline arithmetic -> `pageCountFor`, `idx == activeIndex_` -> `isChosen(idx)` -- plus clang-format re-alignment. Nothing from either merged PR was dropped; `CHECK_ALLOW_UNDO=1` is set deliberately, not to get past a red gate.

## Fixed in passing

`pageCount()` counted **one** chrome tile where `drawGrid` and the tap handler both count `specialTiles()`, which is two while the built-in set is incomplete -- so three wallpapers plus two chrome tiles is five tiles, two pages, reported as one, and `clampPage` forbade the page holding the last wallpaper. Both branches found it; the arithmetic is now `wallpapersui::pageCountFor`, walked over every combination. `sweepPartFiles` now clears `.part` files from all three places this app writes one -- it only ever swept the library, so `/sleep.bmp.part` has been an orphan on any power cut mid-pin since the app shipped.

## Tests, watched failing

- **The invariant**: put the leftover pin back beside a set and `host-tests/wallpapers` fails **516 checks**. Restored: 0.
- **The page count**: with the shipped `1 + N` formula, `host-tests/wallcaption` fails **109 checks**. Restored: 0.
- The caveat-wins ordering, the no-shuffle-word rule, the `cellAction` composition and the case-insensitive matching are all asserted by coverage over every combination rather than by the cases anyone would think to try.

## Renders, looked at

Grid with the chip; choose-a-set with nothing chosen; three chosen with the marks; back in normal mode with the set live; the shadowed-set line. No truncation, no overlap, marks clear of captions. **The set was then driven through three consecutive sleeps and drew three different wallpapers** (Celestial Chart, Bauhaus, Bulge), with `/.sleep` holding exactly the three and no `/sleep.bmp`.

The first render caught what no assertion would have: the chip plus the old `PAGE 1 / 6` label cut the title to `WALLPAPE...`. The label is now `1 / 6` and the count moved to the strip. The second caught the caveat taking the line on a fresh card with nothing chosen.

## Not verified

- **Hardware.** Everything here is host suites, both device builds compiling, and the simulator. The simulator never compiles `lib/hal` and never runs `InputManager`, so no gesture in this change has been through the real touch path -- including the chip, and including the dropped tap on entering the mode (`surfaceMeaning` now mixes in `choosing_`, so the first tile tap after the chip is refused until the new frame is on the glass: 0.3-2s).
- **A real SD card.** Every file operation ran against `fs_agent`, a directory. Nothing here has met a full card, a slow card, or a card that refuses a rename.
- **The upstream recency ring.** Its indices are directory positions, shared with `/sleep`, and persist across the deep-sleep reset, so a newly added member can arrive already marked "recently shown". Documented, not fixed -- it is upstream's.
- **A member whose BMP headers do not parse** is counted here and skipped by the sleep screen. Everything this app writes is size-checked, so that can only be a file put on the card by hand.
