### PR TITLE
Study: resume the open card silently and by its Anki id, no prompt

### DIFF
--- a/host-tests/study/test_deck.cpp
+++ b/host-tests/study/test_deck.cpp
@@ -210,39 +210,62 @@ void run(const std::string& dir) {
   check(study::dayNumber(deck.meta(), deck.meta().collectionCreated) == 0, "the creation instant is day 0");
   check(study::dayNumber(deck.meta(), deck.meta().collectionCreated - 5) == 0, "before day zero clamps to 0");
 
-  // The "resume in progress card" record: whether a saved position is still
-  // safe to trust is the one part of that feature worth host-testing (the SD
-  // read/write around it is Arduino-only).
+  // The resume record: whether it is well formed, and whether the card it
+  // names is still the card at that position. The SD read/write around it is
+  // Arduino-only; the scheduler's own rule (the card goes first only if the
+  // queue holds it) lives in takeNext().
   {
     uint8_t bytes[study::kResumeRecordBytes];
-    study::writeResumeRecord(bytes, 3, 1, 1700000000);
+    study::writeResumeRecord(bytes, 1700000000123, 3, 1);
     study::ResumeRecord record;
     check(study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "a valid record parses");
-    check(record.cardIndex == 3 && record.face == 1 && record.savedAt == 1700000000,
-          "the round-tripped record carries its index, face, and timestamp");
+    check(record.ankiCardId == 1700000000123 && record.cardIndex == 3 && record.face == 1,
+          "the round-tripped record carries its Anki id, index and face");
 
     study::writeResumeRecord(bytes, 0, 0, 0);
     check(study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "index 0 (the first card) parses");
 
-    study::writeResumeRecord(bytes, deck.noteCount(), 0, 0);
+    study::writeResumeRecord(bytes, 7, deck.noteCount(), 0);
     check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record),
           "an index at noteCount (one past the end) is refused");
 
-    study::writeResumeRecord(bytes, -1, 0, 0);
+    study::writeResumeRecord(bytes, 7, -1, 0);
     check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "a negative index is refused");
 
-    study::writeResumeRecord(bytes, 3, 1, 0);
+    study::writeResumeRecord(bytes, 7, 3, 1);
     bytes[0] = study::kResumeRecordVersion + 1;
     check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "a version mismatch is refused");
+    bytes[0] = 2;
+    check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record),
+          "the prompt-era record (version 2, a position and a timestamp) is refused, not misread");
 
-    study::writeResumeRecord(bytes, 3, 2, 0);
+    study::writeResumeRecord(bytes, 7, 3, 2);
     check(!study::parseResumeRecord(bytes, sizeof(bytes), deck.noteCount(), record), "a face byte past 1 is refused");
 
-    study::writeResumeRecord(bytes, 3, 1, 0);
+    study::writeResumeRecord(bytes, 7, 3, 1);
     check(!study::parseResumeRecord(bytes, sizeof(bytes) - 1, deck.noteCount(), record), "a short buffer is refused");
     check(!study::parseResumeRecord(bytes, sizeof(bytes) + 1, deck.noteCount(), record), "a long buffer is refused");
-
     check(!study::parseResumeRecord(bytes, sizeof(bytes), 0, record), "an empty deck refuses every index");
+  }
+
+  // Identity: the record names a card, the index is only where it was.
+  {
+    const int64_t ids[] = {11, 22, 33, 44, 55};
+    const auto idAt = [&](int i) { return ids[i]; };
+    study::ResumeRecord r;
+    r.ankiCardId = 33;
+    r.cardIndex = 2;
+    check(study::resolveResumeIndex(r, 5, idAt) == 2, "the card still at its position resolves to it");
+    r.cardIndex = 0;
+    check(study::resolveResumeIndex(r, 5, idAt) == 2,
+          "a deck reordered since the save is searched, and the card found");
+    r.ankiCardId = 99;
+    check(study::resolveResumeIndex(r, 5, idAt) == -1, "a card the deck no longer has is nobody's to resume");
+    r.ankiCardId = 0;
+    r.cardIndex = 4;
+    check(study::resolveResumeIndex(r, 5, idAt) == 4, "a deck without Anki ids is trusted by position alone");
+    r.cardIndex = 5;
+    check(study::resolveResumeIndex(r, 5, idAt) == -1, "and never past its end");
   }
 }
 

