### PR TITLE
xkcd: a retry no longer says the card is not writable (#475)

### DIFF
--- a/host-tests/xkcd/run.sh
+++ b/host-tests/xkcd/run.sh
@@ -21,3 +21,8 @@ SRC=../../src/apps_local/xkcd
 # fiddly would drift, which is the same reason the pack and the device share
 # one ditherer.
 ./test_layout.py
+
+# Every negated Storage.mkdir() in the fork's apps is guarded by exists():
+# SdFat's mkdir refuses an existing directory, and xkcd once read that as
+# an unwritable card (card #475).
+./test_mkdir_guard.py

--- a/host-tests/xkcd/test_mkdir_guard.py
+++ b/host-tests/xkcd/test_mkdir_guard.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""No app may read Storage.mkdir()'s false as "the card is not writable".
+
+SdFat's mkdir opens the new entry with O_CREAT | O_EXCL, so it returns false
+when the directory ALREADY EXISTS. An app that creates its folder with a bare
+`if (!Storage.mkdir(dir))` works once and then, on every later attempt,
+tells the user the card is not writable: card #475, xkcd, "folders are
+created but it says that sd is not writable or present". The guard is
+`!Storage.exists(dir) && !Storage.mkdir(dir)`, which every other app here
+already had.
+
+Scans src/apps_local for a negated mkdir that is not preceded on the same
+statement by an exists() check. Only the fork's apps: upstream's callers are
+upstream's, and the web server's create-folder handler wants the refusal.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+APPS = ROOT / "src" / "apps_local"
+
+bad = []
+checks = 0
+for path in sorted(APPS.rglob("*.cpp")):
+    text = path.read_text(encoding="utf-8")
+    for m in re.finditer(r"!\s*Storage\.mkdir\(", text):
+        checks += 1
+        # The statement this call sits in: back to the previous ';', '{' or '}'.
+        start = max(text.rfind(c, 0, m.start()) for c in ";{}")
+        statement = text[start + 1 : m.end()]
+        if "exists(" not in statement:
+            line = text.count("\n", 0, m.start()) + 1
+            bad.append(f"{path.relative_to(ROOT)}:{line}")
+
+for b in bad:
+    print(f"FAIL mkdir-guard  {b}: !Storage.mkdir() with no exists() guard; "
+          "SdFat's mkdir refuses an existing directory")
+# The gate counts "N checks, M failed" lines; a suite worded otherwise passes
+# unseen (host-tests/checksh).
+print(f"{'FAIL' if bad else 'ok  '}  xkcd mkdir-guard: {checks} checks, {len(bad)} failed")
+sys.exit(1 if bad else 0)

--- a/src/apps_local/xkcd/XkcdActivity.cpp
+++ b/src/apps_local/xkcd/XkcdActivity.cpp
@@ -786,7 +786,10 @@ void XkcdActivity::runPackDownload() {
       {"images.dat", "the comics"},
   };
 
-  if (!Storage.mkdir(kDir)) {
+  // exists() first: SdFat's mkdir refuses a directory that is already there
+  // (it opens the entry O_CREAT | O_EXCL), so a bare mkdir worked once and
+  // then told every retry that the card was not writable (card #475).
+  if (!Storage.exists(kDir) && !Storage.mkdir(kDir)) {
     showNotice("NO ROOM", "Could not create /xkcd on the card. Is the card in, and writable?");
     return;
   }


### PR DESCRIPTION
Card #475 (x4pro, 1.12.52, reported five hours ago): downloads create the folder, then every attempt says the card is not writable or present.

**Cause.** SdFat's `mkdir` opens the new entry `O_CREAT | O_EXCL`, so it returns false when the directory already exists. xkcd created `/xkcd` with a bare `if (!Storage.mkdir(kDir))` and read the refusal as an unwritable card: the first attempt makes the folder (and fails later, for whatever reason it fails), and every retry after that is refused on the spot with "Could not create /xkcd on the card. Is the card in, and writable?". Reproduced on the desk X4 Pro with an `/xkcd` left by an earlier attempt.

**Fix.** `exists()` before `mkdir()`, as every other app here does. `host-tests/xkcd/test_mkdir_guard.py` scans the fork's apps for a negated mkdir with no exists() on its statement; it was red on this line before the fix.

**Not this bug.** Get Books already guards its folder; the report's books half is something else and stays open on the card.

Verified: xkcd host suite; the check on the branch is running; device verification of the retry follows on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)