### PR TITLE
site+docs: make the 404's only link visible, fix the wallpapers menu, index docs/apps

### DIFF
--- a/docs/apps/README.md
+++ b/docs/apps/README.md
@@ -105,5 +105,7 @@ edited.
 Battleship, Connections, Solitaire, Insider, Hacker News, xkcd, Wallpapers and
 Get Books. Some have auxiliary records here (a format, a plan, a flow) and Get
 Books has nothing at all; none has a file saying what the app is. That is a gap
-rather than a decision, and the number is checkable: every name in
-`Shelf.cpp`'s `kGames` and `kApps` should have a row somewhere above.
+rather than a decision. To check the number, read `Shelf.cpp`'s `kGames` and
+`kApps` against the two sections above that say what a thing IS -- "What an app
+is" and "The rules a game implements". A format or a plan is not a doc for the
+app, which is the whole point of the gap.

--- a/docs/apps/README.md
+++ b/docs/apps/README.md
@@ -65,9 +65,10 @@ The on-disk shapes. Read these before changing a writer.
 
 ## Decision records for things that shipped
 
-Written before the code, kept for the reasoning. **All of these landed.** They
-are in the present tense of the day they were drafted, and each says so at the
-top.
+Written before the code, kept for the reasoning. **All of these landed**, and
+all are in the present tense of the day they were drafted, so read "not built
+yet" here as "not built yet then". Only some carry a marker saying so at the
+top; the rest is this row.
 
 | | |
 | --- | --- |
@@ -81,6 +82,12 @@ top.
 | [`wallpapers-shuffle.md`](wallpapers-shuffle.md) | Choosing a set and letting it take turns. |
 | [`xkcd-viewing-plan.md`](xkcd-viewing-plan.md) | Reworking how comics are shown. |
 
+## Generated, not written
+
+[`study-quick-reference.pdf`](study-quick-reference.pdf) is the one file here
+that is not prose: a printable page for the Study app, produced rather than
+edited.
+
 ## Decided, and nobody is on it
 
 | | |
@@ -93,8 +100,10 @@ top.
 | --- | --- |
 | [`guesswho.md`](guesswho.md) | There is no `src/apps_local/guesswho/`. The doc talks the idea down to the reason it does not work: the faces are hashes, and hashes have no askable attributes. |
 
-## Three apps ship with no doc of their own
+## Eight things on the shelf have no doc of their own
 
-Wallpapers, xkcd and Hacker News are on the shelf and have only auxiliary
-records here: a format, a plan, a flow. Nothing says what the app is. That is a
-gap rather than a decision.
+Battleship, Connections, Solitaire, Insider, Hacker News, xkcd, Wallpapers and
+Get Books. Some have auxiliary records here (a format, a plan, a flow) and Get
+Books has nothing at all; none has a file saying what the app is. That is a gap
+rather than a decision, and the number is checkable: every name in
+`Shelf.cpp`'s `kGames` and `kApps` should have a row somewhere above.