--- a/src/apps_local/study/StudyActivity.cpp
+++ b/src/apps_local/study/StudyActivity.cpp
@@ -109,34 +109,6 @@ uint32_t nextRandom(uint32_t& state) {
   return state;
 }
 
-// "LEFT 12 MIN AGO", for the resume prompt. Minutes and hours rather than a
-// clock time while it is recent: the question the prompt answers is "how
-// stale is this", and a relative answer says that directly where "14:32"
-// would make the reader do the subtraction. Same month-name idiom
-// buildDeckModel() uses for LAST SYNC once a card is more than a week stale.
-void formatResumeAge(const int64_t savedAt, char* out, const size_t outSize) {
-  const int64_t now = static_cast<int64_t>(time(nullptr));
-  const int64_t elapsed = now > savedAt ? now - savedAt : 0;
-  if (elapsed < 60) {
-    std::snprintf(out, outSize, "LEFT JUST NOW");
-  } else if (elapsed < 3600) {
-    const int minutes = static_cast<int>(elapsed / 60);
-    std::snprintf(out, outSize, "LEFT %d MIN%s AGO", minutes, minutes == 1 ? "" : "S");
-  } else if (elapsed < 86400) {
-    const int hours = static_cast<int>(elapsed / 3600);
-    std::snprintf(out, outSize, "LEFT %d HOUR%s AGO", hours, hours == 1 ? "" : "S");
-  } else if (elapsed < 86400 * 7) {
-    const int days = static_cast<int>(elapsed / 86400);
-    std::snprintf(out, outSize, "LEFT %d DAY%s AGO", days, days == 1 ? "" : "S");
-  } else {
-    struct tm parts;
-    const time_t at = static_cast<time_t>(savedAt);
-    localtime_r(&at, &parts);
-    static const char* kMonths[] = {"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
-    std::snprintf(out, outSize, "LEFT %d %s", parts.tm_mday, kMonths[parts.tm_mon % 12]);
-  }
-}
-
 }  // namespace
 
 std::unique_ptr<Activity> StudyActivity::create(GfxRenderer& renderer, MappedInputManager& mappedInput) {
@@ -150,11 +122,7 @@ void StudyActivity::onEnter() {
   if (findDeckDirs() && openDeckAt(deckIndex_)) {
     beginDeckSession();
     view_ = View::Deck;
-    // Offer the card that was open last time rather than landing on it
-    // outright: loadResumeState() already did the loading (note_/card_/
-    // fonts_/image_, via the same loadCurrent() takeNext() uses), so RESUME
-    // on this prompt is just a view switch.
-    if (loadResumeState()) view_ = View::ResumePrompt;
+    armResume();
   } else {
     LOG_ERR("STUDY", "No deck under %s -- run tools_local/study/study.py setup", kStudyRoot);
   }
@@ -438,52 +406,42 @@ bool StudyActivity::openDeckAt(const int index) {
 void StudyActivity::saveResumeState() const {
   char path[80];
   std::snprintf(path, sizeof(path), "%s/.resume", deckDir_);
-  if (view_ == View::ResumePrompt) {
-    // The prompt itself was still on screen -- whatever it is offering was
-    // already written last time and has not been answered yet, so leave it
-    // exactly as it is rather than losing it to a sleep taken mid-prompt.
-    return;
-  }
   if (view_ != View::Card) {
-    // Nothing open worth resuming -- and a stale record here would otherwise
-    // outlive the card it names, the same "still unfinished" caution
-    // Picross applies before offering a resume.
+    // Nothing open worth resuming, and a stale record would otherwise outlive
+    // the card it names.
     Storage.remove(path);
     return;
   }
   uint8_t bytes[study::kResumeRecordBytes];
-  study::writeResumeRecord(bytes, static_cast<int32_t>(currentIndex_), face_ == Face::Answer ? 1 : 0,
-                           static_cast<int64_t>(time(nullptr)));
+  study::writeResumeRecord(bytes, card_.ankiCardId, static_cast<int32_t>(currentIndex_), face_ == Face::Answer ? 1 : 0);
   HalFile file;
   if (!Storage.openFileForWrite("STUDY", path, file)) return;
   file.write(bytes, sizeof(bytes));
 }
 
-bool StudyActivity::loadResumeState() {
+int64_t StudyActivity::cardIdAt(const int index) {
+  if (!cardSource_ || index < 0 || index >= deck_.noteCount()) return 0;
+  // ankiCardId is the first field of the 32-byte record (StudyDeck.h).
+  uint8_t record[study::kCardRecordSize];
+  if (!cardSource_->read(static_cast<uint32_t>(index) * study::kCardRecordSize, record, sizeof(record))) return 0;
+  int64_t id;
+  std::memcpy(&id, record, sizeof(id));
+  return id;
+}
+
+void StudyActivity::armResume() {
+  resumeIndex_ = -1;
   char path[80];
   std::snprintf(path, sizeof(path), "%s/.resume", deckDir_);
   HalFile file;
-  if (!Storage.openFileForRead("STUDY", path, file)) return false;
+  if (!Storage.openFileForRead("STUDY", path, file)) return;
   uint8_t bytes[study::kResumeRecordBytes];
-  if (file.read(bytes, sizeof(bytes)) != static_cast<int>(sizeof(bytes))) return false;
+  if (file.read(bytes, sizeof(bytes)) != static_cast<int>(sizeof(bytes))) return;
   study::ResumeRecord record;
-  if (!study::parseResumeRecord(bytes, sizeof(bytes), deck_.noteCount(), record)) return false;
-  currentIndex_ = record.cardIndex;
-  // loadCurrent() does the real work (note_/card_/fonts_/image_), the same
-  // path takeNext() uses -- but it always lands on the question face, so the
-  // saved face is reapplied after.
-  if (!loadCurrent()) return false;
-  face_ = record.face == 1 ? Face::Answer : Face::Question;
-  formatResumeAge(record.savedAt, resumeCaption_, sizeof(resumeCaption_));
-  return true;
-}
-
-void StudyActivity::declineResumePrompt() {
-  char path[80];
-  std::snprintf(path, sizeof(path), "%s/.resume", deckDir_);
-  Storage.remove(path);
-  view_ = View::Deck;
-  requestUpdate();
+  if (!study::parseResumeRecord(bytes, sizeof(bytes), deck_.noteCount(), record)) return;
+  resumeIndex_ = study::resolveResumeIndex(record, deck_.noteCount(), [this](int i) { return cardIdAt(i); });
+  resumeFace_ = record.face == 1 ? Face::Answer : Face::Question;
+  if (resumeIndex_ < 0) LOG_INF("STUDY", "resume record names a card the deck no longer has; ignored");
 }
 
 bool StudyActivity::openDeck() {
@@ -654,11 +612,28 @@ bool StudyActivity::takeNext() {
     }
   }
 
-  // Nothing ripe: take from the main queue.
+  // Nothing ripe: take from the main queue. The card left open last time
+  // goes first, once, and only if the scheduler put it in this queue (it is
+  // still due, or still new and within the day's allowance); a card the
+  // queue does not hold is not resumed, whatever the record says. A ripe
+  // step above outranks it, as it outranks everything.
   if (best < 0 && queuePos_ < queueCount_) {
+    if (resumeIndex_ >= 0) {
+      for (int i = queuePos_; i < queueCount_; ++i) {
+        if (queue_[i] != resumeIndex_) continue;
+        queue_[i] = queue_[queuePos_];
+        queue_[queuePos_] = resumeIndex_;
+        break;
+      }
+    }
     currentIndex_ = queue_[queuePos_++];
     took_ = Took::Queue;
-    return loadCurrent();
+    const bool ok = loadCurrent();
+    // loadCurrent() lands on the question face; the saved face is reapplied
+    // for the resumed card and for no other.
+    if (ok && currentIndex_ == resumeIndex_) face_ = resumeFace_;
+    resumeIndex_ = -1;
+    return ok;
   }
 
   // Main queue empty and something is still in a step: show the one closest to
@@ -951,10 +926,6 @@ void StudyActivity::loop() {
       requestUpdate();
       return;
     }
-    if (view_ == View::ResumePrompt) {
-      declineResumePrompt();
-      return;
-    }
     if (view_ == View::Card) {
       // Back walks up, never out: a review session returns to the deck
       // screen. The session state stays; the next START REVIEWING re-scans
@@ -981,7 +952,7 @@ void StudyActivity::loop() {
   int tapY = 0;
   if (!mappedInput.wasScreenTapped(tapX, tapY)) return;
 
-  if (view_ == View::Deck || view_ == View::ResumePrompt) {
+  if (view_ == View::Deck) {
     // Hit-testing comes from the buffer the screen filled while drawing, so a
     // region can never drift from the pixels that drew it.
     if (!interactionsReady_) return;
@@ -1549,19 +1520,6 @@ void StudyActivity::routeAction(const fui::ActionEvent& event) {
     beginSync();
     return;
   }
-  if (event.value == 5) {
-    // The ResumePrompt's RESUME button. loadResumeState() already loaded
-    // note_/card_/fonts_/image_ back in onEnter(); revealing the card is the
-    // whole action.
-    view_ = View::Card;
-    requestUpdate();
-    return;
-  }
-  if (event.value == 6) {
-    // The ResumePrompt's NOT NOW button -- same decline as Back.
-    declineResumePrompt();
-    return;
-  }
   // Re-scan rather than resuming a stale queue: a session can end, the user can
   // sit on this screen past the rollover hour, and what was due then is not
   // what is due now.
@@ -1654,24 +1612,6 @@ void StudyActivity::render(RenderLock&&) {
     const bool backLive =
         flow_.verdict != studyui::SyncVerdictKind::None || flow_.safety >= studyui::SyncSafety::ReviewsSafe;
     const auto labels = mappedInput.mapLabels(backLive ? "Back" : "", "", "", "");
-    GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-    renderer.displayBuffer();
-    return;
-  }
-
-  if (view_ == View::ResumePrompt) {
-    fui::GfxRendererTarget target = toybox::makeTarget(renderer);
-    const fui::InputSnapshot noInput{};
-    interactionsReady_ = false;
-    toybox::Frame frame(target, target.deviceContext(), noInput, interactions_);
-    toybox::Screen screen(frame);
-
-    studyui::buildResumePrompt(screen, resumeCaption_);
-
-    interactionsReady_ = true;
-    toybox::reportOverflow(interactions_, "Study resume prompt");
-
-    const auto labels = mappedInput.mapLabels("Back", "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     renderer.displayBuffer();
     return;

--- a/src/apps_local/study/StudyActivity.h
+++ b/src/apps_local/study/StudyActivity.h
@@ -61,11 +61,7 @@ class StudyActivity final : public Activity {
   // whatever sentence the flow is on, the pairing QR, and the on-device
   // "Paired to <account> -- confirm?" gate (which closes both directions of
   // the pairing race; see docs/apps/study-sync-bridge-plan.md).
-  // ResumePrompt: shown at onEnter() when a card was left open last time,
-  // offering to go straight back to it (RESUME) or Back to the deck screen
-  // as normal, before either the fresh queue or the resumed card is on
-  // screen.
-  enum class View : uint8_t { Deck, Card, Image, NoDeck, SyncFlow, PairQr, PairConfirm, DeckPicker, ResumePrompt };
+  enum class View : uint8_t { Deck, Card, Image, NoDeck, SyncFlow, PairQr, PairConfirm, DeckPicker };
   enum class Face : uint8_t { Question, Answer };
 
   bool openDeck();
@@ -87,20 +83,15 @@ class StudyActivity final : public Activity {
   bool openDeckAt(int index);
   void closeDeck();
   void switchDeck();
-  // The card left open last time, if any. saveResumeState() runs
-  // unconditionally from onExit() when a card is on screen; loadResumeState()
-  // runs from onEnter() and, on success, note_/card_/fonts_/image_ are
-  // already loaded (via loadCurrent()) and View::ResumePrompt is shown before
-  // the card itself is. See study::parseResumeRecord (StudyDeck.h) for the
-  // validation the load side trusts.
+  // The card left open last time, if any. saveResumeState() runs from
+  // onExit(): the card on screen and its face, by Anki id, or nothing when no
+  // card is up. armResume() runs from onEnter() and only remembers which
+  // index to hand out first; takeNext() does that once, if the scheduler has
+  // the card in its queue, and restores the face. No screen asks: the queue
+  // would have shown that card next anyway (StudyDeck.h says why).
   void saveResumeState() const;
-  bool loadResumeState();
-  // Declining is authoritative: the offer was for THIS card, and leaving the
-  // record around would ask again next time over whatever the deck screen's
-  // own session produces instead, unrelated to the card it once named. Shared
-  // by the ResumePrompt's NOT NOW button and its Back handling in loop() so
-  // the two cannot drift apart.
-  void declineResumePrompt();
+  void armResume();
+  int64_t cardIdAt(int index);
   bool takeNext();
   // Take back the last answer. One level only: "I meant Good, not Again" is the
   // case that matters, and a deeper stack would need the queue's whole history
@@ -220,8 +211,10 @@ class StudyActivity final : public Activity {
   // The open deck's directory, /study/<name>; empty until a deck is open.
   char deckDir_[64] = "";  // "/study/" + a 40-char slug, with room to spare
 
-  // "LEFT 12 MIN AGO", set by loadResumeState() for View::ResumePrompt to draw.
-  char resumeCaption_[40] = "";
+  // Armed by armResume(): the queue index to hand out first, once, and the
+  // face it was left on. -1 when there is nothing to resume.
+  int resumeIndex_ = -1;
+  Face resumeFace_ = Face::Question;
 
   int currentIndex_ = -1;
   int today_ = 0;

--- a/src/apps_local/study/StudyDeck.h
+++ b/src/apps_local/study/StudyDeck.h
@@ -194,53 +194,68 @@ class StudyDeck {
 // timezone conversation.
 int dayNumber(const DeckMeta& meta, int64_t nowEpochSeconds);
 
-// The card left open across a leave or a sleep, when the "resume in progress
-// card" option is on. Kept freestanding, with the SD read/write in
-// StudyActivity.cpp (Arduino-only), so the one part worth getting wrong --
-// whether a saved position is still safe to trust -- is host-tested.
+// The card left open across a leave or a sleep. Kept freestanding, with the
+// SD read/write in StudyActivity.cpp (Arduino-only), so the two parts worth
+// getting wrong are host-tested: whether a saved record is well formed, and
+// whether the card it names is still the card at that position.
 //
-// Version 2 adds savedAt (epoch seconds), so the resume prompt can say how
-// long ago the card was left rather than just naming it. Bumping the version
-// rather than growing the old layout in place means a v1 file left on an SD
-// card by an older build is refused outright -- read as "no timestamp" it
-// would print an epoch-zero date, which is a worse failure than just not
-// resuming.
-inline constexpr uint8_t kResumeRecordVersion = 2;
-inline constexpr uint32_t kResumeRecordBytes = 14;  // version + int32 index + face + int64 savedAt
+// There is no prompt. An unanswered card writes nothing, and the queue is
+// rebuilt in file order with the answered cards gone, so the card that was on
+// screen is the next one the scheduler hands out anyway; asking "continue?"
+// asked about a card that "not now" would show regardless. The one thing the
+// deck cannot restore is the face, so that is what the record is for, and it
+// names the card by its Anki id: a deck re-synced in between can reorder
+// cards.dat, and a position alone would resume a different card with no way
+// to tell. Version 3; older records are refused and the queue does its job.
+inline constexpr uint8_t kResumeRecordVersion = 3;
+inline constexpr uint32_t kResumeRecordBytes = 14;  // version + int64 ankiCardId + int32 index + face
 
 struct ResumeRecord {
+  int64_t ankiCardId = 0;  // 0 when the deck was built without Anki ids; then the index is all there is
   int32_t cardIndex = -1;
-  uint8_t face = 0;     // 0 Question, 1 Answer
-  int64_t savedAt = 0;  // epoch seconds when the record was written
+  uint8_t face = 0;  // 0 Question, 1 Answer
 };
 
 // False on a version mismatch, a malformed face byte, or an index outside
-// [0, noteCount) -- a deck re-synced since the save was written can shrink or
-// reorder cards.dat, and trusting a stale index would resume the wrong note or
-// read past it. The caller falls back to its normal fresh-queue pick in every
-// one of those cases, same as it would with no saved record at all.
+// [0, noteCount). The caller then behaves as with no record at all.
 inline bool parseResumeRecord(const uint8_t* bytes, uint32_t length, int noteCount, ResumeRecord& out) {
   if (length != kResumeRecordBytes) return false;
   if (bytes[0] != kResumeRecordVersion) return false;
+  int64_t id;
+  std::memcpy(&id, bytes + 1, sizeof(id));
   int32_t index;
-  std::memcpy(&index, bytes + 1, sizeof(index));
-  const uint8_t face = bytes[5];
+  std::memcpy(&index, bytes + 9, sizeof(index));
+  const uint8_t face = bytes[13];
   if (face > 1) return false;
   if (index < 0 || index >= noteCount) return false;
-  int64_t savedAt;
-  std::memcpy(&savedAt, bytes + 6, sizeof(savedAt));
+  out.ankiCardId = id;
   out.cardIndex = index;
   out.face = face;
-  out.savedAt = savedAt;
   return true;
 }
 
 // Serializes exactly kResumeRecordBytes bytes, the inverse of parseResumeRecord.
-inline void writeResumeRecord(uint8_t* bytes, int32_t cardIndex, uint8_t face, int64_t savedAt) {
+inline void writeResumeRecord(uint8_t* bytes, int64_t ankiCardId, int32_t cardIndex, uint8_t face) {
   bytes[0] = kResumeRecordVersion;
-  std::memcpy(bytes + 1, &cardIndex, sizeof(cardIndex));
-  bytes[5] = face;
-  std::memcpy(bytes + 6, &savedAt, sizeof(savedAt));
+  std::memcpy(bytes + 1, &ankiCardId, sizeof(ankiCardId));
+  std::memcpy(bytes + 9, &cardIndex, sizeof(cardIndex));
+  bytes[13] = face;
+}
+
+// The index the record really names, or -1. `idAt(index)` reads the Anki id
+// of the card at a position (0 when it cannot). A record without an id (a
+// deck built from plain text) can only be trusted by position; with an id,
+// the position is a hint: checked first, then the deck is searched, and a
+// card that is nowhere any more is nobody's to resume.
+template <typename IdAt>
+inline int resolveResumeIndex(const ResumeRecord& record, int noteCount, IdAt idAt) {
+  if (record.cardIndex < 0 || record.cardIndex >= noteCount) return -1;
+  if (record.ankiCardId == 0) return record.cardIndex;
+  if (idAt(record.cardIndex) == record.ankiCardId) return record.cardIndex;
+  for (int i = 0; i < noteCount; ++i) {
+    if (i != record.cardIndex && idAt(i) == record.ankiCardId) return i;
+  }
+  return -1;
 }
 
 }  // namespace study

--- a/src/apps_local/study/StudyScreens.cpp
+++ b/src/apps_local/study/StudyScreens.cpp
@@ -377,65 +377,6 @@ void buildDeck(toybox::Screen& screen, const DeckModel& model) {
   screen.list(list, doorBand, fui::LayoutAnchor::Bottom);
 }
 
-void buildResumePrompt(toybox::Screen& screen, const char* caption) {
-  chrome(screen, "STUDY");
-  screen.insetContent(fui::Insets{toybox::kGutter * 3, toybox::kMargin, toybox::kMargin, toybox::kMargin});
-  const fui::Rect body = screen.body();
-
-  fui::TextStyle hero;
-  hero.font = toybox::kDisplayFont;
-  hero.align = fui::TextAlign::Center;
-  screen.target().text(fui::makeRect(body.x, body.y + toybox::kMargin, body.width, 60), "CONTINUE?", hero);
-
-  // caption ("LEFT 12 MIN AGO") is already short by construction
-  // (formatResumeAge): the renderer appends U+2026 on overflow and the UI
-  // face has no glyph for it, so a line that does not fit does not get an
-  // ellipsis, it just stops mid-word. buildPairConfirm's caption hit exactly
-  // this.
-  fui::TextStyle sub;
-  sub.font = toybox::kUiFont;
-  sub.align = fui::TextAlign::Center;
-  sub.color = fui::Color::DarkGray;
-  screen.target().text(fui::makeRect(body.x, body.y + toybox::kMargin + 66, body.width, 32), caption, sub);
-
-  const int16_t resumeH = 56;
-  const int16_t skipH = 48;
-  const int16_t gap = 16;
-  const fui::Rect resumeRect =
-      fui::makeRect(static_cast<int16_t>(body.x + 44), static_cast<int16_t>(body.bottom() - 48 - skipH - gap - resumeH),
-                    static_cast<int16_t>(body.width - 88), resumeH);
-  fui::ButtonProps resume;
-  resume.label = "RESUME";
-  resume.action = ActionStudy;
-  resume.value = 5;
-  resume.text = sub;
-  resume.text.color = fui::Color::Black;
-  resume.text.align = fui::TextAlign::Center;
-  resume.radius = static_cast<uint8_t>(resumeH / 2);
-  screen.button(resume, resumeRect);
-
-  // A real target rather than relying on Back alone: Back still declines too
-  // (StudyActivity's own dispatch), but a screen that offers one way forward
-  // and only an off-screen way back is not offering a choice.
-  const fui::Rect skipRect =
-      fui::makeRect(static_cast<int16_t>(body.x + 44), static_cast<int16_t>(body.bottom() - 48 - skipH),
-                    static_cast<int16_t>(body.width - 88), skipH);
-  fui::ButtonProps skip;
-  skip.label = "NOT NOW";
-  skip.action = ActionStudy;
-  skip.value = 6;
-  skip.text = sub;
-  skip.text.color = fui::Color::Black;
-  skip.text.align = fui::TextAlign::Center;
-  skip.radius = static_cast<uint8_t>(skipH / 2);
-  skip.styles.explicitlySet = true;
-  skip.styles.normal.background = fui::Paint::none();
-  skip.styles.normal.border = fui::Paint::solid(fui::Color::Black);
-  skip.styles.normal.borderWidth = 2;
-  skip.styles.normal.radius = static_cast<uint8_t>(skipH / 2);
-  screen.button(skip, skipRect);
-}
-
 // ---- The sync flow surface (docs/apps/study-syncflow-ui.md). The stage
 // band won the three-variant round; the ladder and line+log arrangements
 // and the STUDY_SYNCFLOW_VARIANT macro died with the choice.

--- a/src/apps_local/study/StudyScreens.h
+++ b/src/apps_local/study/StudyScreens.h
@@ -86,13 +86,6 @@ struct DeckModel {
 
 void buildDeck(toybox::Screen& screen, const DeckModel& model);
 
-// Shown at onEnter() when a card was left open last time. RESUME (action
-// ActionStudy, value 5) reveals it; NOT NOW (value 6) declines, same as
-// Back. `caption` is the already-formatted "LEFT 12 MIN AGO" (StudyActivity
-// computes it -- it needs a wall clock, which this header stays free of so
-// host-tests/ui can build the screen deterministically).
-void buildResumePrompt(toybox::Screen& screen, const char* caption);
-
 // ---- The sync flow surface (docs/apps/study-syncflow-ui.md).
 //
 // One screen, two faces: the stage ladder while the flow runs, the verdict


### PR DESCRIPTION
Card 472. Mario, 2026-09-11: "this should not be a subjective thing, there must be a correct solution." Derived from the scheduler, not from taste:

- An unanswered card writes nothing and the queue is rebuilt in file order with answered cards gone, so the card that was on screen is the next card the scheduler hands out anyway. The prompt from #170 asked "continue?" about a card "not now" would show regardless.
- Its record named the card by position; a deck re-synced in between can reorder cards.dat and resume a different card with no way to tell.

Now the record carries the card's Anki id, its position as a hint and the face (version 3; the prompt-era record is refused). On entry the id is resolved (position, then a search, then nothing); `takeNext()` hands that card out first, once, only if the scheduler has it in its queue, and restores the face. A ripe learning step still outranks it. Decks without Anki ids are trusted by position. The prompt screen, its timestamp and its two actions are gone.

`host-tests/study`: parsing and the identity rule, 20 checks, including that a version-2 record is refused rather than misread. Full gate: every suite green, simulator + x4pro + sticky built; the gate's verdict reads "failed" only for the browser artefact being behind trunk, which is CI's rebuild (and see below). The undo guard was overridden on purpose: this removes 195 lines #170 added hours ago.

Not verified: hardware. Docs: none affected.