### PR TITLE
fix: the render task takes its stack override again, and the gate can fail

### DIFF
--- a/scripts_local/stack_budget.py
+++ b/scripts_local/stack_budget.py
@@ -167,6 +167,33 @@ def budget_of(spec):
     return None, "unresolved"
 
 
+def macro_is_wired(spec):
+    """Is the macro this budget is read from actually compiled into the task?
+
+    Reading -D<spec> out of platformio.ini says what the flag is SET to, never
+    that anything consumes it. For the whole of v1.12.45 the flag said 16384,
+    this gate printed "9520 of 16384, headroom 6864" on every CI run, and
+    xTaskCreatePinnedToCore was passed a literal 8192 -- because a sync had
+    taken upstream's copy of ActivityManager.cpp wholesale and dropped the
+    fork's override with it. Study and xkcd then panicked on the first repaint
+    of their own header, and this gate was green the entire time.
+
+    So: a use has to exist. Definition lines and comments do not count, because
+    the dead state has both of those and nothing else.
+    """
+    for src in list(pathlib.Path("src").rglob("*.cpp")) + list(
+        pathlib.Path("src").rglob("*.h")
+    ):
+        for line in src.read_text(errors="replace").splitlines():
+            code = re.sub(r"//.*|/\*.*?\*/", "", line).strip()
+            if spec not in code:
+                continue
+            if re.match(rf"#\s*(ifndef|ifdef|define|undef|if)\b", code):
+                continue
+            return True, str(src)
+    return False, None
+
+
 def match(needle, pretty, frames):
     """Symbols whose readable signature contains `needle`, worst frame first."""
     hits = [sym for sym, name in pretty.items() if needle in name]
@@ -204,6 +231,18 @@ def main():
             print(f"  ?  {task:<24} stack {budget_spec!r} could not be resolved")
             failed = True
             continue
+        if isinstance(budget_spec, str) and budget_src == "platformio.ini":
+            wired, site = macro_is_wired(budget_spec)
+            if not wired:
+                print(
+                    f"  !! {task:<24} {budget_spec} is set to {budget} in "
+                    f"platformio.ini and NOTHING IN src/ USES IT, so the "
+                    f"firmware runs on the #ifndef default and every number "
+                    f"below would be measured against a stack this task does "
+                    f"not have. Pass {budget_spec} to the task's create call."
+                )
+                failed = True
+                continue
         found = match(entry, pretty, frames)
         if not found:
             # Not a warning. A task whose entry is missing is a task this run

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -28,6 +28,26 @@
 #include "util/FrontlightPanelActivity.h"
 #include "util/FullScreenMessageActivity.h"
 
