### PR TITLE
study: offer to resume the card left open across a leave or a sleep

### DIFF
--- a/host-tests/study/test_deck.cpp
+++ b/host-tests/study/test_deck.cpp
@@ -209,6 +209,43 @@ void run(const std::string& dir) {
   check(today == 10, "day 10 plus an hour is still day 10");
   check(study::dayNumber(deck.meta(), deck.meta().collectionCreated) == 0, "the creation instant is day 0");
   check(study::dayNumber(deck.meta(), deck.meta().collectionCreated - 5) == 0, "before day zero clamps to 0");
+
+  // The "resume in progress card" record: whether a saved position is still
+  // safe to trust is the one part of that feature worth host-testing (the SD
+  // read/write around it is Arduino-only).
+  {
+    uint8_t bytes[study::kResumeRecordBytes];
+    study::writeResumeRecord(bytes, 3, 1, 1700000000);
+    study::ResumeRecord record;
+    check(study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "a valid record parses");
+    check(record.cardIndex == 3 && record.face == 1 && record.savedAt == 1700000000,
+          "the round-tripped record carries its index, face, and timestamp");
+
+    study::writeResumeRecord(bytes, 0, 0, 0);
+    check(study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "index 0 (the first card) parses");
+
+    study::writeResumeRecord(bytes, deck.noteCount(), 0, 0);
+    check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record),
+          "an index at noteCount (one past the end) is refused");
+
+    study::writeResumeRecord(bytes, -1, 0, 0);
+    check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "a negative index is refused");
+
+    study::writeResumeRecord(bytes, 3, 1, 0);
+    bytes[0] = study::kResumeRecordVersion + 1;
+    check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "a version mismatch is refused");
+
+    study::writeResumeRecord(bytes, 3, 2, 0);
+    check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "a face byte past 1 is refused");
+
+    study::writeResumeRecord(bytes, 3, 1, 0);
+    check(!study::parseResumeRecord(bytes, sizeof(bytes) - 1, deck.noteCount(), record),
+          "a short buffer is refused");
+    check(!study::parseResumeRecord(bytes, sizeof(bytes) + 1, deck.noteCount(), record),
+          "a long buffer is refused");
+
+    check(!study::parseResumeRecord(bytes, sizeof(bytes), 0, record), "an empty deck refuses every index");
+  }
 }
 
 }  // namespace

--- a/host-tests/study/test_deck.cpp
+++ b/host-tests/study/test_deck.cpp
@@ -239,10 +239,8 @@ void run(const std::string& dir) {
     check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "a face byte past 1 is refused");
 
     study::writeResumeRecord(bytes, 3, 1, 0);
-    check(!study::parseResumeRecord(bytes, sizeof(bytes) - 1, deck.noteCount(), record),
-          "a short buffer is refused");
-    check(!study::parseResumeRecord(bytes, sizeof(bytes) + 1, deck.noteCount(), record),
-          "a long buffer is refused");
+    check(!study::parseResumeRecord(bytes, sizeof(bytes) - 1, deck.noteCount(), record), "a short buffer is refused");
+    check(!study::parseResumeRecord(bytes, sizeof(bytes) + 1, deck.noteCount(), record), "a long buffer is refused");
 
     check(!study::parseResumeRecord(bytes, sizeof(bytes), 0, record), "an empty deck refuses every index");
   }

--- a/src/apps_local/study/StudyActivity.cpp
+++ b/src/apps_local/study/StudyActivity.cpp
@@ -132,8 +132,7 @@ void formatResumeAge(const int64_t savedAt, char* out, const size_t outSize) {
     struct tm parts;
     const time_t at = static_cast<time_t>(savedAt);
     localtime_r(&at, &parts);
-    static const char* kMonths[] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN",
-                                    "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+    static const char* kMonths[] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
     std::snprintf(out, outSize, "LEFT %d %s", parts.tm_mday, kMonths[parts.tm_mon % 12]);
   }
 }