--- a/docs/apps/README.md
+++ b/docs/apps/README.md
@@ -1,0 +1,100 @@
+# What is in docs/apps/
+
+One directory, 34 files, and until this index they were a raw file listing. A
+doc lands here when something about an app would otherwise be rediscovered the
+hard way; not every app has one, and some have several.
+
+**Read the status first.** Several of these are plans, and a plan describing
+something that shipped six weeks ago reads like unfinished work if nothing says
+otherwise. Where a file is a record rather than a description, it says so in its
+own first paragraph.
+
+## What an app is, and how to use it
+
+The fork's only user-facing app docs. `USER_GUIDE.md` at the repository root is
+upstream's and covers the reader, not these.
+
+| | |
+| --- | --- |
+| [`study.md`](study.md) | Anki decks on the reader: the deck, the scheduler, and what a review does. |
+| [`instapaper.md`](instapaper.md) | The read-later queue and how it syncs. |
+| [`trivia.md`](trivia.md) | The question app, and where the questions come from. |
+
+## The rules a game implements
+
+What the game is, the decisions the rules forced, and what the screens do about
+them. These are the ones worth a stranger's time.
+
+| | |
+| --- | --- |
+| [`chess.md`](chess.md) | The screen graph rather than the rules of chess. |
+| [`checkers.md`](checkers.md) | English draughts, and the compulsory capture the board has to say out loud. |
+| [`connectfour.md`](connectfour.md) | Seven columns, one tap each. |
+| [`yahtzee.md`](yahtzee.md) | The Joker rules are three rules, and conflating them is the bug. |
+| [`knucklebones.md`](knucklebones.md) | The dice duel, and what the critic agents found after "finished". |
+| [`minesweeper.md`](minesweeper.md) | Flagging without a right button. |
+| [`sudoku.md`](sudoku.md) | Difficulty proved by a grader rather than estimated. |
+| [`jaipur.md`](jaipur.md) | The two-player trading game, solo or nearby. |
+| [`seasalt.md`](seasalt.md) | Sea Salt & Paper, and the rulebook contradiction Mario settled. |
+| [`toybattle.md`](toybattle.md) | The fork's first graph board. |
+| [`murdle.md`](murdle.md) | A logic grid built through the solver, so a case is never a guess. |
+| [`wavelength.md`](wavelength.md) | The dial, and why the board is public. |
+| [`forehead.md`](forehead.md) | The first game to make both physical buttons load-bearing. |
+| [`trivia.md`](trivia.md) | Also the app doc, above. |
+
+## Where the content came from
+
+A game whose difficulty is a property of its bank, not its code.
+
+| | |
+| --- | --- |
+| [`dungeon.md`](dungeon.md) | The 64 D&Diagrams puzzles and how they were transcribed. |
+| [`picross.md`](picross.md) | Why no open nonogram corpus exists, and what was generated instead. |
+| [`../trivia-curation.md`](../trivia-curation.md) | Outside this directory: how the Jeopardy pack is cut and ranked. |
+
+## Formats on the card
+
+The on-disk shapes. Read these before changing a writer.
+
+| | |
+| --- | --- |
+| [`study-deck-format.md`](study-deck-format.md) | |
+| [`study-anki-compatibility.md`](study-anki-compatibility.md) | What converts, what is reduced, what stays behind. |
+| [`trivia-pack-format.md`](trivia-pack-format.md) | |
+| [`xkcd-pack-format.md`](xkcd-pack-format.md) | |
+
+## Decision records for things that shipped
+
+Written before the code, kept for the reasoning. **All of these landed.** They
+are in the present tense of the day they were drafted, and each says so at the
+top.
+
+| | |
+| --- | --- |
+| [`hackernews-saved-port.md`](hackernews-saved-port.md) | The saved-articles shelf. |
+| [`instapaper-plan.md`](instapaper-plan.md) | The queue, the sync, and what it costs. |
+| [`study-installer-plan.md`](study-installer-plan.md) | The browser page that converts a deck. |
+| [`study-sync-bridge-plan.md`](study-sync-bridge-plan.md) | Every device syncs, nobody runs a server. |
+| [`study-syncflow-ui.md`](study-syncflow-ui.md) | The sync flow rework. |
+| [`trivia-sync-design.md`](trivia-sync-design.md) | Report a question, filter what you get, sync the pack. |
+| [`wallpapers-phone-flow.md`](wallpapers-phone-flow.md) | From a picture on a phone to the sleep screen. |
+| [`wallpapers-shuffle.md`](wallpapers-shuffle.md) | Choosing a set and letting it take turns. |
+| [`xkcd-viewing-plan.md`](xkcd-viewing-plan.md) | Reworking how comics are shown. |
+
+## Decided, and nobody is on it
+
+| | |
+| --- | --- |
+| [`wavelength-teams.md`](wavelength-teams.md) | Teams mode. `Mode::Teams` exists and is tested, but `WavelengthActivity::kMode` is pinned to `CoOp`, so no player can select it. |
+
+## Argued, and deliberately not built
+
+| | |
+| --- | --- |
+| [`guesswho.md`](guesswho.md) | There is no `src/apps_local/guesswho/`. The doc talks the idea down to the reason it does not work: the faces are hashes, and hashes have no askable attributes. |
+
+## Three apps ship with no doc of their own
+
+Wallpapers, xkcd and Hacker News are on the shelf and have only auxiliary
+records here: a format, a plan, a flow. Nothing says what the app is. That is a
+gap rather than a decision.

--- a/docs/apps/hackernews-saved-port.md
+++ b/docs/apps/hackernews-saved-port.md
@@ -1,5 +1,11 @@
 # Finishing the Hacker News saved-articles feature
 
+**LANDED. This is the plan as it was written, kept for the reasoning.** The
+screens and the Activity it describes as uncommitted are committed:
+`HackerNewsActivity.h` carries `openSavedArticle()` and `hn::Library library_`,
+and the shipped shelf has since had bugs of its own fixed in the release notes.
+Read the present tense below as the state on the day it was drafted.
+
 The storage half is committed and tested. The screens and the Activity are not,
 and this is what the next attempt needs to know before it starts. It replaces an
 earlier `PORT-NOTES.md` on branch `app/hn-saved`, which was right about the

--- a/docs/apps/trivia-sync-design.md
+++ b/docs/apps/trivia-sync-design.md
@@ -97,8 +97,10 @@ copy. **A trivia sync is a new `Endpoint` and two calls, not a new stack.**
 
 **A public unauthenticated report endpoint, already shipped.**
 `site/api/report.js` takes a stranger's bug report with no account, caps every
