### PR TITLE
Inbox: the owner's facts first; the workshop's numbers and the cards fold away

### DIFF
--- a/docs/workflow/events.md
+++ b/docs/workflow/events.md
@@ -159,16 +159,27 @@ Each service says `device report via <service>: crash on <version>` or
 
 ## Reading the numbers
 
-Signed-in users (the inbox page) read five views over the events that carry
-a device: `devices_by_version` (distinct devices per board and version, over
+Signed-in users (the inbox page) lead with the owner's facts, one view
+each (`20260910000200_owner_views.sql`): `devices_heard_from` (distinct
+devices in the last 24 hours, 7, 30 and 90 days, one row), `devices_new`
+(first heard this week and the week before), `devices_now` (every device
+once, at the version it last reported, with when it arrived there; 30
+days), `versions_now` (the same devices grouped, so the table's sum IS the
+device count), `field_7d` (devices that crashed, failed an install, or
+installed fine) and `crashes_7d` (panics by reason, devices first). A
+per-version table summed over its rows is NOT a device count: a device
+that updated inside the window sits in two rows, and the page showed that
+sum until 2026-09-10. Under the fold, the workshop's views:
+`devices_by_version` (distinct devices per board and version, over
 every event with a device and a version in the last 7 days),
 `daily_active_devices` (distinct devices per day, 30 days),
 `battery_by_version` (board, version, the average `battery_pct` of the
 events a device carried, averaged per device first so a reader that syncs
 ten times a day weighs the same as one that syncs once, with the device and
 report counts beside it, 7 days), `events_daily` (30 days, by service and
-event), `service_users` (7 days). The inbox page shows them under "Numbers",
-next to GitHub's own download counts per release.
+event), `service_users` (7 days). The inbox page shows them under "The
+workshop". GitHub's download counts are not on the page: they are not
+users (eleven releases cut in one day each got 6 to 16).
 
 A device is counted when it uses a service, and since the release that
 carried card 449 when it checks for an update (Settings > Update, the one request nearly every

--- a/host-tests/site/inbox_fn.js
+++ b/host-tests/site/inbox_fn.js
@@ -43,6 +43,26 @@ global.fetch = async function (url, opts) {
       ]),
       { status: 200 },
     );
