### PR TITLE
guard: a tree named inside a quoted string is not a write into that tree

### DIFF
--- a/host-tests/bugflow/run.sh
+++ b/host-tests/bugflow/run.sh
@@ -159,6 +159,13 @@ expect "cd into the tree then a commit is refused (semicolon)"      2 pretool "{
 expect "a relative cd into a neighbour's tree is followed"          2 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd ../free && git commit -am wip\"},\"cwd\":\"$ROOT/wt/x\"}"
 expect "git -C into another actor's tree is a write"               2 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C $ROOT/wt/x rebase origin/xteink\"},\"cwd\":\"$ROOT\"}"
 expect "a commit in another actor's tree is refused"               2 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C $ROOT/wt/x commit -am 'work preserved'\"},\"cwd\":\"$ROOT\"}"
+# A tree NAMED in a message is not a tree written to. The rule's first refusal
+# in the real workspace, minutes after it went live, was a printf whose format
+# string mentioned a tree, redirected into a memory file outside every tree.
+expect "a commit message naming another tree is not a write into it"   0 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m 'fix for wt/x'\"},\"cwd\":\"$ROOT\"}"
+expect "a printf naming a tree, into a file elsewhere, is no write into it" 0 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"printf 'note on wt/x' >> $ROOT/notes.md\"},\"cwd\":\"$ROOT\"}"
+expect "a quoted PATH into the tree is still a write"                   2 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"echo x >> \\\"$ROOT/wt/x/a.txt\\\"\"},\"cwd\":\"$ROOT\"}"
+expect "git -C a quoted tree path is a write, whatever the message says" 2 pretool "{\"session_id\":\"other-session\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C \\\"$ROOT/wt/x\\\" commit -am 'msg about wt/y'\"},\"cwd\":\"$ROOT\"}"
 expect "removing another actor's worktree is refused"              2 pretool "{\"session_id\":\"$ORCH\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git worktree remove --force wt/x\"},\"cwd\":\"$ROOT\"}"
 expect "the holder commits from inside its tree"                    0 pretool "{\"session_id\":\"$WORKER\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -am x\"},\"cwd\":\"$ROOT/wt/x\"}"
 python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d["actor"]=="'"$WORKER"':main" and d["card"]=='"$CID"', d' "$ROOT/.board/trees/x.json" && ok "bind wrote the tree record with the actor" || bad "tree record wrong or missing"

--- a/scripts_local/hooks/guard.py
+++ b/scripts_local/hooks/guard.py
@@ -49,6 +49,22 @@ WRITE_VERB = re.compile(
     r"(?<![\w-])pio\s+run|\bbuild\.py|\bprecompress\.py)"
 )
 QUOTED = re.compile(r"'[^']*'|\"[^\"]*\"")
+TREE_NAME = re.compile(r"(?:^|[\s\"'=(/])wt/([A-Za-z0-9_.-]+)(?=[/\s\"');&|]|$)")
+
+
+def tree_names_in(seg):
+    """The trees one command segment writes into: those named in its unquoted
+    text, and those in quoted strings that are PATHS. A quoted string with
+    whitespace in it is a message or a format (`git commit -m 'fix for wt/x'`,
+    `printf 'note on wt/x\\n' >> notes.md`), and a tree it mentions is not a
+    tree it writes: the rule's first refusal, minutes after it went live, was
+    a printf naming a tree into a memory file. A bash -c payload is searched
+    as segments of its own, so the names inside it are still seen."""
+    names = TREE_NAME.findall(QUOTED.sub(" ", seg))
+    for q in QUOTED.findall(seg):
+        if not re.search(r"\s", q[1:-1]):
+            names += TREE_NAME.findall(q)
+    return names
 # Verbs that destroy or rewrite another actor's work in a tree; refused against
 # a tree the caller does not hold whatever the holder's liveness (a sweep once
 # committed another worker's in-progress diff with a reassuring message).
@@ -639,11 +655,14 @@ def pretool(board, data):
                 cur = board.tree_name_of(str(tpath))
                 cwd_path = tpath
                 continue
-            seg_body = QUOTED.sub(" ", seg)
+            # Quoted strings become a placeholder word, not a gap: with a gap,
+            # `git -C "wt/x" commit` read as `git -C commit` and the -C swallowed
+            # the verb, so a quoted tree path was never a write.
+            seg_body = QUOTED.sub(" q ", seg)
             if not (WRITE_VERB.search(seg_body) or REDIRECT.search(seg_body) or DESTRUCTIVE.search(seg_body)):
                 continue
             names = [cur] if cur else []
-            names += re.findall(r"(?:^|[\s\"'=(/])wt/([A-Za-z0-9_.-]+)(?=[/\s\"');&|]|$)", seg)
+            names += tree_names_in(seg)
             for name in dict.fromkeys(n for n in names if n):
                 verdict = board.tree_verdict(actor, name)
                 if verdict:


### PR DESCRIPTION
Card 437. Follow-up to #157, found on its first minutes live: a printf whose string mentioned a tree, into a file outside every tree, was refused as a write into that tree, and `git commit -m 'fix for wt/x'` from any other tree would be too.

- Tree names come from the unquoted text and from quoted strings that are paths (no whitespace); a quoted string with whitespace is a message.
- Quoted strings are a placeholder word for the verb search, so `git -C "wt/x" commit` is a write again (before this it read as `git -C commit` and was not).
- host-tests/bugflow: four cases, three red on the previous guard; 245 checks green.

Not verified: nothing on hardware (no device code touched).