### PR TITLE
docs(apps): give jaipur the section its siblings have, and stop opening on a number

### DIFF
--- a/docs/apps/jaipur.md
+++ b/docs/apps/jaipur.md
@@ -347,6 +347,28 @@ had read them.
 
 ---
 
+## 3. Multiplayer
+
+`GameId::Jaipur`. The wire state is the `Game` struct itself: 64 bytes,
+trivially copyable, well inside LinkPlay's 192-byte cap, and asserted to have no
+padding because every byte of it is compared, saved and transmitted. A layout
+with padding has bytes no field owns, and those are whatever the stack left
+there.
+
+**The deck does not travel.** `Game::seed` does, and both devices rebuild the
+same 52-card shuffle and the same bonus stacks from it (`cardAt`,
+`bonusValueAt`). That is what keeps a hidden-information game inside one packet:
+sending the whole board would mean sending both hands.
+
+**Which is the point of `Observation`.** The struct a player -- or an AI -- is
+handed does not have a field for the opponent's hand composition, only
+`opponentHandSize`, a number. An AI built on it cannot cheat by construction
+rather than by discipline, and the same shape is what a device is allowed to
+draw. `unseen` is the honest substitute: the deck plus their hand as one
+multiset, which is what a person at the table actually knows.
+
+---
+
 ## 4. The opponent
 
 `JaipurBrain` takes an `Observation`, never a `Game`. That is the whole design:

--- a/docs/apps/knucklebones.md
+++ b/docs/apps/knucklebones.md
@@ -1,8 +1,9 @@
 # Knucklebones
 
 The dice game from Cult of the Lamb. Two players, a three by three grid each,
-one die. It is the ninth game in this fork and the first built to find out what
-a repeatable game cycle actually needs, rather than to guess at it.
+one die. It was the first game built to find out what a repeatable game cycle
+actually needs, rather than to guess at it, which is where
+`docs/games-at-scale.md` came from.
 
 ## The rules, exactly
 

--- a/docs/apps/minesweeper.md
+++ b/docs/apps/minesweeper.md
@@ -1,9 +1,9 @@
 # Minesweeper
 
-Eight by ten with ten mines. The eleventh game in this fork, and the second run
-of the build cycle -- chosen because it is the least like the game that cycle was
-written from, which is the only way to find out whether a method generalises or
-just describes one case.
+Eight by ten with ten mines. It was the second game built through the cycle in
+`docs/games-at-scale.md`, chosen because it is the least like the game that
+cycle was written from: the only way to find out whether a method generalises
+or just describes one case.
 
 ## The rules, and the two that are built in
 

--- a/docs/apps/sudoku.md
+++ b/docs/apps/sudoku.md
@@ -1,8 +1,8 @@
 # Sudoku
 
-The sixteenth game. Classic 9x9, generated on the device, graded by the hardest
-technique it actually requires. Solitaire: no link layer, and that is a decision
-rather than an omission.
+Classic 9x9, generated on the device and graded by the hardest technique it
+actually requires. Solitaire: no link layer, and that is a decision rather than
+an omission.
 
 Four layers, as usual: `SudokuCore` (the rules, freestanding), `SudokuGame`
 (what the player touches, freestanding, and also the save), `SudokuScreens`

--- a/docs/apps/wallpapers-phone-flow.md
+++ b/docs/apps/wallpapers-phone-flow.md
@@ -1,8 +1,13 @@
 # Wallpapers: from a picture on a phone to the sleep screen
 
+**Shipped in 1.12.41** ("Wallpapers: scan a code, pick a photo on your phone,
+and it is on the reader"). What follows is the design as written, in the present
+tense of the day it was drafted. `wallpapers-shuffle.md` covers the picker's
+other half, choosing a set; the two overlap where this one reaches Part 2.
+
 Design for card #349, revised after a cold critic agent. Covers three things
-Mario
-asked for in one conversation on 2026-09-05, which are one design and not three:
+Mario asked for in one conversation on 2026-09-05, which are one design and not
+three:
 
 1. Replacing the "+ Add a wallpaper" screen. It currently tells you to go to a
    website **on a computer** and copy a file across with File Transfer. He was

--- a/docs/apps/wallpapers-shuffle.md
+++ b/docs/apps/wallpapers-shuffle.md
@@ -1,5 +1,10 @@
 # Wallpapers: choosing a set, and letting it take turns
 
+**Shipped in 1.12.43** ("Wallpapers: choose several wallpapers, and let them
+take turns"). What follows is the design as written, in the present tense of the
+day it was drafted. `wallpapers-phone-flow.md` covers getting a picture onto the
+device in the first place, and its Part 2 is the same subject as this file.
+
 Card #305. Mario asked twice: *"didn't we agree to have a way to select multiple
 ones at the same time and for them to cycle?"*
 


### PR DESCRIPTION
Closes card #443. Four docs in `docs/apps/` broke the shape the rest of them keep. Presentation only.

## Jaipur had no section 3

Its headings ran `## 1`, `## 2`, `## 4`, `## 5`. The three docs built on the same template all carry `## 3. Multiplayer` at the same position (`checkers.md:115`, `connectfour.md:67`, `yahtzee.md:108`). Jaipur plays nearby, and in 577 lines the only mention of it was one cell of an ASCII diagram. A numbering gap reads as a deleted section, so a reader goes looking for what was removed.

The new section is read out of `JaipurCore.h`, not composed:

- `Game` is 64 bytes, trivially copyable, and asserted to have **no padding**, because every byte is compared, saved and transmitted. A layout with padding has bytes no field owns.
- **The deck does not travel.** `seed` does, and both devices rebuild the same shuffle (`cardAt`, `bonusValueAt`). That is what keeps a hidden-information game inside one 192-byte packet: sending the board would mean sending both hands.
- Which is why `Observation` has `opponentHandSize` and no hand composition. An AI built on it cannot cheat by construction rather than by discipline, and `unseen` is the honest substitute.

## Three docs opened on a number nobody maintains

`sudoku.md` "The sixteenth game", `minesweeper.md` "The eleventh game in this fork", `knucklebones.md` "the ninth game". A stranger cannot use any of them, nothing renumbers them when a game lands in between, and for two of the three it was the first sentence.

They now open on the game and keep the fact that is load-bearing: which of them was the first or second run of the cycle in `games-at-scale.md`.

## The two wallpapers designs never said they shipped

`wallpapers-phone-flow.md` in **1.12.41**, `wallpapers-shuffle.md` in **1.12.43**, both quoted from the release notes, in the shape `study-installer-plan.md` already uses. Each now also names the other and says where they overlap, which is the honest version of a merge nobody has done.

## Merge note

This branch touches `docs/apps/wallpapers-phone-flow.md` on a line #167 also edits, so merging both produces one trivial conflict there. Resolution is to take both: #167's wording change to the "cold critic agent" line, and this branch's "Shipped in 1.12.41" marker above it. I tried moving the marker clear of it and the result landed between a sentence introducing a numbered list and the list itself; contorting the prose to suit git was the worse trade.

## Verification

`CHECKSH-VERDICT: host-green-device-skipped` on the branch before trunk moved under it. **Not verified:** no hardware, no device build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