+  if (u.includes("/rest/v1/cards") && u.includes("source=eq.site"))
+    return new Response(
+      JSON.stringify([
+        {
+          id: 9,
+          title: "Backlight?",
+          app: "unknown",
+          state: "reported",
+          device: "x4pro",
+          version: "1.12.50",
+          reporter: "user",
+          reporter_email: "someone@example.test",
+          photo_path: "reports/9.jpg",
+          created_at: "2026-09-10T18:00:00Z",
+        },
+      ]),
+      { status: 200 },
+    );
+  if (u.includes("/storage/v1/object/sign/reports/9.jpg") && opts.method === "POST")
+    return new Response(JSON.stringify({ signedURL: "/object/sign/reports/9.jpg?token=abc" }), { status: 200 });
   if (u.includes("/rest/v1/cards"))
     return new Response(
       JSON.stringify([
@@ -130,6 +150,13 @@ const expect = (label, got, want) =>
     1,
   );
   expect("and every card", r.json && r.json.cards && r.json.cards.length, 1);
+  expect("and what people wrote in the box, apart from the cards", r.json && r.json.reports && r.json.reports.length, 1);
+  expect("with who sent it", r.json.reports[0].reporter_email, "someone@example.test");
+  expect(
+    "and a link to the photo, signed here so the key stays here",
+    r.json.reports[0].photo_url,
+    process.env.SUPABASE_URL.replace(/\/+$/, "") + "/storage/v1/object/sign/reports/9.jpg?token=abc",
+  );
 
   calls = [];
   r = await call({
@@ -195,6 +222,12 @@ const expect = (label, got, want) =>
   r = await call({ pass: "open sesame", op: "numbers" });
   expect("numbers answers", r.status, 200);
   [
+    "devices_heard_from",
+    "devices_new",
+    "versions_now",
+    "devices_now",
+    "field_7d",
+    "crashes_7d",
     "devices_by_version",
     "daily_active_devices",
     "battery_by_version",

--- a/server/board/supabase/migrations/20260910000100_devices_heard_from.sql
+++ b/server/board/supabase/migrations/20260910000100_devices_heard_from.sql
@@ -1,0 +1,17 @@
+-- One plain number for "how many devices use CrossPlay": distinct devices
+-- heard from in each window, over every event that carries a device (a
+-- service used, an update checked). Mario, 2026-09-10: the inbox showed a
+-- SUM over devices_by_version, which counts a device once per version it
+-- ran inside the window (57 shown, 51 real), beside GitHub's download
+-- counts, and he could not tell how many devices there were. The longest
+-- window is 90 days because the rollup deletes raw rows past that, and
+-- events_rollup keeps distinct devices per day, which cannot be summed
+-- across days.
+create or replace view devices_heard_from as
+  select count(distinct device) filter (where at > now() - interval '1 day') as h24,
+         count(distinct device) filter (where at > now() - interval '7 days') as d7,
+         count(distinct device) filter (where at > now() - interval '30 days') as d30,
+         count(distinct device) as d90
+  from events
+  where device is not null and device <> '' and at > now() - interval '90 days';
+alter view devices_heard_from set (security_invoker = true);

--- a/server/board/supabase/migrations/20260910000200_owner_views.sql
+++ b/server/board/supabase/migrations/20260910000200_owner_views.sql
@@ -1,0 +1,68 @@
+-- The owner's facts, one view each, so the inbox page can lead with them.
+-- Mario, 2026-09-10: the page showed everything about the workshop and
+-- nothing he cared about. What an owner wants: how many devices, what
+-- they run right now with each device counted ONCE (devices_by_version
+-- counts a device once per version it ran inside the window), whether
+-- they crash, and who wrote in.
+
+-- Each device once, at the version it last reported, over the devices
+-- heard from in the last 30 days. since = when it arrived on that version
+-- (the first event on it after the last event on any other version).
+create or replace view devices_now as
+  with latest as (
+    select distinct on (device) device, board, version, at as last_seen
+    from events
+    where device is not null and device <> '' and version is not null
+      and at > now() - interval '30 days'
+    order by device, at desc),
+  spans as (
+    select device, min(at) as first_seen, count(distinct version) as versions_run
+    from events where device is not null and device <> '' group by 1)
+  select l.device, coalesce(l.board, 'unknown') as board, l.version,
+         (select min(e.at) from events e
+           where e.device = l.device and e.version = l.version
+             and e.at > coalesce((select max(x.at) from events x
+                                   where x.device = l.device and x.version is not null and x.version <> l.version),
+                                 '1970-01-01'::timestamptz)) as since,
+         p.first_seen, l.last_seen, p.versions_run
+  from latest l join spans p using (device)
+  order by l.last_seen desc;
+alter view devices_now set (security_invoker = true);
+
+-- What the field runs right now: the same devices, grouped. The sum of
+-- this table IS the number of devices.
+create or replace view versions_now as
+  select version, board, count(*) as devices
+  from devices_now group by 1, 2 order by 3 desc, 1 desc, 2;
+alter view versions_now set (security_invoker = true);
+
+-- Is the firmware hurting anyone this week: devices that reported a panic,
+-- devices whose install failed, devices whose install went through.
+create or replace view field_7d as
+  select count(distinct device) filter (where event = 'crash') as crashed,
+         count(distinct device) filter (where event = 'update' and level = 'error') as update_failed,
+         count(distinct device) filter (where event = 'update' and level = 'info') as updated
+  from events
+  where service = 'firmware' and device is not null and device <> '' and at > now() - interval '7 days';
+alter view field_7d set (security_invoker = true);
+
+-- The panics themselves, by reason, devices first: one device crashing ten
+-- times is one device.
+create or replace view crashes_7d as
+  select coalesce(props->>'message', '(no reason recorded)') as message,
+         count(distinct device) as devices, count(*) as times, max(at) as last
+  from events
+  where service = 'firmware' and event = 'crash' and at > now() - interval '7 days'
+  group by 1 order by 2 desc, 3 desc limit 10;
+alter view crashes_7d set (security_invoker = true);
+
+-- Growth: devices first heard from this week and the week before. Read
+-- with card 463 in mind: before it, every USB reinstall was a "new" device.
+create or replace view devices_new as
+  with f as (select device, min(at) as first_seen from events
+             where device is not null and device <> '' group by 1)
+  select count(*) filter (where first_seen > now() - interval '7 days') as this_week,
+         count(*) filter (where first_seen <= now() - interval '7 days'
+                            and first_seen > now() - interval '14 days') as last_week
+  from f;
+alter view devices_new set (security_invoker = true);

--- a/site/api/inbox.js
+++ b/site/api/inbox.js
@@ -12,7 +12,7 @@
 // Operations:
 //   list     -> {inbox: [open blockers that need Mario, with their card], cards: [every card],
 //                triage: {waiting, claimed, for_mario, oldest_h, last_triaged_at, since_triage_h} or null}
-//   numbers  -> {byVersion, daily, battery, services, errors, pulse, weekly, dwell, latency, byApp}
+//   numbers  -> {heard, fresh, now, devices, field, crashes, byVersion, daily, battery, services, errors, pulse, weekly, dwell, latency, byApp}
 //   answer   -> closes one blocker: {card_id, n, choice, note}
 
 const crypto = require("node:crypto");
@@ -72,21 +72,65 @@ async function rest(path, init) {
   return text ? JSON.parse(text) : null;
 }
 
+// A photo lives in the board's private bucket. A link the browser can open
+// is a signed URL, good for an hour, made here with the service key so the
+// key never reaches the page. No link when the bucket will not sign.
+async function photoUrl(path) {
+  try {
+    const r = await fetch(`${SUPABASE_URL}/storage/v1/object/sign/${path}`, {
+      method: "POST",
+      headers: {
+        apikey: SERVICE_KEY,
+        Authorization: `Bearer ${SERVICE_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ expiresIn: 3600 }),
+    });
+    if (!r.ok) return null;
+    const j = await r.json();
+    return j && j.signedURL ? `${SUPABASE_URL}/storage/v1${j.signedURL}` : null;
+  } catch (e) {
+    return null;
+  }
+}
+
 async function opList() {
-  const [inbox, cards, triage] = await Promise.all([
+  const [inbox, cards, triage, reports] = await Promise.all([
     rest("inbox?select=*"),
     rest("cards?select=id,title,app,state,parent,updated_at&order=id.desc"),
     // How far behind triage is, for one line at the top of the page. A board
     // without the view (or a failing read) leaves the line out; the inbox
     // itself must not depend on it.
     rest("triage_backlog?select=*").catch(() => []),
+    // What people wrote in the box on the site, latest first, with who sent
+    // it. Mario, 2026-09-10: these are cards like any other on the board,
+    // which is how they got buried between every other card.
+    rest(
+      "cards?select=id,title,app,state,device,version,reporter,reporter_email,photo_path,created_at&source=eq.site&order=created_at.desc&limit=50",
+    ).catch(() => []),
   ]);
-  return { inbox: inbox || [], cards: cards || [], triage: (triage || [])[0] || null };
+  const withPhotos = await Promise.all(
+    (reports || []).map(async (c) =>
+      Object.assign({}, c, { photo_url: c.photo_path ? await photoUrl(c.photo_path) : null }),
+    ),
+  );
+  return {
+    inbox: inbox || [],
+    cards: cards || [],
+    triage: (triage || [])[0] || null,
+    reports: withPhotos,
+  };
 }
 
 async function opNumbers() {
   const q = (p) => rest(p).catch(() => []);
   const [
+    heard,
+    fresh,
+    now,
+    devices,
+    field,
+    crashes,
     byVersion,
     daily,
     battery,
@@ -98,6 +142,15 @@ async function opNumbers() {
     latency,
     byApp,
   ] = await Promise.all([
+    // The owner's facts first (20260910000200_owner_views.sql): distinct
+    // devices per window, growth, what runs right now with each device once,
+    // every device once, and whether the firmware hurt anyone this week.
+    q("devices_heard_from?select=*"),
+    q("devices_new?select=*"),
+    q("versions_now?select=*"),
+    q("devices_now?select=*"),
+    q("field_7d?select=*"),
+    q("crashes_7d?select=*"),
     q("devices_by_version?select=*"),
     q("daily_active_devices?select=*"),
     q("battery_by_version?select=*"),
@@ -112,6 +165,12 @@ async function opNumbers() {
     q("open_cards_by_app?select=*"),
   ]);
   return {
+    heard: (heard || [])[0] || null,
+    fresh: (fresh || [])[0] || null,
+    now,
+    devices,
+    field: (field || [])[0] || null,
+    crashes,
     byVersion,
     daily,
     battery,

--- a/site/inbox/fixture.json
+++ b/site/inbox/fixture.json
@@ -1,6 +1,34 @@
 {
-  "_comment": "Dev-only fixture for site/inbox/. serve.py answers POST /api/inbox from this file when INBOX_FIXTURE names it, whatever the passphrase. Shapes follow api/inbox.js: list -> {inbox, cards}, numbers -> the nine views. Production never reads it.",
+  "_comment": "Dev-only fixture for site/inbox/. serve.py answers POST /api/inbox from this file when INBOX_FIXTURE names it, whatever the passphrase. Shapes follow api/inbox.js: list -> {inbox, cards}, numbers -> the views the page reads. Production never reads it.",
   "list": {
+    "reports": [
+      {
+        "id": 460,
+        "title": "hi i love the efforts on the crossplay its super cool",
+        "app": "unknown",
+        "state": "reported",
+        "device": "x4pro",
+        "version": "",
+        "reporter": "user",
+        "reporter_email": "reader@example.test",
+        "photo_path": null,
+        "photo_url": null,
+        "created_at": "2026-09-10T18:02:00Z"
+      },
+      {
+        "id": 434,
+        "title": "I can't find backlight setting in Crossplay",
+        "app": "unknown",
+        "state": "reported",
+        "device": "x4pro",
+        "version": "1.12.48",
+        "reporter": "user",
+        "reporter_email": "",
+        "photo_path": "reports/434.jpg",
+        "photo_url": "https://example.test/storage/v1/object/sign/reports/434.jpg?token=fixture",
+        "created_at": "2026-09-07T09:10:00Z"
+      }
+    ],
     "inbox": [
       {
         "blocker_id": 41,
@@ -377,6 +405,22 @@
     }
   },
   "numbers": {
+    "heard": { "h24": 15, "d7": 51, "d30": 51, "d90": 51 },
+    "fresh": { "this_week": 9, "last_week": 6 },
+    "now": [
+      { "version": "1.12.50", "board": "x4pro", "devices": 21 },
+      { "version": "1.12.48", "board": "x4pro", "devices": 6 },
+      { "version": "1.12.50", "board": "sticky", "devices": 5 }
+    ],
+    "devices": [
+      { "device": "a2c219f7e1c9a0b4d8f2c6e3b7a1d5f9c0e4b8a2d6f0c4e8b2a6d0f4c8e2b6a0", "board": "sticky", "version": "1.12.50", "since": "2026-09-11T01:54:00Z", "first_seen": "2026-09-11T01:54:00Z", "last_seen": "2026-09-11T02:30:00Z", "versions_run": 1 },
+      { "device": "d42c28cb0e5a9f3b7c1d6e2a8f4b0c9d5e1a7f3b9c5d1e7a3f9b5c1d7e3a9f5b", "board": "x4pro", "version": "1.12.50", "since": "2026-09-09T23:24:00Z", "first_seen": "2026-09-04T23:19:00Z", "last_seen": "2026-09-10T21:00:00Z", "versions_run": 4 }
+    ],
+    "field": { "crashed": 18, "update_failed": 1, "updated": 15 },
+    "crashes": [
+      { "message": "panic without a recorded reason (reset: panic; last log: XKCD)", "devices": 10, "times": 10, "last": "2026-09-10T20:00:00Z" },
+      { "message": "abort() was called at PC 0x4037e6eb on core 0 (reset: panic)", "devices": 1, "times": 1, "last": "2026-09-09T11:00:00Z" }
+    ],
     "byVersion": [
       {
         "board": "sticky",

--- a/site/inbox/index.html
+++ b/site/inbox/index.html
@@ -83,6 +83,18 @@
   table.nums td.n, table.nums th.n { text-align: right; }
   table.nums td:first-child { white-space: nowrap; } /* a week or a version never breaks at its hyphen; the box scrolls instead */
   .nums-h { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin: 0.9rem 0 0.2rem; }
+  /* The owner's sections: a heading per fact, the workshop's tiles and
+     tables reused underneath. */
+  .sec { font-family: var(--display); font-weight: 400; font-size: 1.7rem; line-height: 1.1; margin: 2rem 0 0.2rem; padding-top: 0.8rem; border-top: 1px solid var(--edge); }
+  .sec small { font-family: var(--mono); font-size: 0.75rem; letter-spacing: 0.04em; color: var(--muted); margin-left: 0.6rem; }
+  .owner details { margin-top: 0.6rem; border-top: 0; padding-top: 0; }
+  .owner summary { font-weight: 400; font-size: 0.95rem; color: var(--muted); }
+  .rep { display: flex; gap: 0.8rem; align-items: baseline; padding: 0.55rem 0; border-bottom: 1px solid var(--edge); font-size: 0.95rem; }
+  .rep .t { flex: 1; min-width: 0; }
+  .rep .who { display: block; font-family: var(--mono); font-size: 0.75rem; color: var(--muted); margin-top: 0.15rem; }
+  .rep .when { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); white-space: nowrap; }
+  .st { font-family: var(--mono); font-size: 0.72rem; letter-spacing: 0.05em; text-transform: uppercase; color: var(--muted); min-width: 5.5rem; }
+  .st.released, .st.done { color: var(--ink); }
   .foot { margin-top: 2rem; font-size: 0.85rem; color: var(--muted); display: flex; justify-content: space-between; gap: 1rem; }
 
   /* Desktop, from 900px. The ask stays one centred column, because a message
@@ -116,6 +128,8 @@
     .tile { padding: 1rem 1.2rem; }
     .tile b { font-size: 2.8rem; }
     .tile span { font-size: 0.9rem; }
+    .owner .num-grid { grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr)); }
+    .sec { font-size: 2.2rem; margin-top: 2.8rem; padding-top: 1rem; }
     .num-cols { display: grid; grid-template-columns: 1fr 1fr; column-gap: 3rem; align-items: start; }
     .num-block.wide { grid-column: 1 / -1; }
     table.nums { font-size: 0.95rem; }
@@ -144,13 +158,27 @@
   <div id="inbox-view" class="col"></div>
   <p class="status col" id="inbox-status" role="status" aria-live="polite"></p>
 
+  <!-- The owner's facts, in the order an owner asks them. Mario, 2026-09-10:
+       "if you owned this firmware, what data would you like to see?" How many
+       devices, honestly; what they run right now, each device once; whether
+       the firmware is hurting anyone; what people wrote in. The workshop's
+       own numbers and the card list fold away below. -->
+  <section class="owner" id="inbox-owner" hidden>
+    <h2 class="sec">Devices <small>each counted once</small></h2>
+    <div id="owner-devices"><p class="status">Counting...</p></div>
+    <h2 class="sec">In the field <small>last 7 days</small></h2>
+    <div id="owner-field"></div>
+    <h2 class="sec">From people <small id="owner-reports-count"></small></h2>
+    <div id="owner-reports"></div>
+  </section>
+
   <details id="inbox-everything" hidden>
     <summary>Everything <small id="inbox-all-count"></small></summary>
     <ul class="all" id="inbox-all"></ul>
   </details>
 
   <details id="inbox-numbers" hidden>
-    <summary>Numbers <small id="inbox-numbers-note">last 7 days</small></summary>
+    <summary>The workshop <small id="inbox-numbers-note">sessions, services and cards, last 7 days</small></summary>
     <div id="inbox-numbers-body"></div>
   </details>
 
@@ -162,7 +190,7 @@
   "use strict";
   var $ = function (id) { return document.getElementById(id); };
   var KEY = "crossplay-inbox-pass";
-  var pass = null, later = {}, items = [], all = [];
+  var pass = null, later = {}, items = [], all = [], reports = [];
 
   function say(text, err) { var s = $("inbox-status"); s.textContent = text || ""; s.className = "status" + (err ? " err" : ""); }
   function esc(s) { return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) { return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]; }); }
@@ -186,11 +214,12 @@
   function load() {
     say("Loading...");
     return api("list").then(function (res) {
-      items = res.inbox || []; all = res.cards || [];
+      items = res.inbox || []; all = res.cards || []; reports = res.reports || [];
       $("inbox-login").hidden = true;
       say("");
       render();
       triage(res.triage);
+      renderReports();
       loadNumbers();
     }).catch(function (err) {
       if (err.status === 401) { savePass(null); showLogin("That is not the passphrase."); return; }
@@ -278,14 +307,34 @@
     }).join("");
     $("inbox-all-count").textContent = all.length + " cards";
     $("inbox-everything").hidden = false;
+    $("inbox-owner").hidden = false;
     $("inbox-signout").hidden = false;
   }
 
-  // Numbers: the views over events and over the board itself, and GitHub's own download counts.
-  // Every figure names its window, because a count without one reads as
-  // "always".
+  // From people: what came through the box on the site, latest first, with
+  // who sent it, on what, and the photo when there is one.
+  function renderReports() {
+    var el = $("owner-reports");
+    $("owner-reports-count").textContent = reports.length ? reports.length + (reports.length === 1 ? " report" : " reports") : "";
+    if (!reports.length) { el.innerHTML = '<p class="status">Nothing has come through the box yet.</p>'; return; }
+    el.innerHTML = reports.map(function (c) {
+      var who = c.reporter_email || (c.reporter === "mario" ? "you" : "no email left");
+      var meta = [who, c.device, c.version ? "v" + c.version : ""].filter(Boolean).join(" \u00b7 ");
+      return '<div class="rep"><span class="st ' + esc(c.state) + '">' + esc(c.state) + '</span>' +
+        '<span class="t">#' + c.id + ' ' + esc(c.title) +
+        (c.photo_url ? ' <a href="' + esc(c.photo_url) + '" target="_blank" rel="noopener">photo</a>' : '') +
+        '<span class="who">' + esc(meta) + '</span></span>' +
+        '<span class="when">' + esc(String(c.created_at || "").slice(0, 10)) + '</span></div>';
+    }).join("");
+  }
+
+  function when(ts) { return ts ? String(ts).replace("T", " ").slice(0, 16) : ""; }
+
+  // The numbers. The owner's facts go into the sections above; the workshop's
+  // own numbers (sessions, services, cards) go under the fold. Every figure
+  // names its window, because a count without one reads as "always".
   function loadNumbers() {
-    var body = $("inbox-numbers-body");
+    var devEl = $("owner-devices"), fieldEl = $("owner-field"), body = $("inbox-numbers-body");
     $("inbox-numbers").hidden = false;
     body.innerHTML = '<p class="status">Counting...</p>';
     function tbl(head, rows) {
@@ -306,27 +355,48 @@
     function block(title, head, rows, wide) {
       return '<div class="num-block' + (wide ? ' wide' : '') + '"><p class="nums-h">' + esc(title) + '</p>' + tbl(head, rows) + '</div>';
     }
+    function tiles(list) {
+      return '<div class="num-grid">' + list.map(function (t) { return '<div class="tile"><b>' + esc(t[0]) + '</b><span>' + esc(t[1]) + '</span></div>'; }).join("") + '</div>';
+    }
+    var count = function (v) { return v == null ? "?" : v; };
     Promise.all([
-      api("numbers").catch(function () { return { byVersion: [], daily: [], services: [], errors: [] }; }),
-      fetch("https://api.github.com/repos/ma-r-s/crossplay/releases?per_page=10").then(function (r) { return r.ok ? r.json() : []; }).catch(function () { return []; })
+      api("numbers").catch(function () { return {}; }),
+      fetch("https://api.github.com/repos/ma-r-s/crossplay/releases/latest").then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; })
     ]).then(function (res) {
-      var n = res[0], releases = res[1];
-      var devices7 = (n.byVersion || []).reduce(function (a, r) { return a + (r.devices || 0); }, 0);
-      var today = (n.daily || []).length ? n.daily[0].devices : 0;
-      var h = '<div class="num-grid">' +
-        '<div class="tile"><b>' + devices7 + '</b><span>devices that used a service, 7 days</span></div>' +
-        '<div class="tile"><b>' + today + '</b><span>devices today</span></div>' +
-        '<div class="tile"><b>' + (n.errors || []).filter(function (e) { return e.card_id; }).length + '</b><span>distinct errors with a card</span></div>' +
-        '</div>';
+      var n = res[0] || {};
+      var latest = res[1] && res[1].tag_name ? String(res[1].tag_name).replace(/^v/, "") : "";
+      // Devices: distinct per window, never a sum over versions (a device
+      // that updated inside the window would count twice); then what runs
+      // right now with each device at the version it last reported.
+      var heard = n.heard || {}, fresh = n.fresh || {}, field = n.field || {};
+      var now = n.now || [], every = n.devices || [];
+      var total = now.reduce(function (a, r) { return a + (r.devices || 0); }, 0);
+      var onLatest = now.filter(function (r) { return r.version === latest; }).reduce(function (a, r) { return a + (r.devices || 0); }, 0);
+      devEl.innerHTML =
+        tiles([
+          [count(heard.d7), "devices, last 7 days"],
+          [count(heard.d30), "devices, last 30 days"],
+          [count(fresh.this_week), "first heard this week" + (fresh.last_week != null ? " (" + fresh.last_week + " the week before)" : "")],
+          [latest ? onLatest + " of " + total : "?", "on the latest release" + (latest ? ", " + latest : "")]
+        ]) +
+        '<p class="status">A device is counted when it uses a service or checks for an update, and never twice: each sits at the version it last reported. One that only reads is never heard from, so these are floors.</p>' +
+        block("Running right now, devices heard from in 30 days", ["version", "board", "devices"], now.map(function (r) { return [r.version, r.board, r.devices]; })) +
+        '<details><summary>Every device, latest first (' + every.length + ')</summary>' +
+        tbl(["device", "board", "version", "since", "first seen", "last seen", "versions run"], every.map(function (d) { return [String(d.device || "").slice(0, 8), d.board, d.version, when(d.since), String(d.first_seen || "").slice(0, 10), when(d.last_seen), d.versions_run]; })) +
+        '</details>';
+      // In the field: is the firmware hurting anyone.
+      fieldEl.innerHTML =
+        tiles([
+          [count(field.crashed), "devices that crashed"],
+          [count(field.update_failed), "failed updates"],
+          [count(field.updated), "updated fine"]
+        ]) +
+        block("Why they crashed, devices first", ["reason", "devices", "times", "last"], (n.crashes || []).map(function (c) { return [String(c.message || "").slice(0, 70), c.devices, c.times, when(c.last)]; }), true);
+      // The workshop.
       var L = n.latency || null;
-      h += '<div class="num-cols">';
-      h += block("Devices by version, 7 days", ["board", "version", "devices"], (n.byVersion || []).map(function (r) { return [r.board, r.version, r.devices]; }));
-      h += block("Battery by version, 7 days", ["board", "version", "avg %", "devices"], (n.battery || []).map(function (r) { return [r.board, r.version, r.battery_pct, r.devices]; }));
+      var h = '<div class="num-cols">';
       h += block("Who uses each service, 7 days", ["service", "devices", "events"], (n.services || []).map(function (r) { return [r.service, r.devices_7d, r.events_7d]; }));
-      h += block("Downloads per release, from GitHub, all time", ["release", "published", "downloads"], releases.map(function (r) {
-        var d = (r.assets || []).filter(function (a) { return /firmware(-sticky)?\.bin$|-full\.bin$/.test(a.name); }).reduce(function (a, x) { return a + (x.download_count || 0); }, 0);
-        return [r.tag_name, (r.published_at || "").slice(0, 10), d];
-      }));
+      h += block("Battery by version, 7 days", ["board", "version", "avg %", "devices"], (n.battery || []).map(function (r) { return [r.board, r.version, r.battery_pct, r.devices]; }));
       h += block("Your inbox", ["waiting now", "oldest, hours", "median answer, hours, 30 days", "answered, 7 days"], L ? [[L.open_now, L.oldest_open_h == null ? "" : L.oldest_open_h, L.median_answer_h == null ? "" : L.median_answer_h, L.answered_7d]] : []);
       h += block("Errors seen, latest first", ["service", "message", "times", "card"], (n.errors || []).map(function (e) { return [e.service, (e.message || "").slice(0, 60), e.count, e.card_id ? "#" + e.card_id : ""]; }), true);
       h += block("Services answering, 7 days", ["host", "now", "up %", "median ms", "failures"], (n.pulse || []).map(function (r) { return [r.host, r.up_now ? "up" : "DOWN", r.uptime_7d, r.ms_median == null ? "" : Math.round(r.ms_median), r.failures_7d]; }), true);
@@ -334,7 +404,6 @@
       h += block("Hours a card sits in each state, 30 days", ["state", "cards", "median", "longest"], (n.dwell || []).map(function (r) { return [r.state, r.n, r.median_h, r.max_h]; }));
       h += block("Open cards by app", ["app", "open", "untriaged", "oldest, days"], (n.byApp || []).map(function (r) { return [r.app, r.open, r.untriaged, r.oldest_d]; }));
       h += '</div>';
-      if (!(n.byVersion || []).length && !(n.services || []).length) h += '<p class="status">No events yet. Devices are counted from the requests they make to the services; see docs/workflow/events.md.</p>';
       body.innerHTML = h;
     });
   }
@@ -343,6 +412,7 @@
     $("inbox-login").hidden = false;
     $("inbox-view").innerHTML = "";
     $("inbox-everything").hidden = true;
+    $("inbox-owner").hidden = true;
     $("inbox-numbers").hidden = true;
     $("inbox-signout").hidden = true;
     $("inbox-count").textContent = "";


### PR DESCRIPTION
Card 464 (supersedes #177 / card 462). Mario: "whenever I open the inbox I see a bunch of information I do not care about, and none of the information I care about. How many people are really using this, facts not guesses; what version are people actually running right now; devices never shown twice; who sent what through the box, not buried between the cards." And: "if you owned this firmware, what data would you like to see?"

The page, top to bottom:
1. **Needs you**: the one message, as before.
2. **Devices**: distinct devices in 7 and 30 days, first heard this week, how many are on the latest release; a table of what runs right now with each device counted once at the version it last reported; every device once under a fold.
3. **In the field, 7 days**: devices that crashed, failed and successful updates, panics by reason with devices first.
4. **From people**: the report-box cards, latest first: state, who, device, version, date, photo (signed server-side).
5. Folded: **Everything** (the cards) and **The workshop** (sessions, services, cards).

Gone: the per-version table that summed to 57 devices when there were 51, and GitHub's download counts.

- Views `devices_now`, `versions_now`, `field_7d`, `crashes_7d`, `devices_new` (plus `devices_heard_from` from card 462), already applied to the board with `migrate.sh`.
- `host-tests/site`: 235 checks green; inbox_fn reads the reports and the signed photo link; the fixture carries every key the page reads.
- Looked at under `serve.py` with the fixture: the tiles, the crash table and the report rows render with the right values; the folds are closed.

Not verified: the signed-in page on the real deployment (needs the passphrase). The views were read against the live board: 51 devices in 7 days, 26 on 1.12.50, 18 crashed this week (10 with the Xkcd app as the last log).