### PR TITLE
perf(render): stop copying ThemeTokens onto the render task's stack

### DIFF
--- a/host-tests/chromeguard/run.sh
+++ b/host-tests/chromeguard/run.sh
@@ -183,7 +183,7 @@ with tempfile.TemporaryDirectory() as fx:
         'void doors(Screen& s) {\n'
         '  const fui::Rect band = toybox::headerBandRect(s);\n'
         '  s.frame().hit(fui::makeRect(0, 0, w, toybox::kHeaderHeight), Action, 0);\n'
-        '  tokens.headerHeight = xkcdui::kHeaderBand;\n'
+        '  tokens.headerHeight = solitaireui::kHeaderBand;\n'
         '}\n')
     # And the exempt directory really is exempt.
     ui = os.path.join(fx, 'apps_local', 'ui')

--- a/host-tests/fittedtitle/test_fittedtitle.cpp
+++ b/host-tests/fittedtitle/test_fittedtitle.cpp
@@ -572,9 +572,9 @@ void xkcdReaderBar() {
     // an 800px landscape context -- the obvious guess -- makes the bar 320px
     // wider than it is and hides all but eight of the titles it cuts.
     toybox::Frame frame(paint.target, panel(), fui::InputSnapshot{}, paint.interactions);
-    fui::ThemeTokens tokens = toybox::themeTokens();
-    tokens.headerHeight = xkcdui::kHeaderBand;
-    toybox::Screen screen(frame, tokens);
+    // The shared palette, which is what XkcdActivity::render takes: its old
+    // headerHeight override was assigning the default over itself.
+    toybox::Screen screen(frame);
     xkcdui::ReaderModel model;
     model.num = static_cast<uint32_t>(i + 1);
     model.title = fitted::kXkcdTitles[i];

--- a/src/apps_local/solitaire/SolitaireActivity.cpp
+++ b/src/apps_local/solitaire/SolitaireActivity.cpp
@@ -285,8 +285,16 @@ void SolitaireActivity::render(RenderLock&&) {
   // too tight -- the title's cap-centring is sized for the band, and at 48 the
   // bowl of the S and the leg of the R were sliced off by the bar's own bottom
   // edge. 56 is the smallest that clears the descender box.
-  fui::ThemeTokens tokens = toybox::themeTokens();
-  tokens.headerHeight = solitaireui::kHeaderBand;
+  // Built once, not per frame. Screen refers to this rather than copying it, so
+  // it only has to outlive the screen -- and a function-local static outlives
+  // everything, which a named local did at the cost of 2712 bytes of ThemeTokens
+  // on the render task's stack every repaint. That task overflowed on this very
+  // path in v1.12.45 (card #398).
+  static const fui::ThemeTokens tokens = [] {
+    fui::ThemeTokens t = toybox::themeTokens();
+    t.headerHeight = solitaireui::kHeaderBand;
+    return t;
+  }();
   toybox::Screen screen(frame, tokens);
 
   if (view == View::Board) {

--- a/src/apps_local/ui/ToyboxScreen.h
+++ b/src/apps_local/ui/ToyboxScreen.h
@@ -125,9 +125,10 @@ class Screen : public freeink::ui::Screen<kMaxInteractions> {
   explicit Screen(freeink::ui::Frame<kMaxInteractions>& frame)
       : freeink::ui::Screen<kMaxInteractions>(frame, themeTokens()) {}
 
-  // A palette of the caller's own, for the two screens that raise the header
-  // band. `theme` is referred to, not copied, so it has to outlive the screen: a
-  // named local in the same render() does, which is every real use.
+  // A palette of the caller's own, for the one screen that raises the header
+  // band. `theme` is referred to, not copied, so it has to outlive the screen.
+  // Solitaire hands over a function-local static: a named local in the same
+  // render() would also do, but it costs 2712 bytes of stack per repaint.
   Screen(freeink::ui::Frame<kMaxInteractions>& frame, const freeink::ui::ThemeTokens& theme)
       : freeink::ui::Screen<kMaxInteractions>(frame, theme) {}
 

--- a/src/apps_local/xkcd/XkcdActivity.cpp
+++ b/src/apps_local/xkcd/XkcdActivity.cpp
@@ -1313,11 +1313,11 @@ void XkcdActivity::render(RenderLock&&) {
   interactionsReady_ = false;
   toybox::Frame frame(target, target.deviceContext(), noInput, interactions_);
 
-  // A slimmer header than the portrait screens use: in landscape the usual 76
-  // would cost a sixth of the height a comic needs.
-  fui::ThemeTokens tokens = toybox::themeTokens();
-  tokens.headerHeight = xkcdui::kHeaderBand;  // the fork's standard band; see XkcdScreens.h
-  toybox::Screen screen(frame, tokens);
+  // The shared palette, and no copy of it. This screen used to take the
+  // two-argument Screen so it could set headerHeight -- from when xkcd wanted a
+  // slimmer band in landscape. The band became absolute in af1a0fa7 and the
+  // override has been assigning 76 over 76 ever since.
+  toybox::Screen screen(frame);
 
   switch (view_) {
     case View::Menu: {

--- a/src/apps_local/xkcd/XkcdScreens.cpp
+++ b/src/apps_local/xkcd/XkcdScreens.cpp
@@ -27,9 +27,9 @@ constexpr int16_t kOkWidth = 56;
 // shelf the reader just came from -- which, until card 358, they did not.
 //
 // Two faults, both closed here. The row is measured from the whole chrome (band
-// + gap + rule), which is what toybox::kBodyTop derives from chromeBelow();
-// kHeaderBand is the BAND's height, which is what the theme token wants and not
-// what a body top wants. And every site below used to add safe.y to it as well,
+// + gap + rule), which is what toybox::kBodyTop derives from chromeBelow(),
+// and NOT the band's height on its own, which is a different number and the
+// one this used to use. And every site below used to add safe.y to it as well,
 // which put the whole app ten pixels under the rest of the fork: the chrome is
 // pinned at panel row 0 by absoluteChrome, so it already covers the rows the
 // glass hides. toybox::kBodyTop carries the argument in full.

--- a/src/apps_local/xkcd/XkcdScreens.h
+++ b/src/apps_local/xkcd/XkcdScreens.h
@@ -81,11 +81,6 @@ struct MenuModel {
 
 void buildMenu(toybox::Screen& screen, const MenuModel& model);
 
-// The header band. Named here rather than assumed twice: the builder draws the
-// rule under it and the Activity overrides the theme with it, and when those
-// two disagreed the rule floated twenty pixels below the band.
-inline constexpr int16_t kHeaderBand = toybox::kHeaderHeight;
-
 // The band the mosaic is drawn into, shared with the Activity the way
 // Connections shares its grid band. See docs/design-language.md on ornament:
 // it has to be made of the app's own material and carry the app's own data.


### PR DESCRIPTION
Follow-up to #398, which fixed the render task's stack overflow by restoring the 16384 override. The deepest path was 9520 bytes, and two of those frames were a 2712-byte `ThemeTokens` copy that did not need to be on a stack at all.

**xkcd's copy was doing nothing.** It set `headerHeight` to `xkcdui::kHeaderBand`, which is `= toybox::kHeaderHeight` — 76 assigned over 76. The comment above it still described a slimmer landscape band, which stopped being true when the band became absolute in af1a0fa7. Gone; the screen takes the shared palette.

**Solitaire's copy is real** (`kHeaderBand` is 56 against the default 76). It keeps the two-argument `Screen` and hands it a function-local static instead of a named local — `Screen` refers to the tokens rather than copying them and only needs storage that outlives the screen, which a static does.

## Measured, three runs of `scripts_local/stack-budget.sh` on x4pro

| | ceiling | deepest path |
|---|---|---|
| before | 9520 of 16384 | `XkcdActivity::render` (2000) |
| xkcd's copy gone | 9152 | `SolitaireActivity::render` |
| Solitaire's static too | **8800** | `StudyActivity::render` |

**The first step is the interesting one.** Removing a measured 2000-byte frame moved the ceiling **368 bytes**, because xkcd was only the tallest of two. A worst-case total is a MAX, not a sum: deleting the largest item moves it to the second-largest, and the gap between them is the whole saving. Card #411.

## What this does not do

8800 is still above upstream's 8192, so the fork **still depends** on the `CROSSPOINT_RENDER_TASK_STACK` override, and the guard added in #160 that stops a sync deleting it again is still load-bearing. Headroom goes 6864 to 7584.

## Rendering

Unchanged by construction — xkcd was assigning the default over itself, and Solitaire's static holds the same 56. Verified anyway: the xkcd menu renders identically in the simulator, header band included.

Deleting the constant caught a reference my first grep missed (I searched `src/apps_local/xkcd/` rather than the tree): `host-tests/fittedtitle` built the Screen the same way and stopped compiling. It follows the Activity now, and passes under g++-16 as well as clang. `chromeguard`'s synthetic fixture named the symbol too — fixture text, so it compiled, but it now names `solitaireui`, the one app that still overrides the band.

`CHECKSH-VERDICT: green`