+// Upstream's 8192 is sized for the X4 and X3: an ESP32-C3 with ~380KB and no
+// PSRAM, where every kilobyte of a task stack is one the reader cannot have.
+// The X4 Pro is an S3 with 8MB, so this fork can afford the headroom and needs
+// it: its own screens draw through FreeInkUI, whose deepest path wants 9520
+// bytes. The literal has now crashed this fork twice -- v1.0.0 on the first
+// device that ever ran it, and v1.12.45 in Study and xkcd, after a sync took
+// upstream's copy of this file wholesale and dropped the override with it.
+//
+// Left as an overridable default rather than a changed literal so the number
+// this fork uses lives in this fork's platformio.ini, and merges from upstream
+// touching this line stay trivial.
+//
+// scripts_local/stack_budget.py now asserts that this macro actually reaches
+// xTaskCreatePinnedToCore. The define alone silently did nothing for all of
+// v1.12.45: the flag was set to 16384, the gate read the flag and printed
+// headroom on every CI run, and the firmware ran the render task on 8192.
+#ifndef CROSSPOINT_RENDER_TASK_STACK
+#define CROSSPOINT_RENDER_TASK_STACK 8192
+#endif
+
 static portMUX_TYPE activityManagerSpinlock = portMUX_INITIALIZER_UNLOCKED;
 
 void ActivityManager::begin() {
@@ -37,10 +57,10 @@ void ActivityManager::begin() {
   constexpr BaseType_t renderTaskCore = 0;
 #endif
   xTaskCreatePinnedToCore(&renderTaskTrampoline, "ActivityManagerRender",
-                          8192,               // Stack size
-                          this,               // Parameters
-                          1,                  // Priority
-                          &renderTaskHandle,  // Task handle
+                          CROSSPOINT_RENDER_TASK_STACK,  // Stack size
+                          this,                          // Parameters
+                          1,                             // Priority
+                          &renderTaskHandle,             // Task handle
                           renderTaskCore  // Keep long renders/cover decodes off CPU 0's idle watchdog when available
   );
   assert(renderTaskHandle != nullptr && "Failed to create render task");


### PR DESCRIPTION
Study and xkcd panicked on open on v1.12.45. Both crashed in the same place, and it was neither app: **the ActivityManager render task overflowed its stack while drawing its own header.**

## How it was found

Three crash reports off two devices all had an empty `Panic reason` and an empty `Stack memory`, so they named nothing. That is structural, not missing data: `HalSystem`'s backtrace capture sits under `#if !__riscv` and the X4 Pro is Xtensa, so this board never produces a backtrace in `crash_report.txt` for any crash.

The **coredump partition** at `0xFF0000` had 30,820 bytes of real ELF core with 13 task states sitting in it the whole time. Decoded against the published `crossplay-v1.12.45-x4pro.elf`:

```
Crashed task: 'ActivityManager'   exccause 0x41 (DebugException)  <- end-of-stack canary
#0  GfxRendererTarget::text(rect, text="STUDY", style)  FreeInkUIGfxRenderer.h:183
#1  freeink::ui::header<24u>                            header.h:158
#3  toybox::headerBand                                  ToyboxScreen.h:332
#4  studyui::chrome(screen, "STUDY")                    StudyScreens.cpp:23
#5  studyui::buildDeck                                  StudyScreens.cpp:149
#6  StudyActivity::render                               StudyActivity.cpp:1592
```

An overflow **by arithmetic rather than by inference**: the task's stack segment runs `0x3fcc1070..0x3fcc3150` and the stack pointer at the fault is `0x3fcc1130`, so 8224 bytes were in use against the 8192 the task was given. `esp_coredump`'s own `6432/1756 used/free` line in the same report is a high-water heuristic and disagrees; the segment arithmetic is the one to trust.

`chrome() -> headerBand() -> header() -> text()` is **also xkcd's path**, which is why xkcd died before its first repaint with no user input at all. Nothing about decks or packs is involved: one report had no deck, one had 5001 cards, one had no pack, and all three end in the same function.

## The two changes

**1. `ActivityManager.cpp` takes `CROSSPOINT_RENDER_TASK_STACK` again**, with an `#ifndef ... 8192` default so upstream's behaviour is untouched.

This is a **regression of 5daf51e7**, which fixed exactly this in August after v1.0.0 "crashed on the first device that ever ran it". It made the size an overridable default and set 16384 in the fork's `platformio.ini`. A later sync took upstream's copy of this upstream-owned file wholesale and dropped the override, leaving the flag set and consumed by nothing.

**2. `stack_budget.py` fails when a budget macro is defined and unused.** This is the change that matters more. The gate resolved the budget by reading `-DCROSSPOINT_RENDER_TASK_STACK` out of `platformio.ini` and never checked that anything consumed it, so for all of v1.12.45 it printed

```
ok ActivityManagerRender  9520 of 16384  headroom 6864
```

on every CI run (`crossplay-ci.yml` runs it on both release envs) while the firmware ran on 8192 and needed 9520. Green, every time, against a stack the task did not have.

## Seen to fail

On the real `.ci` data, both directions:

| state | result |
|---|---|
| with the fix | `ok ActivityManagerRender 9520 of 16384 headroom 6864` / `All 2 tasks fit` |
| `ActivityManager.cpp` stashed back to the shipped state | `!! CROSSPOINT_RENDER_TASK_STACK is set to 16384 in platformio.ini and NOTHING IN src/ USES IT` / `FAIL` |

## Verified on hardware

Dev build flashed to `b8:1f:3f:d4:82:60` over USB, then driven over Wi-Fi. **Study opens on its deck screen** (256 TO GO, Mandarin: Vocabulary, the forecast chart) and **xkcd on its menu** (#3282, 3279 comics, the mosaic). Neither reboots, and the cable log shows no reset for either. Both panicked on this same unit before the flash, and it has now been up continuously through repeated opens of both.

Free heap with the 16384 stack live was 53KB on a **dev** build; release builds carry more, so the verification is the conservative side.

All four shipped envs (`x4pro`, `sticky`, `gh_release_x4pro`, `gh_release_sticky`) inherit the 16384, checked by walking the `extends` chain.

## Not in this change

- #404 xkcd spends ~2000 bytes of render stack copying a theme whose only override is now the default value. Removing it would cut the deepest path substantially; a stack fix should be one thing.
- #406 the X4 Pro reports **no PSRAM** (`ESP.getPsramSize()` is 0, ~270KB internal heap), against a fork-wide assumption of 8MB. Measured while verifying this; not a blocker, but the reasoning in comments should not lean on PSRAM.
- #405 an AddressSanitizer simulator env was built for this and hangs at startup; reverted rather than shipped.

Docs: none affected. `docs/activity-manager.md` describes the task and states no stack size.
