### PR TITLE
Inbox: one plain number for devices using CrossPlay, not a per-version sum

### DIFF
--- a/docs/workflow/events.md
+++ b/docs/workflow/events.md
@@ -159,8 +159,12 @@ Each service says `device report via <service>: crash on <version>` or
 
 ## Reading the numbers
 
-Signed-in users (the inbox page) read five views over the events that carry
-a device: `devices_by_version` (distinct devices per board and version, over
+Signed-in users (the inbox page) read six views over the events that carry
+a device: `devices_heard_from` (the headline, one row: distinct devices in
+the last 24 hours, 7, 30 and 90 days; 90 is all the raw rows the board
+keeps, and a per-version table summed over its rows is NOT this number,
+since a device that updated inside the window sits in two rows),
+`devices_by_version` (distinct devices per board and version, over
 every event with a device and a version in the last 7 days),
 `daily_active_devices` (distinct devices per day, 30 days),
 `battery_by_version` (board, version, the average `battery_pct` of the

--- a/host-tests/site/inbox_fn.js
+++ b/host-tests/site/inbox_fn.js
@@ -195,6 +195,7 @@ const expect = (label, got, want) =>
   r = await call({ pass: "open sesame", op: "numbers" });
   expect("numbers answers", r.status, 200);
   [
+    "devices_heard_from",
     "devices_by_version",
     "daily_active_devices",
     "battery_by_version",

--- a/server/board/supabase/migrations/20260910000100_devices_heard_from.sql
+++ b/server/board/supabase/migrations/20260910000100_devices_heard_from.sql
@@ -1,0 +1,17 @@
+-- One plain number for "how many devices use CrossPlay": distinct devices
+-- heard from in each window, over every event that carries a device (a
+-- service used, an update checked). Mario, 2026-09-10: the inbox showed a
+-- SUM over devices_by_version, which counts a device once per version it
+-- ran inside the window (57 shown, 51 real), beside GitHub's download
+-- counts, and he could not tell how many devices there were. The longest
+-- window is 90 days because the rollup deletes raw rows past that, and
+-- events_rollup keeps distinct devices per day, which cannot be summed
+-- across days.
+create or replace view devices_heard_from as
+  select count(distinct device) filter (where at > now() - interval '1 day') as h24,
+         count(distinct device) filter (where at > now() - interval '7 days') as d7,
+         count(distinct device) filter (where at > now() - interval '30 days') as d30,
+         count(distinct device) as d90
+  from events
+  where device is not null and device <> '' and at > now() - interval '90 days';
+alter view devices_heard_from set (security_invoker = true);

--- a/site/api/inbox.js
+++ b/site/api/inbox.js
@@ -12,7 +12,7 @@
 // Operations:
 //   list     -> {inbox: [open blockers that need Mario, with their card], cards: [every card],
 //                triage: {waiting, claimed, for_mario, oldest_h, last_triaged_at, since_triage_h} or null}
-//   numbers  -> {byVersion, daily, battery, services, errors, pulse, weekly, dwell, latency, byApp}
+//   numbers  -> {heard, byVersion, daily, battery, services, errors, pulse, weekly, dwell, latency, byApp}
 //   answer   -> closes one blocker: {card_id, n, choice, note}
 
 const crypto = require("node:crypto");
@@ -87,6 +87,7 @@ async function opList() {
 async function opNumbers() {
   const q = (p) => rest(p).catch(() => []);
   const [
+    heard,
     byVersion,
     daily,
     battery,
@@ -98,6 +99,8 @@ async function opNumbers() {
     latency,
     byApp,
   ] = await Promise.all([
+    // The headline: distinct devices heard from, per window. One row.
+    q("devices_heard_from?select=*"),
     q("devices_by_version?select=*"),
     q("daily_active_devices?select=*"),
     q("battery_by_version?select=*"),
@@ -112,6 +115,7 @@ async function opNumbers() {
     q("open_cards_by_app?select=*"),
   ]);
   return {
+    heard: (heard || [])[0] || null,
     byVersion,
     daily,
     battery,

--- a/site/inbox/fixture.json
+++ b/site/inbox/fixture.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Dev-only fixture for site/inbox/. serve.py answers POST /api/inbox from this file when INBOX_FIXTURE names it, whatever the passphrase. Shapes follow api/inbox.js: list -> {inbox, cards}, numbers -> the nine views. Production never reads it.",
+  "_comment": "Dev-only fixture for site/inbox/. serve.py answers POST /api/inbox from this file when INBOX_FIXTURE names it, whatever the passphrase. Shapes follow api/inbox.js: list -> {inbox, cards}, numbers -> the ten views. Production never reads it.",
   "list": {
     "inbox": [
       {
@@ -377,6 +377,7 @@
     }
   },
   "numbers": {
+    "heard": { "h24": 9, "d7": 41, "d30": 51, "d90": 51 },
     "byVersion": [
       {
         "board": "sticky",

--- a/site/inbox/index.html
+++ b/site/inbox/index.html
@@ -149,7 +149,7 @@
     <ul class="all" id="inbox-all"></ul>
   </details>
 
-  <details id="inbox-numbers" hidden>
+  <details id="inbox-numbers" hidden open>
     <summary>Numbers <small id="inbox-numbers-note">last 7 days</small></summary>
     <div id="inbox-numbers-body"></div>
   </details>
@@ -311,19 +311,26 @@
       fetch("https://api.github.com/repos/ma-r-s/crossplay/releases?per_page=10").then(function (r) { return r.ok ? r.json() : []; }).catch(function () { return []; })
     ]).then(function (res) {
       var n = res[0], releases = res[1];
-      var devices7 = (n.byVersion || []).reduce(function (a, r) { return a + (r.devices || 0); }, 0);
-      var today = (n.daily || []).length ? n.daily[0].devices : 0;
+      // The headline is DISTINCT devices per window, from one view. It used
+      // to be a sum over the by-version table, which counts a device once
+      // per version it ran inside the window (57 shown, 51 real), and Mario
+      // could not tell how many devices there were.
+      var heard = n.heard || {};
+      var count = function (v) { return v == null ? "?" : v; };
       var h = '<div class="num-grid">' +
-        '<div class="tile"><b>' + devices7 + '</b><span>devices that used a service, 7 days</span></div>' +
-        '<div class="tile"><b>' + today + '</b><span>devices today</span></div>' +
+        '<div class="tile"><b>' + count(heard.d7) + '</b><span>devices using CrossPlay, 7 days</span></div>' +
+        '<div class="tile"><b>' + count(heard.d30) + '</b><span>devices, 30 days</span></div>' +
+        '<div class="tile"><b>' + count(heard.h24) + '</b><span>devices, last 24 hours</span></div>' +
+        '<div class="tile"><b>' + count(heard.d90) + '</b><span>devices, 90 days (all the board keeps)</span></div>' +
         '<div class="tile"><b>' + (n.errors || []).filter(function (e) { return e.card_id; }).length + '</b><span>distinct errors with a card</span></div>' +
-        '</div>';
+        '</div>' +
+        '<p class="status">A device is counted when it uses a service or checks for an update. One that only reads is never heard from, so this is a floor, not a ceiling.</p>';
       var L = n.latency || null;
       h += '<div class="num-cols">';
       h += block("Devices by version, 7 days", ["board", "version", "devices"], (n.byVersion || []).map(function (r) { return [r.board, r.version, r.devices]; }));
       h += block("Battery by version, 7 days", ["board", "version", "avg %", "devices"], (n.battery || []).map(function (r) { return [r.board, r.version, r.battery_pct, r.devices]; }));
       h += block("Who uses each service, 7 days", ["service", "devices", "events"], (n.services || []).map(function (r) { return [r.service, r.devices_7d, r.events_7d]; }));
-      h += block("Downloads per release, from GitHub, all time", ["release", "published", "downloads"], releases.map(function (r) {
+      h += block("Downloads per release, from GitHub, all time (not users: scanners and CI download too)", ["release", "published", "downloads"], releases.map(function (r) {
         var d = (r.assets || []).filter(function (a) { return /firmware(-sticky)?\.bin$|-full\.bin$/.test(a.name); }).reduce(function (a, x) { return a + (x.download_count || 0); }, 0);
         return [r.tag_name, (r.published_at || "").slice(0, 10), d];
       }));


### PR DESCRIPTION
Card 462. The board already counts devices (51 distinct in the last 7 days, 15 through the update check live since the 8th), but the inbox showed a sum over `devices_by_version` (a device on two versions inside the window counts twice: 57 shown, 51 real), labelled "used a service", inside a collapsed block above GitHub's download table.

- `devices_heard_from` view: distinct devices in the last 24 h, 7, 30, 90 days. Already applied to the board (`migrate.sh`, 22 applied), so the page finds it the moment this deploys.
- `api/inbox.js` returns it as `numbers.heard`; the inbox opens Numbers by default and leads with "devices using CrossPlay, 7 days" plus the other windows, with one line saying what counts and that it is a floor.
- Download table retitled: not users, scanners and CI download too.
- `host-tests/site`: inbox_fn expects the view, fixture carries it; 232 checks green.

Not verified: the signed-in page on the real deployment (needs the passphrase); the numbers op was checked under node with the board stubbed, and the view's SELECT against the live board returns h24=15, d7=51, d30=51, d90=51.