--- a/src/apps_local/study/StudyActivity.cpp
+++ b/src/apps_local/study/StudyActivity.cpp
@@ -109,6 +109,35 @@ uint32_t nextRandom(uint32_t& state) {
   return state;
 }
 
+// "LEFT 12 MIN AGO", for the resume prompt. Minutes and hours rather than a
+// clock time while it is recent: the question the prompt answers is "how
+// stale is this", and a relative answer says that directly where "14:32"
+// would make the reader do the subtraction. Same month-name idiom
+// buildDeckModel() uses for LAST SYNC once a card is more than a week stale.
+void formatResumeAge(const int64_t savedAt, char* out, const size_t outSize) {
+  const int64_t now = static_cast<int64_t>(time(nullptr));
+  const int64_t elapsed = now > savedAt ? now - savedAt : 0;
+  if (elapsed < 60) {
+    std::snprintf(out, outSize, "LEFT JUST NOW");
+  } else if (elapsed < 3600) {
+    const int minutes = static_cast<int>(elapsed / 60);
+    std::snprintf(out, outSize, "LEFT %d MIN%s AGO", minutes, minutes == 1 ? "" : "S");
+  } else if (elapsed < 86400) {
+    const int hours = static_cast<int>(elapsed / 3600);
+    std::snprintf(out, outSize, "LEFT %d HOUR%s AGO", hours, hours == 1 ? "" : "S");
+  } else if (elapsed < 86400 * 7) {
+    const int days = static_cast<int>(elapsed / 86400);
+    std::snprintf(out, outSize, "LEFT %d DAY%s AGO", days, days == 1 ? "" : "S");
+  } else {
+    struct tm parts;
+    const time_t at = static_cast<time_t>(savedAt);
+    localtime_r(&at, &parts);
+    static const char* kMonths[] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN",
+                                    "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+    std::snprintf(out, outSize, "LEFT %d %s", parts.tm_mday, kMonths[parts.tm_mon % 12]);
+  }
+}
+
 }  // namespace
 
 std::unique_ptr<Activity> StudyActivity::create(GfxRenderer& renderer, MappedInputManager& mappedInput) {
@@ -122,6 +151,11 @@ void StudyActivity::onEnter() {
   if (findDeckDirs() && openDeckAt(deckIndex_)) {
     beginDeckSession();
     view_ = View::Deck;
+    // Offer the card that was open last time rather than landing on it
+    // outright: loadResumeState() already did the loading (note_/card_/
+    // fonts_/image_, via the same loadCurrent() takeNext() uses), so RESUME
+    // on this prompt is just a view switch.
+    if (loadResumeState()) view_ = View::ResumePrompt;
   } else {
     LOG_ERR("STUDY", "No deck under %s -- run tools_local/study/study.py setup", kStudyRoot);
   }
@@ -292,6 +326,7 @@ void StudyActivity::onExit() {
     delay(30);
     silentRestart();  // on touch boards: stops SNTP and the radio in place
   }
+  if (deckDir_[0] != '\0') saveResumeState();
   if (cardSource_) cardSource_->flush();
   revlogFile_.flush();
   fonts_.unload(renderer);
@@ -399,6 +434,57 @@ bool StudyActivity::openDeckAt(const int index) {
     lastFile.write(deckNames_[index], std::strlen(deckNames_[index]));
   }
   return openDeck();
+}
+
+void StudyActivity::saveResumeState() const {
+  char path[80];
+  std::snprintf(path, sizeof(path), "%s/.resume", deckDir_);
+  if (view_ == View::ResumePrompt) {
+    // The prompt itself was still on screen -- whatever it is offering was
+    // already written last time and has not been answered yet, so leave it
+    // exactly as it is rather than losing it to a sleep taken mid-prompt.
+    return;
+  }
+  if (view_ != View::Card) {
+    // Nothing open worth resuming -- and a stale record here would otherwise
+    // outlive the card it names, the same "still unfinished" caution
+    // Picross applies before offering a resume.
+    Storage.remove(path);
+    return;
+  }
+  uint8_t bytes[study::kResumeRecordBytes];
+  study::writeResumeRecord(bytes, static_cast<int32_t>(currentIndex_), face_ == Face::Answer ? 1 : 0,
+                           static_cast<int64_t>(time(nullptr)));
+  HalFile file;
+  if (!Storage.openFileForWrite("STUDY", path, file)) return;
+  file.write(bytes, sizeof(bytes));
+}
+
+bool StudyActivity::loadResumeState() {
+  char path[80];
+  std::snprintf(path, sizeof(path), "%s/.resume", deckDir_);
+  HalFile file;
+  if (!Storage.openFileForRead("STUDY", path, file)) return false;
+  uint8_t bytes[study::kResumeRecordBytes];
+  if (file.read(bytes, sizeof(bytes)) != static_cast<int>(sizeof(bytes))) return false;
+  study::ResumeRecord record;
+  if (!study::parseResumeRecord(bytes, sizeof(bytes), deck_.noteCount(), record)) return false;
+  currentIndex_ = record.cardIndex;
+  // loadCurrent() does the real work (note_/card_/fonts_/image_), the same
+  // path takeNext() uses -- but it always lands on the question face, so the
+  // saved face is reapplied after.
+  if (!loadCurrent()) return false;
+  face_ = record.face == 1 ? Face::Answer : Face::Question;
+  formatResumeAge(record.savedAt, resumeCaption_, sizeof(resumeCaption_));
+  return true;
+}
+
+void StudyActivity::declineResumePrompt() {
+  char path[80];
+  std::snprintf(path, sizeof(path), "%s/.resume", deckDir_);
+  Storage.remove(path);
+  view_ = View::Deck;
+  requestUpdate();
 }
 
 bool StudyActivity::openDeck() {
@@ -866,6 +952,10 @@ void StudyActivity::loop() {
       requestUpdate();
       return;
     }
+    if (view_ == View::ResumePrompt) {
+      declineResumePrompt();
+      return;
+    }
     if (view_ == View::Card) {
       // Back walks up, never out: a review session returns to the deck
       // screen. The session state stays; the next START REVIEWING re-scans
@@ -892,7 +982,7 @@ void StudyActivity::loop() {
   int tapY = 0;
   if (!mappedInput.wasScreenTapped(tapX, tapY)) return;
 
-  if (view_ == View::Deck) {
+  if (view_ == View::Deck || view_ == View::ResumePrompt) {
     // Hit-testing comes from the buffer the screen filled while drawing, so a
     // region can never drift from the pixels that drew it.
     if (!interactionsReady_) return;
@@ -1460,6 +1550,19 @@ void StudyActivity::routeAction(const fui::ActionEvent& event) {
     beginSync();
     return;
   }
+  if (event.value == 5) {
+    // The ResumePrompt's RESUME button. loadResumeState() already loaded
+    // note_/card_/fonts_/image_ back in onEnter(); revealing the card is the
+    // whole action.
+    view_ = View::Card;
+    requestUpdate();
+    return;
+  }
+  if (event.value == 6) {
+    // The ResumePrompt's NOT NOW button -- same decline as Back.
+    declineResumePrompt();
+    return;
+  }
   // Re-scan rather than resuming a stale queue: a session can end, the user can
   // sit on this screen past the rollover hour, and what was due then is not
   // what is due now.
@@ -1552,6 +1655,24 @@ void StudyActivity::render(RenderLock&&) {
     const bool backLive =
         flow_.verdict != studyui::SyncVerdictKind::None || flow_.safety >= studyui::SyncSafety::ReviewsSafe;
     const auto labels = mappedInput.mapLabels(backLive ? "Back" : "", "", "", "");
+    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+    renderer.displayBuffer();
+    return;
+  }
+
+  if (view_ == View::ResumePrompt) {
+    fui::GfxRendererTarget target = toybox::makeTarget(renderer);
+    const fui::InputSnapshot noInput{};
+    interactionsReady_ = false;
+    toybox::Frame frame(target, target.deviceContext(), noInput, interactions_);
+    toybox::Screen screen(frame);
+
+    studyui::buildResumePrompt(screen, resumeCaption_);
+
+    interactionsReady_ = true;
+    toybox::reportOverflow(interactions_, "Study resume prompt");
+
+    const auto labels = mappedInput.mapLabels("Back", "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     renderer.displayBuffer();
     return;

--- a/src/apps_local/study/StudyActivity.h
+++ b/src/apps_local/study/StudyActivity.h
@@ -61,7 +61,11 @@ class StudyActivity final : public Activity {
   // whatever sentence the flow is on, the pairing QR, and the on-device
   // "Paired to <account> -- confirm?" gate (which closes both directions of
   // the pairing race; see docs/apps/study-sync-bridge-plan.md).
-  enum class View : uint8_t { Deck, Card, Image, NoDeck, SyncFlow, PairQr, PairConfirm, DeckPicker };
+  // ResumePrompt: shown at onEnter() when a card was left open last time,
+  // offering to go straight back to it (RESUME) or Back to the deck screen
+  // as normal, before either the fresh queue or the resumed card is on
+  // screen.
+  enum class View : uint8_t { Deck, Card, Image, NoDeck, SyncFlow, PairQr, PairConfirm, DeckPicker, ResumePrompt };
   enum class Face : uint8_t { Question, Answer };
 
   bool openDeck();
@@ -83,6 +87,20 @@ class StudyActivity final : public Activity {
   bool openDeckAt(int index);
   void closeDeck();
   void switchDeck();
+  // The card left open last time, if any. saveResumeState() runs
+  // unconditionally from onExit() when a card is on screen; loadResumeState()
+  // runs from onEnter() and, on success, note_/card_/fonts_/image_ are
+  // already loaded (via loadCurrent()) and View::ResumePrompt is shown before
+  // the card itself is. See study::parseResumeRecord (StudyDeck.h) for the
+  // validation the load side trusts.
+  void saveResumeState() const;
+  bool loadResumeState();
+  // Declining is authoritative: the offer was for THIS card, and leaving the
+  // record around would ask again next time over whatever the deck screen's
+  // own session produces instead, unrelated to the card it once named. Shared
+  // by the ResumePrompt's NOT NOW button and its Back handling in loop() so
+  // the two cannot drift apart.
+  void declineResumePrompt();
   bool takeNext();
   // Take back the last answer. One level only: "I meant Good, not Again" is the
   // case that matters, and a deeper stack would need the queue's whole history
@@ -201,6 +219,9 @@ class StudyActivity final : public Activity {
   int deckIndex_ = 0;
   // The open deck's directory, /study/<name>; empty until a deck is open.
   char deckDir_[64] = "";  // "/study/" + a 40-char slug, with room to spare
+
+  // "LEFT 12 MIN AGO", set by loadResumeState() for View::ResumePrompt to draw.
+  char resumeCaption_[40] = "";
 
   int currentIndex_ = -1;
   int today_ = 0;

--- a/src/apps_local/study/StudyDeck.h
+++ b/src/apps_local/study/StudyDeck.h
@@ -210,8 +210,8 @@ inline constexpr uint32_t kResumeRecordBytes = 14;  // version + int32 index + f
 
 struct ResumeRecord {
   int32_t cardIndex = -1;
-  uint8_t face = 0;      // 0 Question, 1 Answer
-  int64_t savedAt = 0;   // epoch seconds when the record was written
+  uint8_t face = 0;     // 0 Question, 1 Answer
+  int64_t savedAt = 0;  // epoch seconds when the record was written
 };
 
 // False on a version mismatch, a malformed face byte, or an index outside

--- a/src/apps_local/study/StudyDeck.h
+++ b/src/apps_local/study/StudyDeck.h
@@ -14,6 +14,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 #include "StudyFsrs.h"
 
@@ -192,5 +193,54 @@ class StudyDeck {
 // lets a due date computed here and one computed on the phone agree without any
 // timezone conversation.
 int dayNumber(const DeckMeta& meta, int64_t nowEpochSeconds);
+
+// The card left open across a leave or a sleep, when the "resume in progress
+// card" option is on. Kept freestanding, with the SD read/write in
+// StudyActivity.cpp (Arduino-only), so the one part worth getting wrong --
+// whether a saved position is still safe to trust -- is host-tested.
+//
+// Version 2 adds savedAt (epoch seconds), so the resume prompt can say how
+// long ago the card was left rather than just naming it. Bumping the version
+// rather than growing the old layout in place means a v1 file left on an SD
+// card by an older build is refused outright -- read as "no timestamp" it
+// would print an epoch-zero date, which is a worse failure than just not
+// resuming.
+inline constexpr uint8_t kResumeRecordVersion = 2;
+inline constexpr uint32_t kResumeRecordBytes = 14;  // version + int32 index + face + int64 savedAt
+
+struct ResumeRecord {
+  int32_t cardIndex = -1;
+  uint8_t face = 0;      // 0 Question, 1 Answer
+  int64_t savedAt = 0;   // epoch seconds when the record was written
+};
+
+// False on a version mismatch, a malformed face byte, or an index outside
+// [0, noteCount) -- a deck re-synced since the save was written can shrink or
+// reorder cards.dat, and trusting a stale index would resume the wrong note or
+// read past it. The caller falls back to its normal fresh-queue pick in every
+// one of those cases, same as it would with no saved record at all.
+inline bool parseResumeRecord(const uint8_t* bytes, uint32_t length, int noteCount, ResumeRecord& out) {
+  if (length != kResumeRecordBytes) return false;
+  if (bytes[0] != kResumeRecordVersion) return false;
+  int32_t index;
+  std::memcpy(&index, bytes + 1, sizeof(index));
+  const uint8_t face = bytes[5];
+  if (face > 1) return false;
+  if (index < 0 || index >= noteCount) return false;
+  int64_t savedAt;
+  std::memcpy(&savedAt, bytes + 6, sizeof(savedAt));
+  out.cardIndex = index;
+  out.face = face;
+  out.savedAt = savedAt;
+  return true;
+}
+
+// Serializes exactly kResumeRecordBytes bytes, the inverse of parseResumeRecord.
+inline void writeResumeRecord(uint8_t* bytes, int32_t cardIndex, uint8_t face, int64_t savedAt) {
+  bytes[0] = kResumeRecordVersion;
+  std::memcpy(bytes + 1, &cardIndex, sizeof(cardIndex));
+  bytes[5] = face;
+  std::memcpy(bytes + 6, &savedAt, sizeof(savedAt));
+}
 
 }  // namespace study

--- a/src/apps_local/study/StudyScreens.cpp
+++ b/src/apps_local/study/StudyScreens.cpp
@@ -402,9 +402,8 @@ void buildResumePrompt(toybox::Screen& screen, const char* caption) {
   const int16_t skipH = 48;
   const int16_t gap = 16;
   const fui::Rect resumeRect =
-      fui::makeRect(static_cast<int16_t>(body.x + 44),
-                    static_cast<int16_t>(body.bottom() - 48 - skipH - gap - resumeH), static_cast<int16_t>(body.width - 88),
-                    resumeH);
+      fui::makeRect(static_cast<int16_t>(body.x + 44), static_cast<int16_t>(body.bottom() - 48 - skipH - gap - resumeH),
+                    static_cast<int16_t>(body.width - 88), resumeH);
   fui::ButtonProps resume;
   resume.label = "RESUME";
   resume.action = ActionStudy;
@@ -418,9 +417,9 @@ void buildResumePrompt(toybox::Screen& screen, const char* caption) {
   // A real target rather than relying on Back alone: Back still declines too
   // (StudyActivity's own dispatch), but a screen that offers one way forward
   // and only an off-screen way back is not offering a choice.
-  const fui::Rect skipRect = fui::makeRect(static_cast<int16_t>(body.x + 44),
-                                           static_cast<int16_t>(body.bottom() - 48 - skipH),
-                                           static_cast<int16_t>(body.width - 88), skipH);
+  const fui::Rect skipRect =
+      fui::makeRect(static_cast<int16_t>(body.x + 44), static_cast<int16_t>(body.bottom() - 48 - skipH),
+                    static_cast<int16_t>(body.width - 88), skipH);
   fui::ButtonProps skip;
   skip.label = "NOT NOW";
   skip.action = ActionStudy;

--- a/src/apps_local/study/StudyScreens.cpp
+++ b/src/apps_local/study/StudyScreens.cpp
@@ -377,6 +377,66 @@ void buildDeck(toybox::Screen& screen, const DeckModel& model) {
   screen.list(list, doorBand, fui::LayoutAnchor::Bottom);
 }
 
+void buildResumePrompt(toybox::Screen& screen, const char* caption) {
+  chrome(screen, "STUDY");
+  screen.insetContent(fui::Insets{toybox::kGutter * 3, toybox::kMargin, toybox::kMargin, toybox::kMargin});
+  const fui::Rect body = screen.body();
+
+  fui::TextStyle hero;
+  hero.font = toybox::kDisplayFont;
+  hero.align = fui::TextAlign::Center;
+  screen.target().text(fui::makeRect(body.x, body.y + toybox::kMargin, body.width, 60), "CONTINUE?", hero);
+
+  // caption ("LEFT 12 MIN AGO") is already short by construction
+  // (formatResumeAge): the renderer appends U+2026 on overflow and the UI
+  // face has no glyph for it, so a line that does not fit does not get an
+  // ellipsis, it just stops mid-word. buildPairConfirm's caption hit exactly
+  // this.
+  fui::TextStyle sub;
+  sub.font = toybox::kUiFont;
+  sub.align = fui::TextAlign::Center;
+  sub.color = fui::Color::DarkGray;
+  screen.target().text(fui::makeRect(body.x, body.y + toybox::kMargin + 66, body.width, 32), caption, sub);
+
+  const int16_t resumeH = 56;
+  const int16_t skipH = 48;
+  const int16_t gap = 16;
+  const fui::Rect resumeRect =
+      fui::makeRect(static_cast<int16_t>(body.x + 44),
+                    static_cast<int16_t>(body.bottom() - 48 - skipH - gap - resumeH), static_cast<int16_t>(body.width - 88),
+                    resumeH);
+  fui::ButtonProps resume;
+  resume.label = "RESUME";
+  resume.action = ActionStudy;
+  resume.value = 5;
+  resume.text = sub;
+  resume.text.color = fui::Color::Black;
+  resume.text.align = fui::TextAlign::Center;
+  resume.radius = static_cast<uint8_t>(resumeH / 2);
+  screen.button(resume, resumeRect);
+
+  // A real target rather than relying on Back alone: Back still declines too
+  // (StudyActivity's own dispatch), but a screen that offers one way forward
+  // and only an off-screen way back is not offering a choice.
+  const fui::Rect skipRect = fui::makeRect(static_cast<int16_t>(body.x + 44),
+                                           static_cast<int16_t>(body.bottom() - 48 - skipH),
+                                           static_cast<int16_t>(body.width - 88), skipH);
+  fui::ButtonProps skip;
+  skip.label = "NOT NOW";
+  skip.action = ActionStudy;
+  skip.value = 6;
+  skip.text = sub;
+  skip.text.color = fui::Color::Black;
+  skip.text.align = fui::TextAlign::Center;
+  skip.radius = static_cast<uint8_t>(skipH / 2);
+  skip.styles.explicitlySet = true;
+  skip.styles.normal.background = fui::Paint::none();
+  skip.styles.normal.border = fui::Paint::solid(fui::Color::Black);
+  skip.styles.normal.borderWidth = 2;
+  skip.styles.normal.radius = static_cast<uint8_t>(skipH / 2);
+  screen.button(skip, skipRect);
+}
+
 // ---- The sync flow surface (docs/apps/study-syncflow-ui.md). The stage
 // band won the three-variant round; the ladder and line+log arrangements
 // and the STUDY_SYNCFLOW_VARIANT macro died with the choice.

--- a/src/apps_local/study/StudyScreens.h
+++ b/src/apps_local/study/StudyScreens.h
@@ -86,6 +86,13 @@ struct DeckModel {
 
 void buildDeck(toybox::Screen& screen, const DeckModel& model);
 
+// Shown at onEnter() when a card was left open last time. RESUME (action
+// ActionStudy, value 5) reveals it; NOT NOW (value 6) declines, same as
+// Back. `caption` is the already-formatted "LEFT 12 MIN AGO" (StudyActivity
+// computes it -- it needs a wall clock, which this header stays free of so
+// host-tests/ui can build the screen deterministically).
+void buildResumePrompt(toybox::Screen& screen, const char* caption);
+
 // ---- The sync flow surface (docs/apps/study-syncflow-ui.md).
 //
 // One screen, two faces: the stage ladder while the flow runs, the verdict


### PR DESCRIPTION
## Summary
- Study now offers to resume the exact card (and face) you left open, across both backing out to Home and the device sleeping mid-review -- neither currently survives, since `onEnter()` always rebuilds the queue and picks a fresh card.
- Matches this fork's own convention (Sudoku/Picross/Solitaire all save unconditionally in `onExit()` and load unconditionally in `onEnter()`, no expiry) and real Anki's behavior (no session timeout -- a card just sits there, however long you're away).
- A new `View::ResumePrompt` at `onEnter()` shows "CONTINUE?" with how long ago the card was left ("LEFT 12 MIN AGO", scaling to hours/days/a date), a RESUME button, and a NOT NOW button (Back does the same). Declining is authoritative and discards the saved position, the same caution Picross applies before offering its own resume.

## Design notes
- `study::ResumeRecord`/`parseResumeRecord`/`writeResumeRecord` (`StudyDeck.h`) are freestanding and host-tested: the one part worth getting wrong -- whether a saved card index is still safe to trust -- is validated against the deck's live `noteCount()` before ever being used, since a re-sync since the save was written can shrink or reorder `cards.dat`.
- Confirmed `onExit()`/`onEnter()` already fire uniformly for both an explicit leave and a device-initiated sleep: `enterDeepSleep()` in `main.cpp` runs the outgoing activity's real `onExit()` before the sleep screen replaces it, so no separate deep-sleep-specific hook was needed.
- The per-deck record lives at `<deck>/.resume`, alongside `deck.dat`/`cards.dat`/`meta.dat`/`revlog.dat`.

## Test plan
- [x] 10 new `host-tests/study/test_deck.cpp` checks: in-bounds/out-of-bounds/negative index, version mismatch, a bad face byte, malformed buffer lengths
- [x] `./host-tests/study/run.sh` -- all 6 suites green
- [x] `pio run -e x4pro` builds clean
- [x] Verified on a real X4 Pro: leaving a card mid-review (both by backing out and by letting the device sleep) and reopening Study shows the CONTINUE? prompt; RESUME lands back on the same card and face; NOT NOW and Back both discard it and land on the deck screen
