### PR TITLE
check.sh --flash: build one env under the lock and flash it, no suites

### DIFF
--- a/docs/developer-mode.md
+++ b/docs/developer-mode.md
@@ -11,7 +11,13 @@ until you turn it off again.
 ./scripts_local/wifi-flash.sh                 # x4pro build, finds the device
 ./scripts_local/wifi-flash.sh --env sticky
 ./scripts_local/wifi-flash.sh --ip 192.168.1.42 --build
+./scripts_local/check.sh --flash              # build x4pro under the workspace lock, then flash
 ```
+
+`--build` compiles the one env in place and is the shortest path from a
+change to the panel (about three minutes); it refuses if another tree's
+device build holds the lock at that moment. `check.sh --flash` queues behind
+that lock instead. Neither is a gate: no host suite runs.
 
 Turning it off is itself a wireless flash:
 

--- a/docs/workflow/worker-contract.md
+++ b/docs/workflow/worker-contract.md
@@ -52,6 +52,9 @@ are enforced by hooks and will refuse rather than remind.
   to Mario. To show him something: identify it by MAC, `wifi-flash.sh` your
   build, drive it with `drive.py --ip`, and record one `mario` blocker saying
   what to look at. `desk` means a person's eyes or fingers, never a cable.
+  A fix he is waiting on goes `wifi-flash.sh --build` or `check.sh --flash`
+  (one env, about three minutes), not through the full gate first; the gate
+  runs before you land, not before he sees it.
 - **If CrossPoint owns it, it is not ours to fix.** Mario, 2026-09-04:
   *"stuff that crosspoint owns is not ours to fix. If the change is not
   CrossPlay specific it is dismissed."* Dismissed -- not filed, not parked for

--- a/scripts_local/README.md
+++ b/scripts_local/README.md
@@ -131,8 +131,19 @@ Developer Mode shows an address and six digits:
 
 ```bash
 ./scripts_local/wifi-flash.sh --pair 123456   # once per dev-mode session
-./scripts_local/wifi-flash.sh                 # every flash after that
+./scripts_local/wifi-flash.sh                 # every flash after that (the image check.sh last built)
+./scripts_local/wifi-flash.sh --build         # change, compile x4pro, flash: about three minutes on a quiet workspace
+./scripts_local/check.sh --flash              # the same, queued behind other trees' builds under the firmware lock
 ./scripts_local/wifi-flash.sh --disable       # close the device again
