### PR TITLE
site: stop serving the inbox's dev fixture, and correct the claim that it could not leak

### DIFF
--- a/site/.vercelignore
+++ b/site/.vercelignore
@@ -15,3 +15,10 @@ README.md
 # sim-shot capture recipes: replay scripts for regenerating the screenshots,
 # consumed by scripts_local on a laptop, loaded by no page.
 recipes/
+# The inbox's dev fixture. serve.py and host-tests/site read it on a laptop; the
+# deployed page never does -- production answers /api/inbox from api/inbox.js.
+# It was served at /inbox/fixture.json (200, 22.8KB) carrying real card titles,
+# real bodies and the asks put to Mario, because this file excluded *.py and not
+# the data those scripts read. Excluding the script and shipping its input is
+# the gap: ask what a tool READS, not just what it is.
+inbox/fixture.json

--- a/site/README.md
+++ b/site/README.md
@@ -348,8 +348,12 @@ INBOX_FIXTURE=site/inbox/fixture.json python3 site/serve.py 8099
 
 `site/inbox/fixture.json` holds three open asks, forty cards and every table
 the Numbers section reads; `host-tests/site/run.sh` fails when the page starts
-reading a key the fixture lacks. Dev only: production is `api/inbox.js` and
-never runs `serve.py`, so the fixture cannot leak.
+reading a key the fixture lacks. Dev only: production answers `/api/inbox` from `api/inbox.js` and never runs
+`serve.py`. That is true of the ENDPOINT and was false of the FILE: until
+`.vercelignore` excluded it, `/inbox/fixture.json` was a public static asset
+serving real card titles and real asks. Keep it excluded, and keep its
+contents synthetic -- the repository is public, so the file is readable there
+whatever the deploy does.
 
 Changes must be _looked at_, not reasoned about -- the same rule the device
 apps follow. `pageshot.py` renders full-page and sliced captures at any width


### PR DESCRIPTION
`/inbox/fixture.json` is a **public static asset** on the live site: `curl` returns **200 and 22,806 bytes**, carrying real card titles, real bodies and the asks put to Mario. `site/.vercelignore` excluded `*.py`, `README.md` and `recipes/` -- the *scripts* -- and not the data those scripts read.

Nothing the deployed page loads references it. Production answers `/api/inbox` from `api/inbox.js`; only `serve.py` and `host-tests/site/run.sh` read the file, both on a laptop. So excluding it costs nothing, verified by grepping every HTML file, `site/assets/*.js` and `site/api/*.js`.

**The README is why nobody looked.** It said: *"production is api/inbox.js and never runs serve.py, so the fixture cannot leak."* That is true of the **endpoint** and false of the **file beside it**. It now states which half is which.

**What this does not fix, said plainly:** the repository is public, so the same content is readable to anyone who clones it. Excluding the fixture stops it being served at a discoverable URL; it does not unpublish it. The durable rule -- its contents must be synthetic -- is now written in the README rather than assumed.

The general shape, recorded in the ignore file itself: **excluding a tool and shipping its input is the gap. Ask what a script READS, not just what it is.**

Found by the cold review of the inbox work (which was about to add three strangers' verbatim reports to this same file). Verified by fetching the live URL before and reading the suite after.

**Verified:** `site` suite ok, `CHECKSH-VERDICT: host-green-device-skipped`.
**Not verified:** whether any other data file under `site/` is served that should not be -- I checked for other fixtures and found none, but did not audit every path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)