### PR TITLE
Count every device that checks for an update: the OTA check asks the site first

### DIFF
--- a/docs/workflow/events.md
+++ b/docs/workflow/events.md
@@ -61,8 +61,11 @@ timeout).
 A device never makes a request just to report: it never brings the radio up
 for the board, and it never spends a request on it. Instead every request
 the firmware makes to one of CrossPlay's own services (Get Books, the Anki
-bridge, the Instapaper bridge) carries three headers, and the service posts
-what they say alongside the event it was going to post anyway:
+bridge, the Instapaper bridge, and since the release that carried card
+449 the update check, which asks the site's `/api/latest` before it asks
+GitHub) carries three headers,
+and the service posts what they say alongside the event it was going to
+post anyway:
 
 ```
 User-Agent: CrossPlay-ESP32-1.12.13
@@ -134,7 +137,10 @@ endpoint:
   `error` twins) gets `device` from the header (over the service's own hash
   when both exist), `board` from the header, `version` from the User-Agent,
   and `battery_pct`, `heap_min_kb`, `uptime_h` copied into `props` when the
-  report carried them.
+  report carried them. The site's update-check proxy (`site/api/latest.js`)
+  posts `site`/`update-check` the same way, with `props.latest` the tag it
+  offered, and only for a request that carried a valid device id: a browser
+  or a curl gets the JSON and is not counted.
 - **A report with `crash`** posts one more event, `{"service":"firmware",
   "event":"crash","level":"error","device":..,"version":<crash.version>,
   "board":..,"props":{"message":<crash.message>,"backtrace":<crash.backtrace>,
@@ -164,10 +170,14 @@ report counts beside it, 7 days), `events_daily` (30 days, by service and
 event), `service_users` (7 days). The inbox page shows them under "Numbers",
 next to GitHub's own download counts per release.
 
-A device is counted when it uses a service. One that only plays games and
-never searches a book or syncs a deck is not on the board at all, and that
-is the design, not a gap: "devices heard from" means devices that used
-something. Downloads per release, from GitHub, is the number for the rest.
+A device is counted when it uses a service, and since the release that
+carried card 449 when it checks for an update (Settings > Update, the one request nearly every
+device makes; `src/network/ReleaseSources.h`). One that only plays games,
+never searches a book, syncs a deck or checks for an update is not on the
+board at all, and that is the design, not a gap: "devices heard from"
+means devices that did something. Downloads per release, from GitHub, is a
+number for the rest, and a poor one: a release cut minutes after another
+gets the same six to sixteen downloads, which is scanners and CI.
 The views are in `20260903000200_events.sql` as written and
 `20260904001100_devices_from_usage.sql` as they read now.
 

--- a/host-tests/devreport/test_devreport.cpp
+++ b/host-tests/devreport/test_devreport.cpp
@@ -1,8 +1,10 @@
 // The device report's rules, tested rather than trusted. See DeviceReportCore.h.
 #include <cstdio>
 #include <cstring>
+#include <string>
 
 #include "DeviceReportCore.h"
+#include "ReleaseSources.h"
 
 namespace {
 
@@ -376,6 +378,19 @@ void testIsOwnHost() {
   check(!devreport::isOwnHost(nullptr), "null is not ours");
 }
 
+// The update check asks the site first and GitHub second (ReleaseSources.h):
+// the first source is one the device reports to, so a check counts it on the
+// board; the second is not, and is the fallback that keeps OTA alive.
+void testReleaseSources() {
+  check(release_sources::kCount == 2, "two sources: the site, then github");
+  check(devreport::reportsTo(true, release_sources::kUrls[0]), "the first source is ours: the check is counted");
+  check(!devreport::reportsTo(true, release_sources::kUrls[1]),
+        "the second source is not: the fallback reports nothing");
+  check(std::string(release_sources::kUrls[0]) == "https://crossplay.ma-r-s.com/api/latest", "the site's /api/latest");
+  check(std::string(release_sources::kUrls[1]) == "https://api.github.com/repos/ma-r-s/crossplay/releases/latest",
+        "github's releases/latest, exactly what the check asked before");
+}
+
 void testReportsTo() {
   check(devreport::reportsTo(true, "https://books.ma-r-s.com/opds"), "on, our host: report");
   check(devreport::reportsTo(true, "https://sync.ma-r-s.com/api/sync"), "on, the sync bridge: report");
@@ -553,6 +568,7 @@ int main() {
   testHostOf();
   testIsOwnHost();
   testReportsTo();
+  testReleaseSources();
   testDelivered();
   testCrashMessage();
   testToggle();

--- a/host-tests/site/latest_fn.js
+++ b/host-tests/site/latest_fn.js
@@ -1,0 +1,294 @@
+// The update-check proxy, run under plain node with GitHub and the board
+// stubbed out.
+//
+// api/latest.js is where a device's update check turns into a count on the
+// board. Every rule it keeps is asserted here: the JSON passes through
+// verbatim, a device is counted once per request and a browser never, the
+// crash and install it carries become the same events the bridges post, a
+// bad header is ignored rather than trusted, GitHub's silence is a stale
+// answer or a 502 (never a 2xx that would clear what the device carries),
+// and the board being down never costs the device its answer.
+//
+//   node host-tests/site/latest_fn.js <repo-root>
+
+const path = require("node:path");
+
+const root = process.argv[2] || path.join(__dirname, "..", "..");
+process.env.SUPABASE_URL = "https://board.test/";
+process.env.SUPABASE_ANON_KEY = "anon-key-for-tests";
+delete process.env.GITHUB_TOKEN;
+const handler = require(path.join(root, "site", "api", "latest.js"));
+
+let pass = 0;
+let fail = 0;
+const ok = (m) => {
+  pass++;
+  console.log("  ok   " + m);
+};
+const bad = (m) => {
+  fail++;
+  console.log("  FAIL " + m);
+};
+const is = (m, got, want) =>
+  JSON.stringify(got) === JSON.stringify(want)
+    ? ok(m)
+    : bad(`${m} (want ${JSON.stringify(want)}, got ${JSON.stringify(got)})`);
+
+const RELEASE = JSON.stringify({
+  tag_name: "v1.12.50",
+  assets: [
+    {
+      name: "firmware.bin",
+      browser_download_url:
+        "https://github.com/ma-r-s/crossplay/releases/download/v1.12.50/firmware.bin",
+      size: 4200000,
+    },
+  ],
+});
+let github = { status: 200, body: RELEASE, etag: '"abc"', throws: false };
+let board = { status: 201 };
+let calls = [];
+global.fetch = async function (url, opts) {
+  opts = opts || {};
+  const u = String(url);
+  calls.push({ url: u, method: opts.method || "GET", headers: opts.headers || {}, body: opts.body });
+  if (u.startsWith("https://api.github.com/")) {
+    if (github.throws) throw new Error("network down");
+    return new Response(github.status === 304 ? null : github.body, {
+      status: github.status,
+      headers: github.etag ? { etag: github.etag } : {},
+    });
+  }
+  if (u.endsWith("/rest/v1/events") && opts.method === "POST")
+    return new Response(null, { status: board.status });
+  return new Response("unexpected", { status: 500 });
+};
+
+function req(headers, method) {
+  const h = {};
+  for (const [k, v] of Object.entries(headers || {})) h[k.toLowerCase()] = v;
+  return { method: method || "GET", headers: h };
+}
+function res() {
+  return {
+    statusCode: 0,
+    headers: {},
+    body: undefined,
+    setHeader(k, v) {
+      this.headers[k.toLowerCase()] = v;
+    },
+    end(b) {
+      this.body = b;
+    },
+  };
+}
+async function call(headers, method) {
+  const r = res();
+  await handler(req(headers, method), r);
+  return r;
+}
+const posts = () => calls.filter((c) => c.url.endsWith("/rest/v1/events") && c.method === "POST");
+const githubCalls = () => calls.filter((c) => c.url.startsWith("https://api.github.com/"));
+const posted = () => posts().map((p) => JSON.parse(p.body));
+function fresh() {
+  calls = [];
+  handler._resetCache();
+  github = { status: 200, body: RELEASE, etag: '"abc"', throws: false };
+  board = { status: 201 };
+}
+
+const DEV = "9f2c".repeat(16);
+const UA = "CrossPlay-ESP32-1.12.47";
+const REPORT = JSON.stringify({ battery_pct: 84, heap_min_kb: 112, uptime_h: 31 });
+const device = (extra) =>
+  Object.assign(
+    { "X-CrossPlay-Device": DEV, "X-CrossPlay-Board": "x4pro", "User-Agent": UA, "X-CrossPlay-Report": REPORT },
+    extra || {},
+  );
+
+(async () => {
+  console.log("api/latest.js");
+
+  fresh();
+  let r = await call({ "User-Agent": "Mozilla/5.0" });
+  is("a browser gets GitHub's JSON, verbatim", [r.statusCode, r.body], [200, RELEASE]);
+  is("and the answer is never CDN-cached", r.headers["cache-control"], "no-store");
+  is("and a browser is not counted", posts().length, 0);
+  is("GitHub was asked as GitHub wants", githubCalls()[0].headers.Accept, "application/vnd.github+json");
+
+  fresh();
+  r = await call(device());
+  is("a device gets the same JSON, verbatim", [r.statusCode, r.body], [200, RELEASE]);
+  is("and is counted once", posts().length, 1);
+  is(
+    "as a site/update-check event with its id, board, version, health and the version offered",
+    posted()[0],
+    [
+      {
+        service: "site",
+        event: "update-check",
+        level: "info",
+        device: DEV,
+        version: "1.12.47",
+        board: "x4pro",
+        props: { battery_pct: 84, heap_min_kb: 112, uptime_h: 31, latest: "v1.12.50" },
+      },
+    ],
+  );
+  is("posted with the public key, as the bridges post", posts()[0].headers.apikey, "anon-key-for-tests");
+  is("and asking for nothing back", posts()[0].headers.Prefer, "return=minimal");
+
+  fresh();
+  r = await call(
+    device({
+      "X-CrossPlay-Report": JSON.stringify({
+        battery_pct: 40,
+        crash: { message: "assert failed: x (reset: panic)", version: "1.12.46", backtrace: "" },
+        ota: { attempted: true, ok: false, error: "too_large", path: "ota" },
+      }),
+    }),
+  );
+  let ev = posted()[0];
+  is("a carried crash and install become three events in one post", [posts().length, ev.length], [1, 3]);
+  is(
+    "the crash is a firmware/crash error on the version that crashed, via the site",
+    ev[1],
+    {
+      service: "firmware",
+      event: "crash",
+      level: "error",
+      device: DEV,
+      version: "1.12.46",
+      board: "x4pro",
+      props: { message: "assert failed: x (reset: panic)", backtrace: "", app: "firmware", via: "site" },
+    },
+  );
+  is(
+    "the failed install is a firmware/update error naming the reason and the path",
+    ev[2],
+    {
+      service: "firmware",
+      event: "update",
+      level: "error",
+      device: DEV,
+      version: "1.12.47",
+      board: "x4pro",
+      props: {
+        attempted: true,
+        ok: false,
+        error: "too_large",
+        path: "ota",
+        app: "firmware",
+        message: "update failed: too_large (ota)",
+      },
+    },
+  );
+
+  fresh();
+  await call(device({ "X-CrossPlay-Report": JSON.stringify({ ota: { attempted: true, ok: true } }) }));
+  ev = posted()[0];
+  is("an install that went well is a firmware/update at level info, no message", [ev[1].level, ev[1].props], [
+    "info",
+    { attempted: true, ok: true, app: "firmware" },
+  ]);
+
+  fresh();
+  r = await call(device({ "X-CrossPlay-Device": "abc" }));
+  is("an id that is not 64 hex is no id: served, not counted", [r.statusCode, posts().length], [200, 0]);
+
+  fresh();
+  await call(device({ "User-Agent": "curl/8.0", "X-CrossPlay-Board": "not a board!" }));
+  ev = posted()[0][0];
+  is("no CrossPlay User-Agent: no version; a board that is not a word: no board", [ev.version, ev.board], [
+    undefined,
+    undefined,
+  ]);
+
+  fresh();
+  await call(device({ "X-CrossPlay-Report": "{" + " ".repeat(1200) + "}" }));
+  ev = posted()[0];
+  is("a report over 1000 bytes is ignored, the device still counted", [ev.length, ev[0].props], [
+    1,
+    { latest: "v1.12.50" },
+  ]);
+
+  fresh();
+  await call(device({ "X-CrossPlay-Report": "not json" }));
+  is("a report that is not JSON is ignored", posted()[0][0].props, { latest: "v1.12.50" });
+
+  fresh();
+  await call(
+    device({
+      "X-CrossPlay-Report": JSON.stringify({ battery_pct: "84", heap_min_kb: true, uptime_h: 3, crash: "boom", ota: [1] }),
+    }),
+  );
+  ev = posted()[0];
+  is("only numbers are health, and a crash or ota that is not an object is nothing", [ev.length, ev[0].props], [
+    1,
+    { uptime_h: 3, latest: "v1.12.50" },
+  ]);
+
+  fresh();
+  github.status = 500;
+  r = await call(device());
+  is("GitHub down with nothing cached: 502, so the device asks GitHub itself", r.statusCode, 502);
+  is(
+    "and the failure is posted as an error naming the status, never the device's report",
+    posted()[0],
+    [
+      {
+        service: "site",
+        event: "update-check",
+        level: "error",
+        device: DEV,
+        version: "1.12.47",
+        board: "x4pro",
+        props: { message: "GitHub answered the update check with HTTP 500", fallback: "the device asks GitHub itself" },
+      },
+    ],
+  );
+
+  fresh();
+  github.throws = true;
+  r = await call(device());
+  is("GitHub unreachable with nothing cached: 502 as well", r.statusCode, 502);
+  is("posted with the cause", posted()[0][0].props.message, "GitHub did not answer the update check: Error");
+
+  fresh();
+  await call(device());
+  await call(device());
+  is("two devices within a minute: one GitHub request, two counts", [githubCalls().length, posts().length], [1, 2]);
+
+  fresh();
+  await call(device());
+  handler._ageCache(61 * 1000);
+  github.status = 304;
+  r = await call(device());
+  is("after a minute GitHub is asked again, conditionally", githubCalls()[1].headers["If-None-Match"], '"abc"');
+  is("and a 304 serves the copy", [r.statusCode, r.body], [200, RELEASE]);
+
+  fresh();
+  await call(device());
+  handler._ageCache(61 * 1000);
+  github.status = 500;
+  r = await call(device());
+  is("GitHub down with a stale copy: the copy is served", [r.statusCode, r.body], [200, RELEASE]);
+
+  fresh();
+  github.body = "<html>rate limited</html>";
+  r = await call(device());
+  is("an answer that is not release JSON is not served", r.statusCode, 502);
+  is("and says so", posted()[0][0].props.message, "GitHub's answer to the update check had no tag_name");
+
+  fresh();
+  board.status = 500;
+  r = await call(device());
+  is("the board refusing the post never costs the device its answer", [r.statusCode, r.body], [200, RELEASE]);
+
+  fresh();
+  r = await call(device(), "POST");
+  is("POST is refused", r.statusCode, 405);
+
+  console.log(`${pass + fail} checks, ${fail} failed`);
+  process.exit(fail ? 1 : 0);
+})();

--- a/host-tests/site/run.sh
+++ b/host-tests/site/run.sh
@@ -201,6 +201,18 @@ else
   while IFS= read -r line; do echo "      $line"; done <<< "$report_out"
 fi
 
+# api/latest.js is where a device's update check becomes a count on the
+# board, and where a bad header must be ignored rather than trusted. Same
+# harness as report_fn.js: node, GitHub and the board stubbed.
+if latest_out="$(node "$HERE/latest_fn.js" "$ROOT" 2>&1)"; then
+  ok
+  n_fail="$(printf '%s\n' "$latest_out" | grep -c '^  FAIL' || true)"
+  [ "$n_fail" -eq 0 ] && ok || { while IFS= read -r line; do bad "latest_fn: $line"; done < <(printf '%s\n' "$latest_out" | grep '^  FAIL'); }
+else
+  bad "latest_fn.js could not run, so api/latest.js went unchecked:"
+  while IFS= read -r line; do echo "      $line"; done <<< "$latest_out"
+fi
+
 # The inbox page looks its controls up by id inside its own file. Same failure
 # as install.js: a renamed id renders fine and does nothing.
 P="$ROOT/site/inbox/index.html"

--- a/site/api/latest.js
+++ b/site/api/latest.js
@@ -1,0 +1,233 @@
+// GET /api/latest
+//
+// The firmware's update check, proxied. A device used to ask GitHub's
+// releases/latest directly, so the one request nearly every device makes was
+// the one nobody could count: a device was seen only when it used Get Books
+// or a bridge. Now it asks here first (src/network/ReleaseSources.h) and
+// this function answers with GitHub's JSON, verbatim, after reading the
+// three device headers and posting the events the bridges post
+// (docs/workflow/events.md, "What each service posts"). GitHub stays the
+// firmware's fallback, so a device never loses OTA to this function.
+//
+// Counting is the point, so every device request runs the function: the
+// answer is never CDN-cached. GitHub's rate limit (60/h per IP without a
+// token, and Vercel's egress IPs are shared) is spared three ways: this
+// instance keeps its last answer for CACHE_MS, asks conditionally so a 304
+// does not count, and sends GITHUB_TOKEN when the deployment has one. When
+// GitHub does not answer, a stale copy is served if there is one, else 502
+// and the device asks GitHub itself.
+//
+// Never a MAC: the device id is the pseudonymous 64-hex the device sends,
+// and a request without one is served and not counted.
+
+const GITHUB =
+  "https://api.github.com/repos/ma-r-s/crossplay/releases/latest";
+const CACHE_MS = 60 * 1000;
+const GITHUB_TIMEOUT_MS = 6000;
+const BOARD_TIMEOUT_MS = 2500;
+// The report header is at most 600 bytes from the firmware; anything past
+// this cap is not a report, whatever it says it is.
+const REPORT_MAX = 1000;
+const HEALTH_KEYS = ["battery_pct", "heap_min_kb", "uptime_h"];
+const HEX64 = /^[0-9a-fA-F]{64}$/;
+const BOARD = /^[a-z0-9]{1,16}$/;
+const UA = /^CrossPlay-ESP32-(\S{1,32})/;
+
+let cached = null; // { at, etag, body, tag }
+// Why the last answer was not GitHub's own: "" when it was, else one line
+// naming the failure, so a 502 can be posted as an error the board turns
+// into a card. Without this a rate-limited egress IP would only ever show
+// as a count that is quietly low.
+let failure = "";
+
+function header(req, name) {
+  const v = (req.headers || {})[name.toLowerCase()];
+  return Array.isArray(v) ? String(v[0] || "") : String(v || "");
+}
+
+function isObject(v) {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+// What one request says about the device that made it, trusting none of it:
+// an id that is not 64 hex is no id, a board that is not a short word is no
+// board, a report over REPORT_MAX bytes or not a JSON object is ignored, and
+// only numbers are copied out of the health fields. The same rules as the
+// bridges' events.py client_of().
+function clientOf(req) {
+  const c = { device: "", board: "", version: "", health: {}, crash: null, ota: null };
+  try {
+    const dev = header(req, "x-crossplay-device").trim();
+    if (HEX64.test(dev)) c.device = dev.toLowerCase();
+    const board = header(req, "x-crossplay-board").trim().toLowerCase();
+    if (BOARD.test(board)) c.board = board;
+    const m = UA.exec(header(req, "user-agent"));
+    if (m) c.version = m[1];
+    const raw = header(req, "x-crossplay-report");
+    if (raw && raw.length <= REPORT_MAX) {
+      let report = null;
+      try {
+        report = JSON.parse(raw);
+      } catch (e) {
+        report = null;
+      }
+      if (isObject(report)) {
+        for (const k of HEALTH_KEYS) {
+          const v = report[k];
+          if (typeof v === "number" && Number.isFinite(v)) c.health[k] = v;
+        }
+        if (isObject(report.crash)) c.crash = report.crash;
+        if (isObject(report.ota)) c.ota = report.ota;
+      }
+    }
+  } catch (e) {
+    // headers ignored; the request is served all the same
+  }
+  return c;
+}
+
+function record(service, event, level, c, version, props) {
+  const r = { service, event, level };
+  if (c.device) r.device = c.device;
+  if (version) r.version = String(version);
+  if (c.board) r.board = c.board;
+  r.props = props;
+  return r;
+}
+
+// The events one counted request posts: the usage event (site/update-check,
+// with the health numbers and the version offered), plus the crash and the
+// install attempt the device is carrying, as firmware events of their own.
+function eventsOf(c, latestTag) {
+  const out = [];
+  const usage = Object.assign({}, c.health);
+  if (latestTag) usage.latest = latestTag;
+  out.push(record("site", "update-check", "info", c, c.version, usage));
+  if (c.crash) {
+    const k = c.crash;
+    out.push(
+      record("firmware", "crash", "error", c, k.version || c.version, {
+        message: String(k.message || ""),
+        backtrace: String(k.backtrace || ""),
+        app: "firmware",
+        via: "site",
+      }),
+    );
+  }
+  if (c.ota) {
+    const o = c.ota;
+    const props = Object.assign({}, o, { app: "firmware" });
+    let level = "info";
+    if (o.ok === false && o.error) {
+      level = "error";
+      props.message = `update failed: ${o.error} (${o.path || "unknown"})`;
+    }
+    out.push(record("firmware", "update", level, c, c.version, props));
+  }
+  return out;
+}
+
+// One POST for all of them, with the public key, as the bridges do. Never
+// throws: the board is where numbers go, never something a device waits on.
+async function post(records) {
+  const url = (process.env.SUPABASE_URL || "").trim().replace(/\/+$/, "");
+  const key = (process.env.SUPABASE_ANON_KEY || "").trim();
+  if (!url || !key || !records.length) return false;
+  try {
+    const r = await fetch(`${url}/rest/v1/events`, {
+      method: "POST",
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+        Prefer: "return=minimal",
+      },
+      body: JSON.stringify(records),
+      signal: AbortSignal.timeout(BOARD_TIMEOUT_MS),
+    });
+    return r.ok;
+  } catch (e) {
+    return false;
+  }
+}
+
+async function latest() {
+  const now = Date.now();
+  if (cached && now - cached.at < CACHE_MS) return cached;
+  const headers = {
+    "User-Agent": "crossplay-site (update check proxy)",
+    Accept: "application/vnd.github+json",
+  };
+  const token = (process.env.GITHUB_TOKEN || "").trim();
+  if (token) headers.Authorization = `Bearer ${token}`;
+  if (cached && cached.etag) headers["If-None-Match"] = cached.etag;
+  let r;
+  try {
+    r = await fetch(GITHUB, { headers, signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS) });
+  } catch (e) {
+    failure = "GitHub did not answer the update check: " + String((e && e.name) || e);
+    return cached;
+  }
+  if (r.status === 304 && cached) {
+    failure = "";
+    cached = Object.assign({}, cached, { at: now });
+    return cached;
+  }
+  if (!r.ok) {
+    failure = `GitHub answered the update check with HTTP ${r.status}`;
+    return cached;
+  }
+  const body = await r.text();
+  let tag = "";
+  try {
+    tag = String(JSON.parse(body).tag_name || "");
+  } catch (e) {
+    tag = "";
+  }
+  if (!tag) {
+    failure = "GitHub's answer to the update check had no tag_name";
+    return cached;
+  }
+  failure = "";
+  cached = { at: now, etag: r.headers.get("etag") || "", body, tag };
+  return cached;
+}
+
+module.exports = async function handler(req, res) {
+  res.setHeader("Content-Type", "application/json");
+  res.setHeader("Cache-Control", "no-store");
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    res.statusCode = 405;
+    res.end(JSON.stringify({ error: "GET only." }));
+    return;
+  }
+  const answer = await latest();
+  const client = clientOf(req);
+  if (!answer) {
+    // Not a 2xx, so the device keeps what it is carrying for the next
+    // request that is one, and asks GitHub itself. The failure is posted as
+    // an error (one fingerprint per cause, so one card with a count): a
+    // device that fell back was not counted, and that must show somewhere.
+    await post([
+      record("site", "update-check", "error", client, client.version, {
+        message: failure || "GitHub did not answer the update check",
+        fallback: "the device asks GitHub itself",
+      }),
+    ]);
+    res.statusCode = 502;
+    res.end(JSON.stringify({ error: "GitHub did not answer; ask it directly." }));
+    return;
+  }
+  if (client.device) await post(eventsOf(client, answer.tag));
+  res.statusCode = 200;
+  res.end(req.method === "HEAD" ? undefined : answer.body);
+};
+
+module.exports.clientOf = clientOf;
+module.exports.eventsOf = eventsOf;
+module.exports._resetCache = function () {
+  cached = null;
+};
+module.exports._ageCache = function (ms) {
+  if (cached) cached.at -= ms;
+};

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -17,6 +17,7 @@
 
 #include "FirmwareBoardTag.h"
 #include "FirmwareFlasher.h"
+#include "ReleaseSources.h"
 
 namespace {
 // This fork's releases, not upstream's. Left pointing at CrossPoint, "check for
@@ -25,7 +26,6 @@ namespace {
 // the X4 and X3, which are ESP32-C3; this fork's devices (X4 Pro, Sticky) are
 // S3. Upstream added a guard against exactly that (crosspoint-reader#2880),
 // which says how it ends without one.
-constexpr char latestReleaseUrl[] = "https://api.github.com/repos/ma-r-s/crossplay/releases/latest";
 }  // namespace
 
 OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
@@ -36,7 +36,12 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   // on top of the TLS session's heap during the fetch; with -fno-exceptions an
   // OOM there aborts. fetchUrl handles the verified-https GET, redirects, and
   // User-Agent (see HttpDownloader).
-  ReleaseJsonParser releaseParser;
+  //
+  // Sources in order: the site, which counts the device and answers with
+  // GitHub's JSON verbatim, then GitHub itself when the site does not answer
+  // or answers nothing with a tag in it (ReleaseSources.h says why). One
+  // parser per attempt: a half-fed parser is not reset by feeding it more.
+  //
   // FORK CHANGE: upstream suffixes the asset per board (firmware-x4pro.bin)
   // because one release feeds many devices. This fork's x4pro asks for the
   // literal "firmware.bin": every unit in the field since v1.0.0 asks for
@@ -47,30 +52,51 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   // one; CROSSPOINT_RELEASE_ASSET in FirmwareBoardTag.h encodes both rules,
   // and host-tests/release pins the workflow to whatever each device asks
   // for.
-  releaseParser.setFirmwareAssetName(CROSSPOINT_RELEASE_ASSET);
-  const bool ok = HttpDownloader::fetchUrl(latestReleaseUrl, [&releaseParser](const uint8_t* data, size_t len) {
-    releaseParser.feed(reinterpret_cast<const char*>(data), len);
-    return true;
-  });
-  if (!ok) {
+  bool fetched = false;
+  bool tagged = false;
+  bool hasFirmware = false;
+  std::string tag;
+  std::string firmwareUrl;
+  size_t firmwareSize = 0;
+  for (const char* source : release_sources::kUrls) {
+    ReleaseJsonParser parser;
+    parser.setFirmwareAssetName(CROSSPOINT_RELEASE_ASSET);
+    const bool ok = HttpDownloader::fetchUrl(source, [&parser](const uint8_t* data, size_t len) {
+      parser.feed(reinterpret_cast<const char*>(data), len);
+      return true;
+    });
+    if (!ok) {
+      LOG_INF("OTA", "Release check via %s failed; next source", source);
+      continue;
+    }
+    fetched = true;
+    LOG_DBG("OTA", "Parser results from %s: tag=%s firmware=%s", source, parser.foundTag() ? "yes" : "no",
+            parser.foundFirmware() ? "yes" : "no");
+    if (!parser.foundTag()) {
+      LOG_INF("OTA", "No tag_name from %s; next source", source);
+      continue;
+    }
+    tagged = true;
+    hasFirmware = parser.foundFirmware();
+    tag = parser.getTagName();
+    firmwareUrl = parser.getFirmwareUrl();
+    firmwareSize = parser.getFirmwareSize();
+    break;
+  }
+  if (!fetched) {
     LOG_ERR("OTA", "Release check fetch failed");
     return HTTP_ERROR;
   }
-
-  LOG_DBG("OTA", "Parser results: tag=%s firmware=%s", releaseParser.foundTag() ? "yes" : "no",
-          releaseParser.foundFirmware() ? "yes" : "no");
-
-  if (!releaseParser.foundTag()) {
+  if (!tagged) {
     LOG_ERR("OTA", "No tag_name in release JSON");
     return JSON_PARSE_ERROR;
   }
-
-  if (!releaseParser.foundFirmware()) {
+  if (!hasFirmware) {
     LOG_INF("OTA", "No " CROSSPOINT_RELEASE_ASSET " asset in latest release");
     return NO_UPDATE;
   }
 
-  latestVersion = releaseParser.getTagName();
+  latestVersion = tag;
   // Tags carry a v prefix ("v1.3.3"); CROSSPOINT_VERSION does not ("1.3.3").
   // Comparing them raw meant isUpdateNewer()'s sscanf choked on the 'v' and
   // compared uninitialized ints -- every install since v1.0.0 rode on that
@@ -79,8 +105,8 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   if (!latestVersion.empty() && (latestVersion[0] == 'v' || latestVersion[0] == 'V')) {
     latestVersion.erase(0, 1);
   }
-  otaUrl = releaseParser.getFirmwareUrl();
-  otaSize = releaseParser.getFirmwareSize();
+  otaUrl = firmwareUrl;
+  otaSize = firmwareSize;
   totalSize = otaSize;
   updateAvailable = true;
 

--- a/src/network/ReleaseSources.h
+++ b/src/network/ReleaseSources.h
@@ -1,0 +1,27 @@
+#pragma once
+
+// Where the update check asks for the latest release, in the order it asks.
+//
+// The device used to ask GitHub's releases/latest directly, so the one
+// request nearly every device makes was the one nobody could count: a device
+// was seen on the board only when it used Get Books or a bridge. The site's
+// /api/latest answers with GitHub's JSON verbatim, and because its host is
+// ours the request carries the three device headers (DeviceReport.h) and the
+// site posts the events the bridges post (docs/workflow/events.md). GitHub
+// itself comes second: when the site does not answer, or answers nothing
+// with a tag_name in it, the check goes on exactly as it did before, so no
+// device loses OTA to the site, its certificate or its rate limit. Old
+// firmware keeps asking GitHub until it updates once.
+//
+// A pure header, so host-tests/devreport can pin the two facts that matter:
+// the first source is one the device reports to, the second is not.
+
+namespace release_sources {
+
+constexpr const char* const kUrls[] = {
+    "https://crossplay.ma-r-s.com/api/latest",
+    "https://api.github.com/repos/ma-r-s/crossplay/releases/latest",
+};
+constexpr int kCount = static_cast<int>(sizeof(kUrls) / sizeof(kUrls[0]));
+
+}  // namespace release_sources


### PR DESCRIPTION
Card 449, Mario's yes on 2026-09-08. A device was counted on the board only when it used Get Books or a bridge; the update check went straight to GitHub and was never seen.

- **Firmware:** `src/network/ReleaseSources.h` lists the site's `/api/latest` first and GitHub's `releases/latest` second. `OtaUpdater::checkForUpdate` tries each with a fresh parser and stops at the first answer with a tag. The site's host is ours, so the request carries the three device headers; GitHub's does not, as before. Old firmware keeps asking GitHub until it updates once.
- **Site:** `api/latest.js` proxies GitHub's JSON verbatim, reads the headers by the bridges' rules, posts `site/update-check` (plus the carried crash and install as firmware events) with the public key, only for a valid device id. Never CDN-cached; a 60 s per-instance copy and conditional requests spare GitHub's limit, `GITHUB_TOKEN` is used when the deployment has one (it has none today). GitHub down: stale copy, else 502 and an error event, so a device that fell back is never silently uncounted.
- **Tests:** `host-tests/site/latest_fn.js` (30 checks), `host-tests/devreport` pins the two sources (417). Gate green, simulator + x4pro + sticky built.
- **Docs:** `docs/workflow/events.md`.

Not verified: no device ran the new check (the site fetch goes through the same `setInsecure()` path GitHub's does, so no new certificate is trusted). The function itself ran only under node with GitHub and the board stubbed; once this deploys, a browser hit on `https://crossplay.ma-r-s.com/api/latest` should return the release JSON and post nothing, and the first device on the release should appear as a `site`/`update-check` row.