+```
+
+A fix that has to reach the panel does not wait for the full gate: `--build`
+compiles the one env and flashes it (it refuses only when another tree's
+build holds the lock right then), and `check.sh --flash` takes the lock and
+waits its turn. Neither runs a host suite, and `--flash` says so with the
+token `flashed`, never `green`; run the gate before you land.
+
+```bash
 ```
 
 It is a runtime setting present in every build including releases, so flashing a

--- a/scripts_local/check.sh
+++ b/scripts_local/check.sh
@@ -3,6 +3,8 @@
 #
 #   ./scripts_local/check.sh              # host tests, both builds
 #   ./scripts_local/check.sh --tests      # host tests only (fast)
+#   ./scripts_local/check.sh --flash      # build x4pro under the lock and flash it, no suites (~3 min)
+#   ./scripts_local/check.sh --flash sticky --ip 192.168.1.42   # env first, then wifi-flash.sh's own flags
 #   ./scripts_local/check.sh --committed  # verify HEAD, not your working tree
 #
 # HOW TO READ THE RESULT -- grep the token, never tail the output:
@@ -195,6 +197,29 @@ for _a in "$@"; do
 done
 # shellcheck disable=SC2086
 set -- $_rest
+# --flash [env]: build ONE device env under the firmware lock and hand the
+# image to wifi-flash.sh, with no host suite in between. Change, compile,
+# flash, in about three minutes; the full gate front-loads eight minutes of
+# suites and two more envs before an image exists, and on 2026-09-11 that
+# was the wait between a one-line fix and the panel. Its verdict token is
+# `flashed`, never `green`: nothing was verified beyond the compiler.
+FLASH_MODE=""
+FLASH_ENV=""
+FLASH_ARGS=""
+if [ "${1:-}" = "--flash" ]; then
+  FLASH_MODE=1
+  shift
+  FLASH_ENV="x4pro"
+  case "${1:-}" in
+    x4pro|sticky|gh_release_x4pro|gh_release_sticky) FLASH_ENV="$1"; shift ;;
+    --*|"") ;;
+    *) die "--flash: '$1' is not a device env (x4pro, sticky, gh_release_x4pro, gh_release_sticky)" ;;
+  esac
+  # Whatever follows goes to wifi-flash.sh as it is: --ip when discovery
+  # cannot hear the unit, --pair on a fresh Developer Mode session.
+  FLASH_ARGS="$*"
+  set --
+fi
 if [ "$_committed" = "1" ]; then
   # One trial directory PER RUN ($$), never shared. It used to be per tree,
   # which serialised nothing: sessions never close here, and two of them
@@ -538,6 +563,9 @@ infra_fault_note() {  # label, T0, logfile
 # accumulated and how one PR ate three CI cycles for other people's whitespace.
 # --check is the same file list the fixer uses, reporting instead of rewriting,
 # so it cannot drift from what CI enforces.
+if [ -n "${FLASH_MODE:-}" ]; then
+  echo "--flash ${FLASH_ENV:-x4pro}: no host suite runs; this builds one image and flashes it, and is not a gate."
+else
 echo "formatting"
 T0=$(date +%s)
 if ./bin/clang-format-fix --check > "$LOGS/clang-format.log" 2>&1; then
@@ -936,6 +964,7 @@ if [ -n "$STUDY_PY" ] && [ -f tools_local/site/precompress.py ]; then
     FAILED=1
   fi
 fi
+fi  # not --flash
 
 if [ "${1:-}" != "--tests" ]; then
   # Shared, content-addressed object cache: a tree that has never built before
@@ -961,6 +990,7 @@ if [ "${1:-}" != "--tests" ]; then
   FW_LOCK="${PLATFORMIO_BUILD_CACHE_DIR:-$WS/.pio-cache}/x4pro.lock"
 
   BUILD_ENVS="simulator_x4_pro x4pro sticky"
+  [ -n "${FLASH_MODE:-}" ] && BUILD_ENVS="${FLASH_ENV:-x4pro}"
   # --committed SWAPS the dev pair for the release pair. It used to APPEND, and
   # built four device images where two would do.
   #
@@ -1012,7 +1042,9 @@ if [ "${1:-}" != "--tests" ]; then
   DEVICE_SKIP_WHY="nothing in this diff reaches a device image"
   _scope="${REPO:-}/scripts_local/device-build-needed.sh"
   _dev_envs="$(printf '%s\n' $BUILD_ENVS | grep -v '^simulator' | tr '\n' ' ' | sed 's/ *$//')"
-  if [ -n "${CHECK_FORCE_DEVICE_BUILDS:-}" ]; then
+  if [ -n "${FLASH_MODE:-}" ]; then
+    echo "device build: ${FLASH_ENV:-x4pro} (--flash); the diff was not consulted"
+  elif [ -n "${CHECK_FORCE_DEVICE_BUILDS:-}" ]; then
     echo "device builds: forced (CHECK_FORCE_DEVICE_BUILDS is set); the diff was not consulted"
   elif [ -n "${REPO:-}" ] && [ -x "$_scope" ]; then
     # --build-loop, not the default question: --committed exports
@@ -1455,6 +1487,21 @@ if [ "${CHECK_OUTER_BRANCH:-$(git branch --show-current 2>/dev/null)}" = "$DEPLO
   fi
 fi
 
+# --flash: the image is built; hand it to the unit. A failed flash is a
+# failed run, so the token below cannot say flashed over a device that is
+# still on the old image.
+if [ -n "${FLASH_MODE:-}" ] && [ "$FAILED" -eq 0 ]; then
+  echo
+  echo "flash"
+  # shellcheck disable=SC2086
+  if ./scripts_local/wifi-flash.sh --env "${FLASH_ENV:-x4pro}" ${FLASH_ARGS:-}; then
+    echo "  flashed ${FLASH_ENV:-x4pro}"
+  else
+    echo "  FLASH FAILED (the image is built; ./scripts_local/wifi-flash.sh again once the unit answers)"
+    FAILED=1
+  fi
+fi
+
 # --tests asked for the host suites and nothing else. Card #317 turned the
 # verdict into a TOKEN a reader acts on without ever having seen the command
 # line, and `green` from a run that compiled nothing is exactly the
@@ -1582,6 +1629,12 @@ fi
 # Printed unconditionally, after the fi, so no branch can be added later that
 # forgets it: a verdict this file can reach without emitting a token is the
 # defect coming back.
+# --flash covered one compiler and one cable: whatever the block above
+# concluded from suites that never ran, the token says what happened.
+if [ -n "${FLASH_MODE:-}" ] && [ "$FAILED" -eq 0 ]; then
+  VERDICT=flashed; STATUS=0
+  echo "BUILT ${FLASH_ENV:-x4pro} AND FLASHED -- no host suite ran; run the gate before you land."
+fi
 echo "CHECKSH-VERDICT: $VERDICT exit=$STATUS transcript=${CHECK_RUNLOG:-none}"
 # 0 green (and host-green-device-skipped), 1 failed, 3 withheld. Withheld used
 # to exit 0, which is why "$? is meaningless here" had to be written into four

--- a/scripts_local/wifi-flash.sh
+++ b/scripts_local/wifi-flash.sh
@@ -296,9 +296,17 @@ echo "uploading $SIZE bytes ..."
 # both the upload and raw paths with no way to tell them apart, and taking the
 # upload path here dereferences null and resets the device; PUT makes that path
 # structurally unreachable. See docs/developer-mode.md.
-curl -fsS --max-time 600 -X PUT "http://$IP/api/dev/upload" \
+# A stalled upload (a weak signal, a device whose loop is blocked) fails in
+# twenty seconds under 8 KB/s rather than sitting on --max-time: on 2026-09-11
+# one sat for ten minutes, and the device's own web server sat with it, since
+# a body that never finishes holds its loop.
+RSSI="$(printf '%s' "$STATUS" | sed -n 's/.*"rssi":\(-\{0,1\}[0-9]*\).*/\1/p')"
+if [ -n "$RSSI" ] && [ "$RSSI" -lt -70 ]; then
+  echo "warning: the device's Wi-Fi signal is weak ($RSSI dBm); the upload may crawl or stall. Closer to the router helps." >&2
+fi
+curl -fsS --max-time 600 --speed-limit 8000 --speed-time 20 -X PUT "http://$IP/api/dev/upload" \
   -H "X-Dev-Token: $TOKEN" -H "Content-Type: application/octet-stream" \
-  --data-binary "@$FW" >/dev/null || { echo "error: upload failed" >&2; exit 1; }
+  --data-binary "@$FW" >/dev/null || { echo "error: upload failed (stalled or refused)${RSSI:+; signal $RSSI dBm}" >&2; exit 1; }
 echo "uploaded."
 
 # -- flash -------------------------------------------------------------------


### PR DESCRIPTION
Card #479. Mario: "should be as easy and fast as change code, compile, flash." The full gate runs eight minutes of host suites and two extra envs before an x4pro image exists. `./scripts_local/check.sh --flash [env] [wifi-flash flags]` builds the one env through the gate's own firmware lock and queue, then runs `wifi-flash.sh`; no suite runs and the verdict token is `flashed`, never `green`. `wifi-flash.sh --build` (which already existed) stays the shortest path on a quiet workspace; `--flash` queues instead of refusing when another tree is building.

Also in `wifi-flash.sh`: a stalled upload fails in twenty seconds instead of ten minutes, and a weak signal (below -70 dBm) is named before the upload.

Verified: `host-tests/checksh` 151 checks green with the mode in; `--flash x4pro --ip ...` trialled on the desk unit from the Wikipedia tree. Not verified: `--flash` while another tree holds the lock (the queue path is the gate's own, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)