-size, runs a honeypot, rate-limits on a salted hash of the address so the
-address is never stored, and writes to the board with the service key. It is
+size, runs a honeypot, rate-limits on a salted hash of the client IP, and
+writes to the board with the service key. (An earlier draft said the hash was
+of the address and that the address is never stored. Both were wrong; see the
+header of `site/api/report.js`.) It is
 the precedent for the trivia endpoint and most of it is copyable.
 
 Checked live rather than read: an empty `POST` to
@@ -294,7 +296,8 @@ property wanted and loses exactly the one not wanted:
   guesses a device id, which, since the id is `sha256(MAC + a device secret)`,
   is already infeasible, but the salt means it does not have to be relied on.
 - `site/api/report.js` already does this shape with `reporterHash`, a salted
-  hash of the address kept "so the address itself is never stored". Same trick,
+  hash of the CLIENT IP. Do not copy its `clientIp()`: it reads the first
+  x-forwarded-for hop, which the caller controls (card #444). Same trick,
   same reason.
 
 The alternative (**suppress the header on this path**) stays available and

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -477,12 +477,6 @@ fi
 # on the width where the button is the only navigation there is.
 TOPNAV="$ROOT/site/assets/topnav.js"
 SP_HTML="$ROOT/site/study/index.html"
-# Every page that draws a .topbar, not just the two that had one when this
-# was written. /wallpapers/ carried a stripped local copy of the menu that
-# toggled .is-open and never added .has-menu, so its button was display:none
-# at every width and the bar overflowed again -- invisible to a loop that
-# did not include the page.
-WP_HTML="$ROOT/site/wallpapers/index.html"
 [ -f "$TOPNAV" ] || { echo "FAIL site  missing $TOPNAV"; exit 1; }
 
 # Selectors only, comments and :not() contents stripped -- see css_selectors.py.
@@ -516,7 +510,14 @@ for sel in topnav-toggle topnav; do
   printf '%s\n' "$css_sels" | grep -qE "\.$sel([^A-Za-z0-9_-]|\$)" \
     && ok || bad "styles.css has no .$sel selector"
 done
-for p in "$HTML" "$SP_HTML" "$WP_HTML"; do
+# FOUND, not listed. /wallpapers/ shipped with a stripped local copy of the menu
+# that toggled .is-open and never added .has-menu, so its button was
+# display:none at every width and the bar overflowed -- and it was invisible
+# here because this loop named two files by hand. A page that draws a .topbar
+# and is not in this list is the bug, so the list is the grep.
+topbar_pages="$(grep -rl 'class="topbar"' "$ROOT/site" --include='*.html' | sort)"
+[ -n "$topbar_pages" ] && ok || bad "no page in site/ draws a .topbar, which cannot be right"
+for p in $topbar_pages; do
   rel="${p#"$ROOT"/}"
   grep -q 'class="topnav-toggle"' "$p" && ok || bad "$rel has no .topnav-toggle button, so its narrow bar has no navigation"
   grep -qE 'src="/?assets/topnav\.js"' "$p" && ok || bad "$rel does not load assets/topnav.js, so its menu button opens nothing"

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -253,8 +253,12 @@ grep -q '<dialog[^>]*id="report-dialog"' "$HTML" && ok || bad "#report-dialog in
 grep -q 'id="report-open"' "$HTML" && ok || bad "index.html has no #report-open button"
 grep -q 'id="report-open"[^>]*data-report-open' "$HTML" && ok || bad "#report-open does not carry data-report-open, so report.js will not wire it"
 grep -q '\[data-report-open\]' "$REPORTJS" && ok || bad "report.js never looks for [data-report-open], so nothing opens the dialog"
-# Both pages mount the form and load the script and its stylesheet.
-for p in "$HTML" "$REPORTPAGE"; do
+# Found, not listed, for the same reason the .topbar loop is: a third page that
+# mounts the form must load the script and the stylesheet too, and nobody will
+# remember to add it here.
+form_pages="$(grep -rl 'data-report-mount' "$ROOT/site" --include='*.html' | sort)"
+[ -n "$form_pages" ] && ok || bad "no page in site/ mounts the report form"
+for p in $form_pages; do
   rel="${p#"$ROOT"/}"
   grep -q 'data-report-mount' "$p" && ok || bad "$rel has nowhere to mount the report form"
   grep -qE 'src="/?assets/report\.js"' "$p" && ok || bad "$rel does not load assets/report.js"
@@ -515,7 +519,7 @@ done
 # display:none at every width and the bar overflowed -- and it was invisible
 # here because this loop named two files by hand. A page that draws a .topbar
 # and is not in this list is the bug, so the list is the grep.
-topbar_pages="$(grep -rl 'class="topbar"' "$ROOT/site" --include='*.html' | sort)"
+topbar_pages="$(grep -rlE 'class="[^"]*\btopbar\b' "$ROOT/site" --include='*.html' | sort)"
 [ -n "$topbar_pages" ] && ok || bad "no page in site/ draws a .topbar, which cannot be right"
 for p in $topbar_pages; do
   rel="${p#"$ROOT"/}"

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -477,6 +477,12 @@ fi
 # on the width where the button is the only navigation there is.
 TOPNAV="$ROOT/site/assets/topnav.js"
 SP_HTML="$ROOT/site/study/index.html"
+# Every page that draws a .topbar, not just the two that had one when this
+# was written. /wallpapers/ carried a stripped local copy of the menu that
+# toggled .is-open and never added .has-menu, so its button was display:none
+# at every width and the bar overflowed again -- invisible to a loop that
+# did not include the page.
+WP_HTML="$ROOT/site/wallpapers/index.html"
 [ -f "$TOPNAV" ] || { echo "FAIL site  missing $TOPNAV"; exit 1; }
 
 # Selectors only, comments and :not() contents stripped -- see css_selectors.py.
@@ -510,7 +516,7 @@ for sel in topnav-toggle topnav; do
   printf '%s\n' "$css_sels" | grep -qE "\.$sel([^A-Za-z0-9_-]|\$)" \
     && ok || bad "styles.css has no .$sel selector"
 done
-for p in "$HTML" "$SP_HTML"; do
+for p in "$HTML" "$SP_HTML" "$WP_HTML"; do
   rel="${p#"$ROOT"/}"
   grep -q 'class="topnav-toggle"' "$p" && ok || bad "$rel has no .topnav-toggle button, so its narrow bar has no navigation"
   grep -qE 'src="/?assets/topnav\.js"' "$p" && ok || bad "$rel does not load assets/topnav.js, so its menu button opens nothing"

--- a/server/board/supabase/migrations/20260903000100_reports.sql
+++ b/server/board/supabase/migrations/20260903000100_reports.sql
@@ -1,6 +1,8 @@
 -- What the public report form adds to a card: where it came from, so the
--- function can refuse a flood from one address without a CAPTCHA. The address
--- is stored hashed; the function never stores or shows the address itself.
+-- function can refuse a flood without a CAPTCHA. The hash is of the CLIENT IP,
+-- not of the address. The address itself is stored, in reporter_email, so a
+-- reply can reach the sender; board.py shows it. This comment used to say the
+-- opposite of both.
 
 alter table cards add column if not exists reporter_hash text;
 create index if not exists cards_reporter_recent on cards (reporter_hash, created_at desc)

--- a/site/404.html
+++ b/site/404.html
@@ -9,11 +9,14 @@
   body { margin: 0; min-height: 100vh; display: grid; place-items: center;
          background: #f5f2ea; color: #111110;
          font-family: Georgia, serif; text-align: center; }
+  a { color: #111110; }
+  /* After the light rule, never before it: at equal specificity the last
+     declaration wins, and with these two the other way round the link came
+     out #111110 on #191916 -- the only way off this page, invisible. */
   @media (prefers-color-scheme: dark) {
     body { background: #191916; color: #f2f1ec; }
     a { color: #f2f1ec; }
   }
-  a { color: #111110; }
   p { font-size: 1.2rem; line-height: 1.6; padding: 0 1rem; }
 </style>
 </head>

--- a/site/README.md
+++ b/site/README.md
@@ -6,9 +6,10 @@ stylesheet, and the assets it names.
 **To serve it locally, `python3 site/serve.py 8099`**, not `python3 -m
 http.server`. **Looking at it** below says why.
 
-One exception, and it is deliberate: `api/firmware.js`, a single Vercel
-function that exists so the Install button can work at all. See **The Install
-button** below before touching it.
+One exception, and it is deliberate: `api/firmware.js`, the Vercel function
+that exists so the Install button can work at all. It is not the only function
+in `site/api/`, but it is the only one the page cannot do without. See **The
+Install button** below before touching it.
 
 ## When it deploys, and when it does not
 
@@ -271,9 +272,10 @@ answer.
 
 **`api/firmware.js` is the one server-side thing the PAGE cannot do without,
 and it is not optional.** (It is not the only function here: `site/api/` also
-holds `report.js`, `inbox.js`, `trivia.js` and `board-config.js`, which serve
-the report form and the board. Those are services the site talks to; this one
-is the Install button working at all.) GitHub serves release assets from
+holds `report.js` and `inbox.js` for the report form and the inbox,
+`board-config.js` for the board, and `trivia.js`, which is called by the
+FIRMWARE rather than by any page. This one is the Install button working at
+all.) GitHub serves release assets from
 `release-assets.githubusercontent.com`, which sends **no**
 `Access-Control-Allow-Origin` header at all -- so a page cannot `fetch()` a
 release asset, on this site or any other. (The site-wide COEP `require-corp`

--- a/site/README.md
+++ b/site/README.md
@@ -8,8 +8,9 @@ http.server`. **Looking at it** below says why.
 
 One exception, and it is deliberate: `api/firmware.js`, the Vercel function
 that exists so the Install button can work at all. It is not the only function
-in `site/api/`, but it is the only one the page cannot do without. See **The
-Install button** below before touching it.
+in `site/api/` -- `/report/` is nothing without `report.js`, and the inbox
+nothing without `inbox.js` -- but it is the one the FRONT page cannot do
+without. See **The Install button** below before touching it.
 
 ## When it deploys, and when it does not
 

--- a/site/README.md
+++ b/site/README.md
@@ -269,8 +269,11 @@ that talks the protocol. Someone said on Reddit that they could not flash the
 device and had been looking for a tutorial, and a longer tutorial was not the
 answer.
 
-**The one server-side thing on this site is `api/firmware.js`, and it is not
-optional.** GitHub serves release assets from
+**`api/firmware.js` is the one server-side thing the PAGE cannot do without,
+and it is not optional.** (It is not the only function here: `site/api/` also
+holds `report.js`, `inbox.js`, `trivia.js` and `board-config.js`, which serve
+the report form and the board. Those are services the site talks to; this one
+is the Install button working at all.) GitHub serves release assets from
 `release-assets.githubusercontent.com`, which sends **no**
 `Access-Control-Allow-Origin` header at all -- so a page cannot `fetch()` a
 release asset, on this site or any other. (The site-wide COEP `require-corp`

--- a/site/api/report.js
+++ b/site/api/report.js
@@ -8,9 +8,12 @@
 // on what a caller may do lives here and nowhere else.
 //
 // No account, no CAPTCHA. A honeypot field catches the dumb bots (they fill
-// every input; a person never sees it), sizes are capped, and one address gets
-// ten reports an hour, counted against a salted hash of the address so the
-// address itself is never stored.
+// every input; a person never sees it), sizes are capped, and ten reports an
+// hour are allowed per SALTED HASH OF THE CLIENT IP -- so the cap is per
+// network, not per address, and someone who gives no address is capped too.
+// An address, when one is given, IS stored: `reporter_email` on the card, so a
+// reply can reach them. This comment used to say the opposite and a page on
+// the site repeated it.
 //
 // `device` names one or both of the two boards the fork runs on, comma-joined
 // ("x4pro", "sticky", "x4pro,sticky"). There is no "not sure": a person

--- a/site/api/report.js
+++ b/site/api/report.js
@@ -9,11 +9,17 @@
 //
 // No account, no CAPTCHA. A honeypot field catches the dumb bots (they fill
 // every input; a person never sees it), sizes are capped, and ten reports an
-// hour are allowed per SALTED HASH OF THE CLIENT IP -- so the cap is per
-// network, not per address, and someone who gives no address is capped too.
-// An address, when one is given, IS stored: `reporter_email` on the card, so a
-// reply can reach them. This comment used to say the opposite and a page on
-// the site repeated it.
+// hour are allowed per salted hash of the client IP -- not per address, so
+// someone who gives no address is capped too.
+//
+// An address, when one is given, IS stored (`reporter_email` on the card, so a
+// reply can reach them) and IS read: reporterFor() compares it to OWNER_EMAIL
+// so Mario's own reports file as `mario` rather than `user`. This comment used
+// to claim the address was never stored, and a page on the site repeated it.
+//
+// The bucket is NOT trustworthy: clientIp() below takes the first
+// x-forwarded-for hop, which the caller sets. api/trivia.js takes the last and
+// says why, with a test. Card #444.
 //
 // `device` names one or both of the two boards the fork runs on, comma-joined
 // ("x4pro", "sticky", "x4pro,sticky"). There is no "not sure": a person

--- a/site/assets/report.css
+++ b/site/assets/report.css
@@ -337,6 +337,15 @@ html.report-open {
   font-size: 1.25rem;
   margin-bottom: 1.75rem;
 }
+/* Small print, under the form rather than above it: what happens to a report
+   is worth saying and is not worth a paragraph before the box it describes. */
+.report-fine {
+  margin-top: 1.75rem;
+  max-width: 46ch;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
 .report-back {
   display: inline-block;
   margin-top: 2rem;

--- a/site/assets/report.js
+++ b/site/assets/report.js
@@ -89,6 +89,12 @@
     <p class="report-status" id="report-status" role="status" aria-live="polite"></p>
     <button type="submit" class="report-btn primary" id="report-send">Send</button>
   </div>
+  <p class="report-fine">It becomes a card on a board one person reads. An
+    address, if you give one, is stored with the card so a reply can reach you,
+    and is checked against the maintainer's own address so that his reports file
+    apart from yours. Submissions are rate limited. For a security problem,
+    <a href="https://github.com/ma-r-s/crossplay/blob/xteink/SECURITY.md">SECURITY.md</a>
+    says where to send it instead.</p>
 </form>
 
 <section class="report-done" id="report-done" hidden>

--- a/site/assets/topnav.js
+++ b/site/assets/topnav.js
@@ -9,7 +9,8 @@
  *
  * The class comes from here rather than living in the markup so that a page
  * whose scripts failed keeps the plain inline bar instead of a button that
- * opens nothing. Both pages that have a .topbar load this file; a page without
+ * opens nothing. Every page that has a .topbar loads this file, and
+ * host-tests/site/run.sh greps for them rather than listing them; a page without
  * one is left alone.
  */
 (function () {

--- a/site/report/index.html
+++ b/site/report/index.html
@@ -10,6 +10,12 @@
 <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
 <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png">
 <meta name="theme-color" content="#111110">
+<meta property="og:title" content="Tell CrossPlay what happened">
+<meta property="og:description" content="Report a bug or send an idea for CrossPlay in under a minute. No account needed.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://crossplay.ma-r-s.com/report/">
+<meta property="og:image" content="https://crossplay.ma-r-s.com/assets/shots/og.png">
+<meta name="twitter:card" content="summary_large_image">
 </head>
 <body>
 <!-- The same form the front page opens in a dialog, as a page of its own for
@@ -21,6 +27,12 @@
   <p class="report-lead">One box. Say it however it comes out. No account, under a minute.</p>
 
   <div data-report-mount></div>
+
+  <p class="report-fine">It becomes a card on a board one person reads. Your
+    address is never stored, only a salted hash of it, which is what caps how
+    many reports one sender can file an hour. For a security problem,
+    <a href="https://github.com/ma-r-s/crossplay/blob/xteink/SECURITY.md">SECURITY.md</a>
+    says where to send it instead.</p>
 
   <a class="report-back" href="/">Back to CrossPlay</a>
 </main>

--- a/site/report/index.html
+++ b/site/report/index.html
@@ -28,9 +28,10 @@
 
   <div data-report-mount></div>
 
-  <p class="report-fine">It becomes a card on a board one person reads. Your
-    address is never stored, only a salted hash of it, which is what caps how
-    many reports one sender can file an hour. For a security problem,
+  <p class="report-fine">It becomes a card on a board one person reads. An
+    address, if you give one, is stored with the card so a reply can reach you,
+    and is used for nothing else. Ten reports an hour are allowed per network.
+    For a security problem,
     <a href="https://github.com/ma-r-s/crossplay/blob/xteink/SECURITY.md">SECURITY.md</a>
     says where to send it instead.</p>
 

--- a/site/report/index.html
+++ b/site/report/index.html
@@ -28,13 +28,6 @@
 
   <div data-report-mount></div>
 
-  <p class="report-fine">It becomes a card on a board one person reads. An
-    address, if you give one, is stored with the card so a reply can reach you,
-    and is used for nothing else. Ten reports an hour are allowed per network.
-    For a security problem,
-    <a href="https://github.com/ma-r-s/crossplay/blob/xteink/SECURITY.md">SECURITY.md</a>
-    says where to send it instead.</p>
-
   <a class="report-back" href="/">Back to CrossPlay</a>
 </main>
 

--- a/site/set-host.py
+++ b/site/set-host.py
@@ -22,6 +22,7 @@ PAGES = {
     ROOT / "index.html": "/",
     ROOT / "study" / "index.html": "/study/",
     ROOT / "wallpapers" / "index.html": "/wallpapers/",
+    ROOT / "report" / "index.html": "/report/",
 }
 
 

--- a/site/set-host.py
+++ b/site/set-host.py
@@ -21,6 +21,7 @@ ROOT = pathlib.Path(__file__).resolve().parent
 PAGES = {
     ROOT / "index.html": "/",
     ROOT / "study" / "index.html": "/study/",
+    ROOT / "wallpapers" / "index.html": "/wallpapers/",
 }
 
 

--- a/site/wallpapers/index.html
+++ b/site/wallpapers/index.html
@@ -111,6 +111,11 @@
 
   <section class="wp-steps">
     <h2>Getting it onto the reader</h2>
+    <p class="wp-note">If the photo is already on your phone, you do not need
+      this page at all: open <strong>Apps &rsaquo; Wallpapers</strong> on the
+      reader, scan the code it shows, and pick the picture. The reader converts
+      it. This page is for making one on a computer, or for getting exactly the
+      crop and dither you want before it goes across.</p>
     <ol class="wp-rail">
       <li><p>Download the wallpaper above. It is a small <code>.bmp</code> sized to the screen.</p></li>
       <li><p>On the reader, open <strong>File Transfer</strong> from the home screen and follow it to the address it shows in your browser. (Or plug the reader in over USB.)</p></li>
@@ -120,6 +125,7 @@
   </section>
 </main>
 
+<script src="/assets/topnav.js"></script>
 <script type="module" src="/wallpapers/wallpapers.js"></script>
 </body>
 </html>

--- a/site/wallpapers/index.html
+++ b/site/wallpapers/index.html
@@ -112,7 +112,7 @@
   <section class="wp-steps">
     <h2>Getting it onto the reader</h2>
     <p class="wp-note">If the photo is already on your phone, you do not need
-      this page: open <strong>Apps &rsaquo; Wallpapers</strong> on the device,
+      this page: open <strong>Apps &rsaquo; Wallpapers</strong> on the reader,
       tap <strong>+ Add a wallpaper</strong>, and scan the code. Your phone
       crops and dithers the picture and sends it over, so both have to be on
       the same Wi-Fi and nothing leaves your network. This page is the same job

--- a/site/wallpapers/index.html
+++ b/site/wallpapers/index.html
@@ -112,10 +112,11 @@
   <section class="wp-steps">
     <h2>Getting it onto the reader</h2>
     <p class="wp-note">If the photo is already on your phone, you do not need
-      this page at all: open <strong>Apps &rsaquo; Wallpapers</strong> on the
-      reader, scan the code it shows, and pick the picture. The reader converts
-      it. This page is for making one on a computer, or for getting exactly the
-      crop and dither you want before it goes across.</p>
+      this page: open <strong>Apps &rsaquo; Wallpapers</strong> on the device,
+      tap <strong>+ Add a wallpaper</strong>, and scan the code. Your phone
+      crops and dithers the picture and sends it over, so both have to be on
+      the same Wi-Fi and nothing leaves your network. This page is the same job
+      from a computer, and it hands you the <code>.bmp</code> to keep.</p>
     <ol class="wp-rail">
       <li><p>Download the wallpaper above. It is a small <code>.bmp</code> sized to the screen.</p></li>
       <li><p>On the reader, open <strong>File Transfer</strong> from the home screen and follow it to the address it shows in your browser. (Or plug the reader in over USB.)</p></li>

--- a/site/wallpapers/wallpapers.css
+++ b/site/wallpapers/wallpapers.css
@@ -220,6 +220,15 @@
   font-size: 1.3rem;
   margin: 0 0 1rem;
 }
+/* The shorter route, said before the numbered one rather than after it: the
+   device converts a phone photo over its own QR, so the steps below are for
+   making a wallpaper on a computer, not the only way in. */
+.wp-note {
+  max-width: 58ch;
+  margin: 0 0 1.5rem;
+  color: var(--muted);
+  line-height: 1.55;
+}
 .wp-rail {
   list-style: none;
   counter-reset: step;

--- a/site/wallpapers/wallpapers.js
+++ b/site/wallpapers/wallpapers.js
@@ -228,5 +228,6 @@ another.addEventListener("click", () => {
 // live here "so the page works on its own"; it toggled .is-open but never
 // added .has-menu, which is the class every mobile rule in styles.css is
 // scoped to. The button was display:none at every width and INSTALL THE
-// FIRMWARE went back to 49px of text in a 50px bar -- the regression the
-// shared menu exists to prevent.
+// FIRMWARE was 49px of text in a 50px bar. Not a regression: this page was
+// created hours after topnav.js and shipped with the stripped copy already in
+// it, so the bar it prevents was never prevented here.

--- a/site/wallpapers/wallpapers.js
+++ b/site/wallpapers/wallpapers.js
@@ -224,14 +224,9 @@ another.addEventListener("click", () => {
   filepick.click();
 });
 
-// The shared topbar's mobile menu toggle, kept local so the page works on its
-// own without depending on a site-wide script existing.
-const navToggle = document.querySelector(".topnav-toggle");
-const nav = $("topnav");
-if (navToggle && nav) {
-  navToggle.addEventListener("click", () => {
-    const open = navToggle.getAttribute("aria-expanded") === "true";
-    navToggle.setAttribute("aria-expanded", String(!open));
-    nav.classList.toggle("is-open", !open);
-  });
-}
+// The menu is assets/topnav.js, loaded before this file. A local copy used to
+// live here "so the page works on its own"; it toggled .is-open but never
+// added .has-menu, which is the class every mobile rule in styles.css is
+// scoped to. The button was display:none at every width and INSTALL THE
+// FIRMWARE went back to 49px of text in a 50px bar -- the regression the
+// shared menu exists to prevent.


### PR DESCRIPTION
Closes card #441. Third cold review, scoped to the site's **sub-pages** and **`docs/apps/` as a corpus** -- ground the first two reviews never covered. Presentation only; `--ships` says this reaches no user's device.

## Two of these were bugs, not tidying

### The 404 page hid its only link in dark mode

`site/404.html` declared `a { color: #111110 }` **after** the `prefers-color-scheme: dark` block, at equal specificity. The later rule wins in both schemes, so the dark-mode link rendered near-black on `#191916` -- roughly **1.05:1**. A visitor landing on a dead URL in dark mode saw three sentences and no visible way off the page.

Moving the light rule above the media block is the entire fix. Measured after: `rgb(242,241,236)` on `rgb(25,25,22)`.

### The wallpapers menu was dead at every width, and always had been

`site/wallpapers/index.html` never loaded `assets/topnav.js`. `wallpapers.js` carried a stripped local copy that toggled `.is-open` and **never added `.has-menu`** -- the class every mobile rule in `styles.css` is scoped to. Consequences at 320px, measured live before the fix: the Menu button computed `display:none` at every width, and `INSTALL THE FIRMWARE` rendered **49px tall inside a 50px bar**.

**Not a regression: born broken.** `topnav.js` landed 2026-09-05 03:17 and `site/wallpapers/index.html` at 10:37 the same morning, with the stripped copy in it from its first commit. The page never had a working menu, which is why nothing noticed: `host-tests/site/run.sh` looped over index and study by hand, while **three** pages carry a `.topbar`.

**The test is the part worth keeping, and its first version had the same shape as the bug.** It named three paths by hand under a comment claiming it covered every page with a bar, so the next page would go missing the same way. It now greps for `class="topbar"` under `site/` and loops over what it finds. It fails without the fix:

```
FAIL site  site/wallpapers/index.html does not load assets/topnav.js, so its menu button opens nothing
223 checks, 1 failed
```

With the fix: `223 checks, 0 failed`. Measured after: class `topbar has-menu`, toggle `display: block`, bar 50px, no horizontal overflow.

## Pages saying things that are not so

- **`/wallpapers/` taught only the flow the device replaced** -- download a `.bmp`, open File Transfer, copy it across. The QR route shipped (`release-notes.md:60`, `WallpapersScreens.h:292`) and the page never mentioned it. Now named first, because a reader whose photo is already on their phone does not need the page at all.
- **`/report/` never said where a report goes.** It takes a bug report from a stranger and said nothing about what happens to it. Now: a card on a board one person reads, an address stored with the card if you give one so a reply can reach you, ten reports an hour per network, and `SECURITY.md` for a security problem instead. It also had **no og tags at all**, on a page whose own comment says it exists *"for the links and QR codes that point here"*.
- **`site/README.md`** said *"The one server-side thing on this site is `api/firmware.js`"*. `site/api/` holds five. Corrected to what is true: that one is what the **page** cannot work without.
- **`set-host.py`** managed two pages and `/wallpapers/` was not one, so its absolute `og:url` was hand-written and unmanaged. In `PAGES` now.

## docs/apps had no index

34 files. `docs/README.md` pointed at the directory and the reader got a raw file listing.

`docs/apps/README.md` groups them by what they are **for**: how to use an app, the rules a game implements, where the content came from, formats on the card, decision records for things that shipped, decided-but-unstaffed, and argued-and-deliberately-not-built. Checked both directions: every one of the 34 files is linked, and every link resolves.

It lands as `docs/apps/README.md` rather than as an edit to `docs/README.md` because GitHub renders it automatically when the directory is browsed, and `docs/README.md` is in flight on #167.

`hackernews-saved-port.md` opened *"The screens and the Activity are not [committed]"*. They are: `HackerNewsActivity.h` carries `openSavedArticle()` and `hn::Library library_`. Marked **LANDED** rather than deleted -- the reasoning is worth keeping, the present tense was not.

## Deliberately not in this PR

`docs/apps/trivia-sync-design.md` opens "Nothing here is built yet" and it shipped. Already fixed in #167; editing it on two branches manufactures a conflict for nothing.

## A second commit corrects the first

A cold review of the first commit found four false statements published to the site, three checkable against files in this repository. The worst was a **privacy claim that was backwards**: `/report/` said *"your address is never stored, only a salted hash of it, which is what caps how many reports one sender can file an hour."* `report.js:220` writes `reporter_email` to a real column, `board.py:1531` prints it, and the salted hash is of the **client IP** -- so the cap is per network and applies to someone who gives no address at all. The sentence was copied from `api/report.js`'s own header comment, which has claimed it since the endpoint was written; that comment is fixed too.

Also corrected: the QR note said *"the reader converts it"* when the **phone** crops and dithers (`WallpaperPage.html:29`), and skipped both the `+ Add a wallpaper` step and the same-Wi-Fi precondition; the index claimed nine plan files carry a landed marker when one does; it said three shelf apps lack a doc when it is eight; it omitted `study-quick-reference.pdf`; `api/trivia.js` was described as a site endpoint when only the firmware calls it (`TriviaActivity.cpp:720`); and `/report/` was given og tags without being added to `set-host.py`'s PAGES.

The `site/README.md` twin claim four lines from the top is fixed here too. I had left it out of the first commit assuming it would conflict with #167; a scratch merge showed both branches merge clean, so the assumption was the only thing stopping it.

## Verification

- `CHECKSH-VERDICT: host-green-device-skipped`
- `host-tests/site/run.sh`: 223 checks, 0 failed -- and seen to fail without the wallpapers fix.
- The three changed pages were served locally, measured, and looked at.

**Not verified:** no hardware, no device build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
