### PR TITLE
site: the report form's email, and the fields a reporter gave that nothing showed

### DIFF
--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -614,6 +614,55 @@ THEIRS=$(board new "Study: pairing says the bridge is invitation-only" --from st
 board show "$MINE" | grep -q "reported by mario" && ok "--reporter mario is recorded" || bad "--reporter mario was not stored"
 board show "$THEIRS" | grep -q "reported by user" && ok "--reporter user is recorded" || bad "--reporter user was not stored"
 
+# The address the report form has always asked for. api/report.js validated it,
+# stored it as reporter_email and used it to tell Mario's own reports from a
+# stranger's from the first day the field existed -- and `board show` printed
+# every other thing about the card and not that, so #426 (someone offering to
+# send us games) and #389 (owed a pairing code) read as unreachable strangers
+# while their addresses sat in the column. There is no CLI flag to set one: the
+# public form is the only writer, so the card is seeded the way the form's
+# function writes it.
+WROTE=$(board new "Instapaper: no code came back from the sync server" --from instapaper --kind bug --reporter user | sed 's/^#\([0-9]*\).*/\1/')
+python3 - "$ROOT/.board/cards/$WROTE.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+c = json.load(open(p))
+c["reporter_email"] = "ojuergens@gmx.de"
+json.dump(c, open(p, "w"), indent=2)
+PY
+board show "$WROTE" | grep -q "ojuergens@gmx.de" \
+  && ok "board show prints the address a reporter left" \
+  || bad "board show hides reporter_email, so nobody can answer the person: $(board show "$WROTE" | sed -n 2p)"
+board show "$WROTE" | grep -q "reported by user <ojuergens@gmx.de>" \
+  && ok "and puts it beside who reported it" \
+  || bad "the address is not on the reporter line: $(board show "$WROTE" | sed -n 2p)"
+# A card nobody left an address on must not grow an empty pair of brackets.
+board show "$THEIRS" | grep -q "reported by user  created" \
+  && ok "a card with no address says only who reported it" \
+  || bad "a card without an address gained an empty address: $(board show "$THEIRS" | sed -n 2p)"
+
+# The address was not the only thing collected and never shown. A report brings
+# the board it was made on, the version the person looked up in Settings >
+# About, and sometimes a photo of the broken screen; `board show` printed none
+# of them, so the one field that named the device did so only as prose inside a
+# history line. Same rule as the address: shown when there, absent when not.
+SENT=$(board new "Trivia: the answer row draws through the header" --from trivia --kind bug --reporter user | sed 's/^#\([0-9]*\).*/\1/')
+python3 - "$ROOT/.board/cards/$SENT.json" <<'PY'
+import json, sys
+p = sys.argv[1]
+c = json.load(open(p))
+c.update(device="sticky", version="1.12.11", photo_path="photos/%s.jpg" % c["id"])
+json.dump(c, open(p, "w"), indent=2)
+PY
+board show "$SENT" >"$WORK/sent.out" 2>&1
+grep -q "device sticky" "$WORK/sent.out" && ok "board show names the board the report came from" || bad "the device is invisible: $(cat "$WORK/sent.out")"
+grep -q "version 1.12.11" "$WORK/sent.out" && ok "and the version the reporter looked up" || bad "the version a reporter went and found is invisible: $(cat "$WORK/sent.out")"
+grep -q "photo photos/$SENT.jpg" "$WORK/sent.out" && ok "and says a photo came with it" || bad "an attached photo is invisible, so nobody knows to look: $(cat "$WORK/sent.out")"
+# A card carrying none of them gains no empty line for them.
+board show "$THEIRS" | grep -qE "^  (device|version|photo|issue) " \
+  && bad "a card with no device, version or photo grew a line for them anyway: $(board show "$THEIRS")" \
+  || ok "a card carrying none of them shows no line for them"
+
 # The question he actually asked, as one command.
 board list --from-mario >"$WORK/mine.out" 2>&1
 grep -q "#$MINE " "$WORK/mine.out" && ok "--from-mario lists his card" || bad "--from-mario missed his card: $(cat "$WORK/mine.out")"

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -272,6 +272,43 @@ api_devices="$(grep -oE 'DEVICES = \[[^]]*\]' "$ROOT/site/api/report.js" | grep 
 printf '%s' "$api_devices" | grep -qw unknown && bad "api/report.js accepts 'unknown' as a device again; a report names a board or is refused" || ok
 grep -qE 'type="radio" name="device"' "$REPORTJS" && bad "device is a radio again; it is two checkboxes, both allowed" || ok
 
+# -- the email field, and the one rule spelled in both files --------------------
+#
+# The address is how a stranger gets answered: #426 offered to send us games and
+# #389 was owed a pairing code, and both left one. Three things have to hold or
+# it stops being an address people give.
+#
+# It stays optional. The function refuses a report naming no device and files
+# one carrying no email, so a `required` here would turn a thirty-second bug
+# report into a decision about handing over an address.
+grep -qE 'id="report-email"[^>]*\brequired\b' "$REPORTJS" && bad "the email field is required; it is optional and the function stores null for an empty one" || ok
+grep -qE '<label[^>]*for="report-email"[^>]*>[^<]*<small>\(optional\)</small>' "$REPORTJS" && ok || bad "the email label no longer says (optional), so nothing on screen says it can be skipped"
+# And it says what the address is FOR. This form has no privacy statement of any
+# kind, so the hint under the field is the only place the scope is ever stated;
+# "only if you want a reply" says why you might give it and never what happens
+# to it. The hint must name THIS report, not replies in general.
+email_hint="$(sed -n '/for="report-email"/,/<\/div>/p' "$REPORTJS" | grep -oE '<p class="report-hint">[^<]*</p>' | head -1)"
+printf '%s' "$email_hint" | grep -qi 'this report' && ok || bad "the email hint does not say the address is only used to reply about THIS report: $email_hint"
+# What counts as an address is decided in two files that never see each other.
+# They disagreeing is not cosmetic: the page would post an address the function
+# then answers 400 to, which files NOTHING -- the report is refused whole over a
+# typo in an optional field. Read out of both rather than written here, so
+# changing one alone goes red.
+form_email_re="$(grep -oE '^  var EMAIL = /.*/;' "$REPORTJS" | sed -E 's/^  var EMAIL = //; s/;$//')"
+api_email_re="$(grep -oE '^const EMAIL = /.*/;' "$ROOT/site/api/report.js" | sed -E 's/^const EMAIL = //; s/;$//')"
+[ -n "$form_email_re" ] && ok || bad "report.js has no EMAIL expression, so a bad address is only caught by a 400 that files nothing"
+[ "$form_email_re" = "$api_email_re" ] && ok || bad "report.js tests an address with $form_email_re and api/report.js with $api_email_re"
+form_email_max="$(grep -oE '^  var MAX_EMAIL = [0-9]+;' "$REPORTJS" | grep -oE '[0-9]+')"
+api_email_max="$(grep -oE 'clean\(body\.email, [0-9]+\)' "$ROOT/site/api/report.js" | grep -oE '[0-9]+')"
+[ -n "$form_email_max" ] && [ "$form_email_max" = "$api_email_max" ] && ok || bad "report.js caps an address at [$form_email_max] and api/report.js at [$api_email_max]"
+# The guard has to run BEFORE the post, and has to say the way out. A person
+# whose address our expression rejects must be told they can empty the field,
+# or the optional one becomes the thing that stopped them reporting.
+sed -n '/form.addEventListener("submit"/,/fetch("\/api\/report"/p' "$REPORTJS" | grep -q 'EMAIL.test' \
+  && ok || bad "report.js posts before it checks the address, so a typo costs a round trip and files nothing"
+sed -n '/form.addEventListener("submit"/,/fetch("\/api\/report"/p' "$REPORTJS" | grep -qi 'clear it' \
+  && ok || bad "the bad-address message never says the field can be cleared, leaving no way past it"
+
 # -- the study installer's ids, spelled in two files that never see each other -
 #
 # Same failure as install.js above, on the page that was actually caught by it:

--- a/site/assets/report.js
+++ b/site/assets/report.js
@@ -22,6 +22,13 @@
 (function () {
   "use strict";
 
+  // Kept in step with api/report.js by hand, the way the version placeholder
+  // is not: a second spelling of one rule is the usual way two answers to the
+  // same question appear, and here disagreeing would mean the page sending an
+  // address the function then refuses.
+  var MAX_EMAIL = 200;
+  var EMAIL = /^[^\s@]{1,64}@[^\s@]{1,190}$/;
+
   var TEMPLATE = `
 <form class="report-form" id="report-form" novalidate>
   <div class="report-row report-choices">
@@ -56,7 +63,7 @@
     <div class="report-field">
       <label class="report-label" for="report-email">Your email <small>(optional)</small></label>
       <input type="email" id="report-email" name="email" autocomplete="email" placeholder="you@example.com">
-      <p class="report-hint">Only if you want a reply.</p>
+      <p class="report-hint">Only to reply about this report. Nothing else.</p>
     </div>
   </div>
 
@@ -235,6 +242,21 @@
         form.querySelector('input[name="device"]').focus();
         return;
       }
+      // Caught here rather than by the function, because the function's only
+      // way to say no is a 400 that files nothing: the text survives in the
+      // box, but the refusal lands in the status line at the foot of a long
+      // form, nowhere near the field it is about, and somebody who came to
+      // report a bug leaves having filed none. Same cap and same expression as
+      // api/report.js so the two cannot disagree about what an address is.
+      var addr = email.value.trim().slice(0, MAX_EMAIL);
+      if (addr && !EMAIL.test(addr)) {
+        say(
+          "That email does not look right. Fix it, or clear it to send without one.",
+          true,
+        );
+        email.focus();
+        return;
+      }
       send.disabled = true;
       say("Sending...");
       var body = {
@@ -242,7 +264,7 @@
         what: text,
         device: picked.join(","),
         version: version.value.trim(),
-        email: email.value.trim(),
+        email: addr,
         app: app.value,
         website: website.value,
       };

--- a/tools_local/board/board.py
+++ b/tools_local/board/board.py
@@ -1277,15 +1277,42 @@ def fmt_card(c, full=False):
     line = f"#{c['id']:<4} {c['state']:<9} {c['from']:<14} {c['title']}{flag}"
     if not full:
         return line
+    # The address the report form asks for, on the line that already says who
+    # reported it. It was collected and stored from the first day the form had
+    # the field and rendered nowhere, so two people who left one -- including
+    # someone offering to send us games -- read as unreachable strangers.
+    who = c.get("reporter") or UNKNOWN_REPORTER
+    if c.get("reporter_email"):
+        who += f" <{c['reporter_email']}>"
     lines = [
         line,
-        f"  kind {c['kind']}  reported by {c.get('reporter') or UNKNOWN_REPORTER}"
+        f"  kind {c['kind']}  reported by {who}"
         f"  created {c['created']}  updated {c['updated']}",
     ]
     if c.get("tree") or c.get("branch") or c.get("session"):
         lines.append(
             f"  tree {c.get('tree')}  branch {c.get('branch')}  session {c.get('session')}"
         )
+    # Everything else a reporter took the trouble to give us. The email was not
+    # the only field collected and never shown: #389 named its board and looked
+    # 1.12.11 up in Settings > About, #207 attached a photo of the screen, and
+    # `board show` printed none of it -- the device only ever appeared as prose
+    # inside a history line. Each is omitted when absent rather than printed
+    # empty, because a blank is how a missing thing starts reading as a present
+    # one. Values are safe by construction: the function accepts a device only
+    # from a fixed list, a version only as three dotted numbers, and builds
+    # photo_path itself as photos/<id>.<ext>.
+    got = []
+    if c.get("device"):
+        got.append(f"device {c['device']}")
+    if c.get("version"):
+        got.append(f"version {c['version']}")
+    if c.get("photo_path"):
+        got.append(f"photo {c['photo_path']}")
+    if c.get("github_issue"):
+        got.append(f"issue #{c['github_issue']}")
+    if got:
+        lines.append("  " + "  ".join(got))
     d = derived(c)
     if d:
         lines.append("  derived " + json.dumps(d))


### PR DESCRIPTION
Mario: *"add it to the form so we can contact them if we need more info"*.

## The form already asked

Since `20499cb6` (2026-09-03). The premise that it did not came from grepping
`site/report/index.html`, which is a 1,297-byte shell around a form assembled in
`assets/report.js`. `api/report.js` already validated the address, stored it as
`reporter_email`, and used it to tell Mario's own submissions from a stranger's.

**Two of the four site reports carry an address nobody had ever seen:** #389
(`ojuergens@gmx.de`, owed the pairing code he wrote in about) and #426
(`linesegment@gmail.com`, offering to send us Cross Clues and The Gang). He
asked "did they leave contact info?" and no tool could answer.

## The email was not the only field being dropped

This is the wider find. A card carries `device`, `version`, `photo_path` and
`github_issue`, and `fmt_card` printed **none** of them. #389 named its board
and looked 1.12.11 up in Settings > About; the device survived only as prose
inside a history line. #207 has `photos/207.jpg` attached: somebody photographed
a broken screen, the function stored it, and no reader anywhere mentions a photo
exists.

`board show` on the real cards, through this branch:

```
#389  kind bug  reported by user <ojuergens@gmx.de>  created ...
      device sticky  version 1.12.11
#207  kind feature  reported by mario <testv@gmail.com>  created ...
      device x4pro,sticky  version 1.12.9  photo photos/207.jpg
#425  kind feature  reported by user  created ...
      device x4pro,sticky
```

Full, not elided, beside who reported it, and only when present. #425 left no
address and grows no empty brackets.

## On the form

- **The hint said what, not why.** "Only if you want a reply" says why you might
  give an address and never what happens to it. This form has no privacy
  statement of any kind, so that line is the only place the scope is ever
  stated. It now reads **"Only to reply about this report. Nothing else."**
- **A typo cost the whole report.** The function's only way to refuse an address
  is a 400 that files NOTHING, and the refusal landed in the status line at the
  foot of a long form, nowhere near the field. Verified in a browser *before*
  changing anything: the text survived, but somebody who came to report a bug
  could leave having filed none. The page now tests the address before it posts,
  with the same cap and the same expression as the function, focuses the field,
  and says the way out: *"Fix it, or clear it to send without one."* A person
  whose address our expression rejects must not be stuck behind an optional
  field.

Still optional in every path. An empty value posts exactly as before and stores
null; nothing is required, including from the device's own report link.

## Verified in a browser, against the real function

Static server plus the real `api/report.js` with the board stubbed, all three
paths:

| submitted | what happened |
|---|---|
| `ojuergens at gmx.de` | caught before any request; **no POST reached the function**, nothing filed, focus moved to the email field, the report text intact |
| corrected to `ojuergens@gmx.de` | filed, `reporter_email` stored, `reporter=user` |
| left empty | filed, `reporter_email` **null** |

## Tests

Every one seen red with the fix reverted, then green with it.

- **6 in `host-tests/site`** -- the hint names *this report*; the page and the
  function spell one address rule (regex and cap read out of both files, so
  changing one alone goes red); the guard runs before the post; the message
  offers the way out. Plus two regression guards: the field stays optional and
  keeps its `(optional)` label.
- **5 in `host-tests/bugflow`** -- the address prints, beside the reporter, and
  a card without one grows no empty brackets; device, version and photo print,
  and a card with none grows no line for them.

## Coordination and escaping

**The inbox is not touched.** `wt/inboxpeople` (`a0455947`) already surfaces the
address in both `board inbox` and `site/inbox/`, and escapes it correctly
(`esc()` on the text, `encodeURIComponent` in the mailto href). I checked rather
than assumed. **Neither of us renders `photo_path`, so an attached photo is
still invisible in the inbox** -- worth its own card.

`board show` is terminal output with no markup, and `title` and `body` (4,000
characters of arbitrary public input) have always printed raw there, so the
address is not a newly unescaped field. The three new values are safe by
construction anyway: device comes from a fixed list, version is three dotted
numbers, `photo_path` is built server-side as `photos/<id>.<ext>`.

`#207` reads `reported by mario` on a non-owner address; that is deliberate,
set by `20260906000200_reporter_corrections.sql` because it is his own test
submission on a throwaway address. Making the email visible is what surfaced it.

## Not verified

No hardware. The two `board show` outputs above are real cards read through this
branch's `board.py`; everything else the board does is exercised by the file
store in `host-tests/bugflow`.

Card #429. Docs: none affected -- `docs/workflow/what-mario-reported.md` is in
inboxpeople's diff and left to it.
