### PR TITLE
study: fix quoted image filenames with spaces in make_images.py

### DIFF
--- a/tools_local/study/make_images.py
+++ b/tools_local/study/make_images.py
@@ -42,7 +42,18 @@ MAX_W, MAX_H = 448, 620
 # Anki's editor writes src="..." but a hand-written template or an imported
 # deck may write src='...' or src=... unquoted, and each of those was a note
 # whose picture was simply not found.
-IMG_RE = re.compile(r"""<img[^>]+src=["']?([^"'>\s]+)""", re.IGNORECASE)
+#
+# Three separate alternatives, not one shared character class, because a
+# quoted value and an unquoted one disagree about what a space MEANS. Anki's
+# own media filenames routinely contain one -- the stroke-order diagrams in a
+# kana deck are literally "a h.png", "a k.png" -- and a space is content
+# inside quotes but a terminator outside them. One class that excluded
+# whitespace to handle the unquoted case correctly truncated every quoted
+# filename at its first space instead: `src="a h.png"` matched `a`, not
+# `a h.png`, and every stroke-order image on the card silently became "no
+# picture on this note" rather than a picture the card checker or this script
+# could see and report.
+IMG_RE = re.compile(r"""<img[^>]+src=(?:"([^"]*)"|'([^']*)'|([^\s"'>]+))""", re.IGNORECASE)
 
 
 def first_image(parts):
@@ -60,7 +71,7 @@ def first_image(parts):
     for raw in parts:
         match = IMG_RE.search(raw or "")
         if match:
-            return match.group(1)
+            return match.group(1) or match.group(2) or match.group(3)
     return None
 
 

--- a/tools_local/study/test_convert_text.py
+++ b/tools_local/study/test_convert_text.py
@@ -279,5 +279,16 @@ check(make_images.first_image(['<img src="one.png"> <img src="two.png">']) == "o
 check(make_images.first_image(["no image here", ""]) is None, "a note with no picture has none")
 check(make_images.first_image([]) is None, "and neither does a note with no fields")
 
+# A filename containing a space -- Anki's own media names routinely have one,
+# e.g. a kana deck's stroke-order diagrams are literally "a h.png". A single
+# character class that excluded whitespace to handle the UNQUOTED case
+# correctly truncated every QUOTED filename at its first space instead: real
+# regression, found live on a real deck, where every stroke-order image
+# silently became "no picture on this note".
+check(make_images.first_image(['<img src="a h.png" />']) == "a h.png",
+      "a quoted filename containing a space is not truncated at the space")
+check(make_images.first_image(["<img src='y z.jpg'>"]) == "y z.jpg",
+      "neither is a single-quoted one")
+
 print(f"{'PASS' if failures == 0 else 'FAIL'} {checks} checks, {failures} failed")
 sys.exit(1 if failures else 0)


### PR DESCRIPTION
## Summary
- `make_images.py`'s `IMG_RE` truncated quoted `src` attributes at the first space, so filenames like Anki's own `"a h.png"` (the kana decks' stroke-order diagrams) matched only `"a"` and were reported as "referenced but unreadable" -- the image was silently dropped from the card.
- Fixes with a three-way regex alternation: quoted-double, quoted-single, and unquoted each get their own capture group, since a space is content inside quotes and a terminator outside them.

## How this was found
Redeploying decks for a real X4 Pro device after rebuilding from the latest `xteink`, both kana decks came back with `images.dat` missing entirely -- 0/198 images packed, all reported unreadable. Root cause traced to this regex.

## Test plan
- [x] Added two regression tests to `test_convert_text.py` covering both quote styles with a space in the filename
- [x] `python3 tools_local/study/test_convert_text.py` -- 91 checks, all passing
- [x] `./host-tests/study/run.sh` -- all 6 suites green (106+28+37+74+33+20 checks)
- [x] Regenerated `images.dat` for both real kana decks on device -- 102/102 and 96/96 images packed, 0 unreadable, byte-identical in size to the originals
