### PR TITLE
wikipedia: the full pack, its conversion rules and its quality gate

### DIFF
--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Twenty-one rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Twenty-two rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Fourteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Fifteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Fifteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Sixteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Sixteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Seventeen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Twelve rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Thirteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished
@@ -457,7 +457,14 @@ copies, an abbreviation's tooltip, "v t e" in a table header, a coordinate
 pair glued to the lead, a name glued to its birth date, a spanning cell
 said once per column, stacked header rows, a definition list that lost
 its values (medal counts), a chembox sub-label glued to its value, and a
-unit rule of ours that superscripted a longitude.
+unit rule of ours that superscripted a longitude. Two more reads of
+fresh full samples (round thirteen) closed the infobox shapes those
+showed: dead link captions, a header taken for a group, a row whose
+value is the title, a romanised aside that now keeps the word
+"romanized" so a Latin string is not taken for the native spelling
+("Russian, romanized: Semnadtsat'"), the title's own words reordered in
+a lead aside. A rule of 36 equals signs stalled a full build on an
+ambiguous quantifier; every rule is now timed on 400-character runs.
 
 What the census decided, in order: a pronunciation between slashes or
 brackets goes whole and first; a symbol the serif lacks is spelled

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Nineteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Twenty rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Twenty rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Twenty-one rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,13 +432,25 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Eight rounds ran on the night of 2026-09-11/12 (commits bb0ad49df to
-a4cb4b2c0): each one a census or a detector report or a cold reviewer's
+Eleven rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished
 after each. Reviewer samples take `--seed`; the default seed picks the
 same thirty every time. The live pack is the best build so far, and a
 round that changes rules materially ends with the full pack rebuilt.
+Round eleven closed the last artifact classes the gate still counted, one
+cause each: Parsoid's leaked protection markers, an unclosed ref tag, a
+footnote template in the prose, a quoted or comma-separated script run
+that left `(")` or `(,)`, an inline label rule that took a link's own
+closing tag for the end of the piece and ate "Vizing's Theorem:", the
+space a lost icon left inside a link's text, a table caption repeated as
+the header of every row, rp page references, a formula whose middle the
+dump lost, the residue of an align block, two quoted lines joined. Four
+detectors were narrowed where every hit was legitimate: a colon after a
+digit is a ratio or a title, `|-` is the turnstile's spelling, `{{ A, A }}`
+is set notation, `[[1,3-...` is a chemical name. What stays flagged after
+that is the dump's own and is listed in the report, not hidden.
 
 What the census decided, in order: a pronunciation between slashes or
 brackets goes whole and first; a symbol the serif lacks is spelled

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,6 +432,14 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
+Eight rounds ran on the night of 2026-09-11/12 (commits bb0ad49df to
+a4cb4b2c0): each one a census or a detector report or a cold reviewer's
+read of thirty random articles, every finding checked against the dump's
+own text before a rule was written, the essentials rebuilt and republished
+after each. Reviewer samples take `--seed`; the default seed picks the
+same thirty every time. The live pack is the best build so far, and a
+round that changes rules materially ends with the full pack rebuilt.
+
 What the census decided, in order: a pronunciation between slashes or
 brackets goes whole and first; a symbol the serif lacks is spelled
 (`symbols.py`, written from the census, most frequent first); a letter

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Thirteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Fourteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished
@@ -465,6 +465,10 @@ value is the title, a romanised aside that now keeps the word
 ("Russian, romanized: Semnadtsat'"), the title's own words reordered in
 a lead aside. A rule of 36 equals signs stalled a full build on an
 ambiguous quantifier; every rule is now timed on 400-character runs.
+A fifth read (round fourteen) settled feet-and-inches beside the
+unit-power rule, taxon authorities, commas in addresses, compass
+points after a parenthesis, machine dates in cells and a density row
+the dump nests under "Government".
 
 What the census decided, in order: a pronunciation between slashes or
 brackets goes whole and first; a symbol the serif lacks is spelled

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Eleven rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Twelve rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished
@@ -450,7 +450,14 @@ dump lost, the residue of an align block, two quoted lines joined. Four
 detectors were narrowed where every hit was legitimate: a colon after a
 digit is a ratio or a title, `|-` is the turnstile's spelling, `{{ A, A }}`
 is set notation, `[[1,3-...` is a chemical name. What stays flagged after
-that is the dump's own and is listed in the report, not hidden.
+that is the dump's own and is listed in the report, not hidden. Round
+twelve came from a cold read of the FULL pack's sample, which is stubs
+with infoboxes where the essentials are long articles: hidden ISO-date
+copies, an abbreviation's tooltip, "v t e" in a table header, a coordinate
+pair glued to the lead, a name glued to its birth date, a spanning cell
+said once per column, stacked header rows, a definition list that lost
+its values (medal counts), a chembox sub-label glued to its value, and a
+unit rule of ours that superscripted a longitude.
 
 What the census decided, in order: a pronunciation between slashes or
 brackets goes whole and first; a symbol the serif lacks is spelled

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Seventeen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Eighteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished

--- a/docs/apps/wikipedia-plan.md
+++ b/docs/apps/wikipedia-plan.md
@@ -432,7 +432,7 @@ what MathML would have shown for that TeX; otherwise the words stay and
 the TeX goes. Counted per build (formulas_rendered, formulas_unmatched);
 96% of formulas render on the essentials.
 
-Eighteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
+Nineteen rounds ran on the night of 2026-09-11/12 (commits bb0ad49df
 onward): each one a census or a detector report or a cold reviewer's
 read of thirty random articles, every finding checked against the dump's
 own text before a rule was written, the essentials rebuilt and republished

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -135,7 +135,11 @@ def _comma_words(m):
 _GREEK_WORDS = frozenset(symbols.GREEK.values())
 # "{{rp}}" page references after a period: ".: ii. 161 : I.68 However"
 # the same with plain pages: "speciosa.: 86-95, 137)"
-_CITE_NUMERIC = re.compile(r"(?<=[a-z]{4}[.!?])(?::\s?\d{1,4}(?:[\u2013-]\d{1,4})?(?:, \d{1,4}(?:[\u2013-]\d{1,4})?)*)(?=[\s)]|$)")
+_CITE_NUMERIC = re.compile(
+    r"(?:(?<=[a-z]{4}[.!?])|(?<=[a-z][.!?]\)))(?::\s?(?:\d{1,4}|[ivxlc]{1,7})(?:[\u2013-]\d{1,4})?(?:,\s?(?:\d{1,4}(?:[\u2013-]\d{1,4})?|(?:fn|n|note)\.?\s?\d{1,3}))*)(?=[\s)]|$)"
+)
+# "Battle of the Windmill: 288 George's brother": the same after a bare word
+_CITE_AFTER_WORD = re.compile(r"(?<=[a-z]{3}): \d{2,4}(?:[\u2013-]\d{1,4})?(?=\s[A-Z][a-z])")
 _CITE_ROMAN = re.compile(r"(?<=[.,;!?])(?:\s?:\s?[IVXLCivxlc]{1,7}\.\s?\d{1,4}(?:[\u2013-]\d{1,4})?)+(?=\s|$)")
 # what the residue scanner steps over: TeX spacing, align marks, empty groups
 _TEX_LEFTOVER = re.compile(r"\\[,;:!>]|\{\s*\}")
@@ -502,7 +506,7 @@ def clean_text(s):
     if ": p" in s or ":p" in s:
         s = _CITE_PAGES.sub("", s)
     if ":" in s:
-        s = _CITE_NUMERIC.sub("", _CITE_ROMAN.sub("", s))
+        s = _CITE_AFTER_WORD.sub("", _CITE_NUMERIC.sub("", _CITE_ROMAN.sub("", s)))
     if s.startswith("#"):
         s = _NOTE_MARKER.sub("", s)
     if "==" in s:
@@ -1104,7 +1108,7 @@ _YEAR_TWICE = re.compile(r"\b(\d{4}) \(\1\)")
 _DECIMAL_COORDS = re.compile(r"\s*/\s*[\d.\u2212-]+\u00b0[NS]\s*[\d.\u2212-]+\u00b0[EW]")
 _COORDS_AFTER_TEXT = re.compile(r"([a-z]) (?=\d{1,3}\u00b0\d)")  # "Pakistan 25°24′N", not the N of a pair
 # "Coordinates: 41°37′N 44°00′E" as a nameless value: the label is the name
-_LABELLED_VALUE = re.compile(r"^([A-Z][a-z]+(?: [a-z]+){0,2}): (\S.*)$")
+_LABELLED_VALUE = re.compile(r"^([A-Z][a-z]+(?: [a-z]+){0,2}(?: \([^()]{1,30}\))?): (\S.*)$")
 # "team Former teams": a word of the row above leaked into the name
 _LEAKED_WORD = re.compile(r"^[a-z]+ (?=[A-Z][a-z]+)")
 _WEBSITE_VALUE = re.compile(r"^(?:official )?(?:web ?site|site|homepage|home page)$", re.I)
@@ -1136,7 +1140,7 @@ def _paren_then_item(m):
     inner, nxt = m.group(1), m.group(2)
     # "(Barfod) A.J.Hend.": a capitalised name in the parenthesis followed by
     # an initial is a botanical authority and keeps its shape
-    if inner[:1].isupper() and " " not in inner and re.match(r"[A-Z]\.", nxt):
+    if inner[:1].isupper() and " " not in inner and re.match(r"[A-Z][a-z]{0,6}\.", nxt):
         return m.group(0)
     if _COMPASS.match(nxt):
         return m.group(0)  # "(118 mi) W of Sydney"
@@ -1213,6 +1217,8 @@ def _spell_iso_date(s):
 
 _FACT_SKIP_NAMES = frozenset(("Imperial conversion", "Metric conversion", "NFPA 704 (fire diamond)", "NFPA 704"))
 _FACT_JUNK_VALUE = re.compile(r"^[\W_]*$|^\* ")
+_PARAM_LEAK = re.compile(r"^[a-z]+(?:_[A-Za-z]+)+\s?=")
+_GLUED_FIELD = re.compile(r"^([A-Z][A-Za-z]*(?: [A-Za-z]+){0,2}) ([A-Z][a-z]+): (\S.*)$")
 _NAMELESS_FACT = re.compile(r"\d|^In office|^Term|^Reign")
 _FOOTNOTE_VALUE = re.compile(r"^\d [A-Z][a-z]+ [a-z]")  # "1 Playing statistics correct to ..."
 # "C 20 H 8 Br 2" in a formula row: the subscripts the dump spaced out
@@ -1294,7 +1300,8 @@ def fact_value(name, value):
     if name.lower() in _DATE_KEYS:
         value = re.sub(r"\b([A-Za-z]+) (?=(?:c\. )?\d{4}\b)", _word_then_year, value)  # "Kirkpatrick III 1951"
         value = _DATE_THEN_PLACE.sub(r"\1, ", value)
-    value = _PAREN_THEN_ITEM.sub(_paren_then_item, value)
+    if not _TAXON_RANK.match(name.strip()):
+        value = _PAREN_THEN_ITEM.sub(_paren_then_item, value)
     return value.strip()
 
 
@@ -1710,6 +1717,13 @@ class _Doc:
             )
             if "coordinates" in name.lower() and " / " in value:
                 value = value.split(" / ")[0].strip()
+            if _PARAM_LEAK.match(value):
+                return  # "share_of_grocery_market_in_Taiwan =41.3%"
+            glued = _GLUED_FIELD.match(value)
+            if glued and len(name.split()) <= 2:
+                add(name, glued.group(1), group)
+                add(glued.group(2), glued.group(3), group)
+                return
             if value in _FACT_LABELS or value in (self.title, self.title.split(",")[0].strip(), base):
                 return  # "Preceded by: Succeeded by": both values were flags; "Azerbaijani: <title>"
             name = name[:1].upper() + name[1:]

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -103,6 +103,8 @@ _CITE_PAGE = re.compile(r"(?<=[.,;!?])(?:\s?:\s?[A-Z]?\d+(?:[\u2013-]\d+)?(?:,\s
 _COMMA_GLUE = re.compile(r"(?<=[a-z]),(?=[A-Za-z]{2,})")
 # "A_{1}^{\\complement }\\quad": TeX the dump left outside any block
 _TEX_LOOSE = re.compile(r"(?:\\[A-Za-z]+\s*|[A-Za-z]?[_^]\{[^{}]*\}\s*){2,}")
+_TEX_ENV = re.compile(r"\{?\\begin\{([a-z*]+)\}.*?\\end\{\1\}\}?\s*(?:\\right\.)?", re.S)
+_TEMPLATE_ERROR = re.compile(r"\s*(?::\s*)?(?:ISBN / Date incompatibility|Check date values in: [^()]*|Cite \w+ requires [^()]*)\s*\(help\)")
 _WS = re.compile(r"\s+")
 # A Greek letter standing alone is a symbol ("frequency \u03bd"), and the
 # reader's serif has no Greek; a Greek word beside other Greek is a run the
@@ -292,7 +294,7 @@ _TIDY = (
     (re.compile(r"\s*[,;:]\s*\)"), ")"),
     (re.compile(r"\(\s*\)"), ""),
     (re.compile(r"\[\s*\]"), ""),
-    (re.compile(r"\s+([,;:?)]|!(?!=))"), r"\1"),  # "a != 0" keeps its space
+    (re.compile(r"\s+([,;?)]|!(?!=)|:(?!\s?\d))"), r"\1"),  # "a != 0" and "3 : 1" keep their spaces
     (re.compile(r"\s+\.(?![A-Za-z0-9])"), "."),
     (re.compile(r"\(\s+"), "("),
     (re.compile(r"(?:[,;:]\s*)+([,;:])"), r"\1"),
@@ -339,7 +341,10 @@ def clean_text(s):
     if "style" in s and _TEX_OPEN.search(s):
         s = _render_tex(s)
     if "\\" in s:
+        s = _TEX_ENV.sub("", s)
         s = _TEX_LOOSE.sub("", s)  # TeX the dump left outside any block
+    if "(help)" in s:
+        s = _TEMPLATE_ERROR.sub("", s)
     if "{{" in s:
         s = _TEMPLATE.sub("", s)
     s = _CITE.sub("", s)
@@ -422,7 +427,7 @@ _CLITIC_GAP = re.compile(r"(?<=[\w)\]\"\u201d])[ \u00a0]+(['\u2019])(s|d|ll|re|v
 _PUNCT_GAP = re.compile(r"(?<=\S)[ \u00a0]+([,.;!?])(?=\s|$)")
 # "epsilon : Permittivity": a colon padded between two words (a ratio,
 # "3 : 1", keeps its spaces)
-_COLON_GAP = re.compile(r"(?<=[A-Za-z\u00c0-\u024f]) :(?= [A-Za-z\u00c0-\u024f])")
+_COLON_GAP = re.compile(r"(?<=[A-Za-z\u00c0-\u024f)]) :(?=\s|$)|(?<=[A-Za-z\u00c0-\u024f]) :(?= [A-Za-z\u00c0-\u024f])")
 # "Protestant -led", "post- Civil War": a hyphen padded on one side after a
 # link or an italic (0.8 and 0.5 per article). "pre- and post-war" is the
 # one idiom that keeps its space, so a hyphen before "and" or "or" stays.
@@ -621,7 +626,16 @@ def _plain(word):
 
 
 _MARK_LABEL = re.compile(r"(?<![A-Za-z])[A-Z][A-Za-z]*(?:[ -][A-Za-z]+){0,2}:\s*" + _MARK + r"\s*,?\s*(?=(?:romani[sz]ed|translit\w*|pinyin|lit\.|literally|IPA)\b)")
-_MARK_COMMA = re.compile(_MARK + r"\s*,\s*(?=[A-Z])")
+# "pl. <run>, madhāhib" reads "pl. madhāhib": after an abbreviation the
+# romanisation may be lowercase
+_MARK_COMMA = re.compile(r"(\b(?:pl|sing|lit|abbr|orig|trans|cf)\.\s*)?" + _MARK + r"\s*,\s*(?=(\S)?)")
+
+
+def _mark_comma(m):
+    nxt = m.group(2) or ""
+    if m.group(1) or nxt.isupper():
+        return (m.group(1) or "") + " "
+    return m.group(0)
 _MARK_COLON = re.compile(r":\s*" + _MARK + r"\s*,\s*")
 _MARK_ANY = re.compile(r"\s*" + _MARK + r"\s*")
 
@@ -636,7 +650,7 @@ def _settle_marks(text):
     label."""
     text = _MARK_ROMAN.sub(" ", text)
     text = _MARK_LABEL.sub("", text)
-    text = _MARK_COMMA.sub(" ", text)
+    text = _MARK_COMMA.sub(_mark_comma, text)
     text = _MARK_COLON.sub(": ", text)
     text = _MARK_ANY.sub(" ", text)
     return text
@@ -685,9 +699,11 @@ def strip_undrawable(text, stats, lead=False):
                 continue
             rest = _settle_marks(run_re.sub(_MARK, seg))
             rest = _EMPTY_LABEL_END.sub("", rest).strip(" ,:")
-            # "romanized: Theophrastos" is two words and the whole point;
+            # "romanized: Theophrastos" is two words and the whole point, and
+            # "Moskva" alone is the romanisation of the word that went;
             # "from" alone, or "from or", is what a removal left behind
-            if len(rest.split()) >= 2 and not all(w.lower().strip(".,") in _FUNCTION_WORDS for w in rest.split()):
+            words = rest.split()
+            if words and (len(words) >= 2 or words[0][:1].isupper()) and not all(w.lower().strip(".,") in _FUNCTION_WORDS for w in words):
                 kept.append(re.sub(r"  +", " ", rest))
         if not kept:
             return ""
@@ -785,9 +801,14 @@ def scrub_artifacts(text):
     if not text or not _SCRUB_HINT.search(text):
         return text, 0
     n = 0
-    for rx, rep in _SCRUB:
-        text, k = rx.subn(rep, text)
-        n += k
+    for _ in range(3):
+        k_all = 0
+        for rx, rep in _SCRUB:
+            text, k = rx.subn(rep, text)
+            k_all += k
+        n += k_all
+        if not k_all:
+            break
     if text.count("(") != text.count(")"):
         text, k = _balance(text, "(", ")")
         n += k
@@ -862,7 +883,19 @@ _AGE = re.compile(r"\s*\(aged?\s+\d+(?:\s*[\u2013-]\s*\d+)?\)")
 _DATE_THEN_PLACE = re.compile(
     r"(\b(?:\d{1,2} [A-Z][a-z]+ \d{4}|[A-Z][a-z]+ \d{1,2}, \d{4}|\d{4}))\s+(?=[A-Z])"
 )
-_PAREN_THEN_ITEM = re.compile(r"\)\s+(?=[A-Z])")
+# "(aged 45) Chicago" reads "(aged 45), Chicago"; "(Barfod) A.J.Hend.", a
+# botanical authority, keeps its shape: only a parenthesis that ends in a
+# digit is a date's
+_PAREN_THEN_ITEM = re.compile(r"\(([^()]*)\)\s+(?=([A-Z][A-Za-z.]*))")
+
+
+def _paren_then_item(m):
+    inner, nxt = m.group(1), m.group(2)
+    # "(Barfod) A.J.Hend.": a capitalised name in the parenthesis followed by
+    # an initial is a botanical authority and keeps its shape
+    if inner[:1].isupper() and " " not in inner and re.match(r"[A-Z]\.", nxt):
+        return m.group(0)
+    return "(" + inner + "), "
 _DATE_KEYS = frozenset(("born", "died", "birth date", "death date"))
 
 
@@ -950,7 +983,7 @@ def fact_value(name, value):
     value = _DEGREE_GAP.sub("\u00b0", value)
     if name.lower() in _DATE_KEYS:
         value = _DATE_THEN_PLACE.sub(r"\1, ", value)
-    value = _PAREN_THEN_ITEM.sub("), ", value)
+    value = _PAREN_THEN_ITEM.sub(_paren_then_item, value)
     return value.strip()
 
 
@@ -1215,11 +1248,12 @@ class _Doc:
                 # arrives as the same text in every column: say it once
                 cells = cells[:1]
             for j, c in enumerate(cells):
-                c = cut_words(c, TABLE_ROW_CELL_WORDS)
+                c = cut_words(c.strip(), TABLE_ROW_CELL_WORDS)
                 if len(c.split(" ")) >= TABLE_ROW_CELL_WORDS:
                     c, _ = scrub_artifacts(c)  # a cut can leave a parenthesis open
-                if not c:
-                    continue
+                c = re.sub(r"  +", " ", c).strip()
+                if not c or c.endswith(":"):
+                    continue  # empty, or a label whose script went
                 label = labels[j] if j < len(labels) else ""
                 if _REF_COLUMN.match(label):
                     continue
@@ -1230,7 +1264,7 @@ class _Doc:
                 else:
                     parts.append(esc(c))
             if parts:
-                out.append("<p>" + "; ".join(parts) + "</p>")
+                out.append("<p>" + re.sub(r"  +", " ", "; ".join(parts)) + "</p>")
         if len(body) > TABLE_ROWS_LISTED:
             out.append("<p><i>(%d more rows)</i></p>" % (len(body) - TABLE_ROWS_LISTED))
         if out:

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -412,6 +412,10 @@ _LEAD_COORDS = re.compile(
     r"^\s*\d{1,3}\u00b0[\d\u2032\u2033'\"\s.]*[NS]\s*\d{1,3}\u00b0[\d\u2032\u2033'\"\s.]*[EW]"
     r"(?:\s*/\s*[\d.\u2212-]+\u00b0[NS]\s*[\d.\u2212-]+\u00b0[EW])?(?:\s*/\s*[\d.\u2212-]+;\s*[\d.\u2212-]+)?\s*(?=[A-Z])"
 )
+# a paragraph that is only a coordinate pair (a fact's value may be one)
+_COORDS_ONLY = re.compile(
+    r"^\s*\d{1,3}\u00b0[\d\u2032\u2033'\"\s.]*[NS]\s*\d{1,3}\u00b0[\d\u2032\u2033'\"\s.]*[EW](?:\s*/.*)?$"
+)
 _FUNCTION_WORDS = frozenset("from or and of the a an in at by to lit also see cf".split())
 _EMPTY_PAREN = re.compile(r"\s?\(\s*[,;:\s]*\)")
 # "(pronounced French pronunciation:)": the IPA went with its slashes
@@ -435,7 +439,8 @@ _TIDY = (
     (re.compile(r"\s+([,;?)]|!(?![=A-Za-z0-9])|:(?!\s?\d|-?[()]))"), r"\1"),  # "a != 0", "3 : 1", the click in "!Nanseb" and the face in ":)" keep their spaces
     (re.compile(r"\s+\.(?![A-Za-z0-9])"), "."),
     (re.compile(r"\(\s+"), "("),
-    (re.compile(r"(?:[,;:]\s*)+([,;:])"), r"\1"),
+    (re.compile(r"(?:[,;]\s*)+([,;:])"), r"\1"),  # ",," and ";,"
+    (re.compile(r":(?:\s*:)+(?=\s|$)"), ":"),  # "Note:: text", not the "::" of "fec0::/10"
     (re.compile(r"\s{2,}"), " "),
 )
 
@@ -1223,7 +1228,8 @@ def _spell_iso_date(s):
 
 
 _FACT_SKIP_NAMES = frozenset(("Imperial conversion", "Metric conversion", "NFPA 704 (fire diamond)", "NFPA 704", "Title card", "Caption", "Image caption", "Logo caption", "Map caption"))
-_FACT_JUNK_VALUE = re.compile(r"^[\W_]*$|^\* ")
+_FACT_JUNK_VALUE = re.compile(r"^[\W_]*$|^\* |^<-\s|^.*\s->$")  # "<- 1962", "1964 ->": an infobox's previous/next arrows
+_HEADER_VALUE = re.compile(r"^(?:Scientific classification|Official (?:Results|Website|Site)|Details|Overview|History)$", re.I)
 _PARAM_LEAK = re.compile(r"^[a-z]+(?:_[A-Za-z]+)+\s?=")
 _GLUED_FIELD = re.compile(r"^([A-Z][A-Za-z]*(?: [A-Za-z]+){0,2}) ([A-Z][a-z]+): (\S.*)$")
 _NAMELESS_FACT = re.compile(r"\d|^In office|^Term|^Reign")
@@ -1293,6 +1299,8 @@ def fact_value(name, value):
     value = _spell_iso_date(value)
     if value.startswith("-> "):
         value = "to " + value[3:]  # a loan arrow at the front of a cell
+    value = re.sub(r";\s*\(", " (", value)  # "Townsquare Media; (Townsquare License, LLC)": a folded line break
+    value = re.sub(r"\)\s+\(", "; ", value)  # "Illinois (Vacated) (1st title)": two asides where a line broke
     value = re.sub(r"\b([A-Z]):(?=\d)", r"\1: ", value)
     if "\u00b0" in value:
         value = _DECIMAL_COORDS.sub("", value)
@@ -1383,7 +1391,7 @@ class _Doc:
         text = strip_undrawable(
             clean_text(part.get("value") or ""), self.stats, lead=lead
         )
-        if not text:
+        if not text or _COORDS_ONLY.match(text):
             return ""
         links = self._place_links(text, part.get("links"), lead)
         bold = self._subject(text) if subject else None
@@ -1731,6 +1739,8 @@ class _Doc:
                 add(name, glued.group(1), group)
                 add(glued.group(2), glued.group(3), group)
                 return
+            if name in (self.title, base) or _HEADER_VALUE.match(value):
+                return  # a taxobox's "<title>: Scientific classification", a link caption "Official Results"
             if value in _FACT_LABELS or value in (self.title, self.title.split(",")[0].strip(), base):
                 return  # "Preceded by: Succeeded by": both values were flags; "Azerbaijani: <title>"
             name = name[:1].upper() + name[1:]

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -141,7 +141,10 @@ _FLAT_THEN_TEX = re.compile(r"\b(\w) (\w) (?=\1\^\{\2\})")
 _SCRIPT_BRACES = re.compile(r"(\w)\^\{(\w)\}")
 # a formula the dump lost the middle of: "sigma = sigma_ij = = == ==,"
 _REPEATED_EQUALS = re.compile(r"([=\u2261]=?)(?:\s+[=\u2261]=?)+(?!\S)")
-_TRAILING_EQUALS = re.compile(r"(?:\s*[=\u2261]=?)+(?=\s*[,.;]?\s*$)")
+# one greedy run per group, groups split by whitespace: "(?:\\s*=?=)+" was
+# ambiguous on "=====" and took exponential time on a rule of 36 of them,
+# which stalled a full build (2026-09-12)
+_TRAILING_EQUALS = re.compile(r"\s*[=\u2261]+(?:\s+[=\u2261]+)*(?=\s*[,.;]?\s*$)")
 # two quoted lines the dump joined: "her.'""'Did you" gets its space back
 _QUOTE_GLUE = re.compile(r"([.!?][\"']{1,2})([\"']{1,2}[A-Z])")
 _TEX_START = re.compile(r"\\(?:\\|[A-Za-z]+)")

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -1156,7 +1156,7 @@ def _word_then_year(m):
     return w + ", "
 
 
-_NAME_GROUP = re.compile(r"\bnames?$", re.I)  # "Korean name", "Chinese name": every row carries it
+_NAME_GROUP = re.compile(r"\b[A-Za-z]+ names?$", re.I)  # "Korean name", "Chinese name": every row carries it; a bare "Names" group does not
 
 
 _LIST_ROWS = re.compile(
@@ -1215,7 +1215,7 @@ def _spell_iso_date(s):
     return "%d %s %s" % (int(m.group(3)), _MONTHS[int(m.group(2))], m.group(1))
 
 
-_FACT_SKIP_NAMES = frozenset(("Imperial conversion", "Metric conversion", "NFPA 704 (fire diamond)", "NFPA 704"))
+_FACT_SKIP_NAMES = frozenset(("Imperial conversion", "Metric conversion", "NFPA 704 (fire diamond)", "NFPA 704", "Title card", "Caption", "Image caption", "Logo caption", "Map caption"))
 _FACT_JUNK_VALUE = re.compile(r"^[\W_]*$|^\* ")
 _PARAM_LEAK = re.compile(r"^[a-z]+(?:_[A-Za-z]+)+\s?=")
 _GLUED_FIELD = re.compile(r"^([A-Z][A-Za-z]*(?: [A-Za-z]+){0,2}) ([A-Z][a-z]+): (\S.*)$")

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -113,7 +113,7 @@ _REF_TAG = re.compile(r"<ref\b[^>]*/>|<ref\b[^>]*>.*?</ref>|<ref\b[^>]*>|<ref\b[
 # Parsoid's protection markers, leaked into a few articles: "\ufffdPROT139\ufffd"
 # stands where a reference or template was, and one can end an unclosed
 # template ("{{Pie chart| caption = ...\ufffdPROT199\ufffd Roughly ...")
-_PROT = re.compile(r"\{\{[^{}]*?\ufffdPROT\d+\ufffd\s*|\s?\ufffdPROT\d+\ufffd")
+_PROT = re.compile(r"\{\{[^{}]*?\ufffdPROT\d+\ufffd\s*|\s?\ufffdPROT\d+\ufffd|\s?`UNIQ--[a-z]+-[0-9A-Fa-f ]+-QINU`")
 # a footnote the dump left in the prose, and a template opener never closed
 # ("{{block indent| sigma: F -> F'"): the note goes, the opener alone goes
 _NOTE_TEMPLATE = re.compile(r"\s?\{\{(?:efn|sfn|refn|notetag|note)\|[^{}]{0,800}\}\}")
@@ -425,10 +425,12 @@ _BRACKETED = re.compile(r" ?\[[^\[\]]{1,80}\]")
 
 _TIDY = (
     (re.compile(r"\(\s*[,;:]\s*"), "("),
-    (re.compile(r"(?<![\s(]\")(?<!^\")\s*[,;:]\s*\)"), ")"),  # not the face of ":)"
+    # a mark after a word, a closing quote or a bracket goes before ")"; after a
+    # space or an opening quote it is the face of ":)" and stays
+    (re.compile(r"(?<=[A-Za-z0-9.')\]])[,;:]\s*\)|(?<=[A-Za-z0-9.]\")[,;:]\s*\)"), ")"),
     (re.compile(r"\(\s*\)"), ""),
     (re.compile(r"\[\s*\]"), ""),
-    (re.compile(r"\s+([,;?)]|!(?!=)|:(?!\s?\d))"), r"\1"),  # "a != 0" and "3 : 1" keep their spaces
+    (re.compile(r"\s+([,;?)]|!(?![=A-Za-z0-9])|:(?!\s?\d|-?[()]))"), r"\1"),  # "a != 0", "3 : 1", the click in "!Nanseb" and the face in ":)" keep their spaces
     (re.compile(r"\s+\.(?![A-Za-z0-9])"), "."),
     (re.compile(r"\(\s+"), "("),
     (re.compile(r"(?:[,;:]\s*)+([,;:])"), r"\1"),
@@ -511,7 +513,7 @@ def clean_text(s):
         s = _NOTE_MARKER.sub("", s)
     if "==" in s:
         s = _HEADING_MARKS.sub("", s)
-    if "PROT" in s:
+    if "PROT" in s or "QINU" in s:
         s = _PROT.sub("", s)
     if "{{" in s:
         s = _TEMPLATE.sub("", s)
@@ -963,10 +965,11 @@ def strip_undrawable(text, stats, lead=False):
     if n:
         removed += 1
         stats["inline_gaps_closed"] = stats.get("inline_gaps_closed", 0) + n
-    if removed:
-        for rx, rep in _TIDY:
-            text = rx.sub(rep, text)
-        text = text.strip()
+    # the seams a removal leaves, and the same seams the dump itself has
+    # ("(e.g.:)", "apostrophe';)"): tidied whether or not anything went
+    for rx, rep in _TIDY:
+        text = rx.sub(rep, text)
+    text = text.strip()
     text, n = scrub_artifacts(text)
     if n:
         stats["artifacts_scrubbed"] = stats.get("artifacts_scrubbed", 0) + n
@@ -1032,7 +1035,7 @@ def _is_face(text, i):
         j -= 1
     if j < 0 or text[j] not in ":;":
         return False
-    return j == 0 or text[j - 1] in " \t\"'\u201c\u2018"
+    return j == 0 or text[j - 1] in " \t\"\u201c\u2018"
 
 
 def _balance(text, opener, closer):
@@ -1968,8 +1971,8 @@ _INLINE_EMPTY_LABEL = re.compile(
 )
 _EMPTY_ANCHOR = re.compile(r'<a href="[^"]*">\s*</a>')
 _INLINE_TIDY = (
-    (re.compile(r"\(\s*[;,]\s*"), "("),
-    (re.compile(r"\s*[;,]\s*\)"), ")"),
+    (re.compile(r"\(\s*[;,:]\s*"), "("),
+    (re.compile(r"(?<![\s(]\")\s*[;,:]\s*\)"), ")"),
     (re.compile(r"\s?\(\s*\)"), ""),
     (re.compile(r"\s+([,;)])"), r"\1"),
 )

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -104,6 +104,62 @@ _COMMA_GLUE = re.compile(r"(?<=[a-z]),(?=[A-Za-z]{2,})")
 # "A_{1}^{\\complement }\\quad": TeX the dump left outside any block
 _TEX_LOOSE = re.compile(r"(?:\\[A-Za-z]+\s*|[A-Za-z]?[_^]\{[^{}]*\}\s*){2,}")
 _TEX_ENV = re.compile(r"\{?\\begin\{([a-z*]+)\}.*?\\end\{\1\}\}?\s*(?:\\right\.)?", re.S)
+# ": p.45–78 : p.1–46 : p.111–157": page ranges of citations in a row
+_CITE_PAGES = re.compile(r"(?:\s*:\s*p{1,2}\.\s?\d+(?:[\u2013-]\d+)?\b)+")
+# "## x:", "#; Key": a note marker the dump kept at a line's start
+_NOTE_MARKER = re.compile(r"^#+;?\s+")
+# a raw reference tag the dump left in the prose
+_REF_TAG = re.compile(r"<ref\b[^>]*/>|<ref\b[^>]*>.*?</ref>|<ref\b[^>]*>", re.S | re.I)
+_TEX_START = re.compile(r"\\(?:\\|[A-Za-z]+)")
+_TEX_SCRIPT_GROUP = re.compile(r"\s?[A-Za-z]?(?:[_^]\{[^{}]*\}\s*)+")
+
+
+def _strip_tex_residue(s):
+    """TeX the dump left outside any block, in any shape: from a backslash
+    command on, over braces (balanced), scripts, operators and letters, up to
+    the end of the run. "nabla v = R nabla u \\nabla v=R\\nabla u where R is"
+    keeps its words and loses the TeX."""
+    out = []
+    i = 0
+    n = len(s)
+    while True:
+        m = _TEX_START.search(s, i)
+        if not m:
+            out.append(s[i:])
+            break
+        j = m.start()
+        k = m.end()
+        depth = 0
+        while k < n:
+            c = s[k]
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                if depth == 0:
+                    break
+                depth -= 1
+            elif depth == 0:
+                if c == "\\":
+                    k += 1  # a command: its letters belong to the run
+                    while k < n and s[k].isalpha():
+                        k += 1
+                    continue
+                if c.isalpha():
+                    # a word of two or more letters is prose again; a single
+                    # letter is a variable and stays in the run
+                    if k + 1 < n and s[k + 1].isalpha():
+                        break
+                elif c == "." and k + 1 < n and s[k + 1] == " ":
+                    break
+                elif not (c in "^_&=+*/,;()[]| \t" or c.isdigit() or c in "\u2212-'"):
+                    break
+            k += 1
+        # trim to the last TeX-looking char
+        run = s[j:k].rstrip(" ,;")
+        out.append(s[i:j].rstrip())
+        out.append(" ")
+        i = j + len(run)
+    return re.sub(r"  +", " ", "".join(out))
 _TEMPLATE_ERROR = re.compile(r"\s*(?::\s*)?(?:ISBN / Date incompatibility|Check date values in: [^()]*|Cite \w+ requires [^()]*)\s*\(help\)")
 _WS = re.compile(r"\s+")
 # A Greek letter standing alone is a symbol ("frequency \u03bd"), and the
@@ -266,7 +322,7 @@ def _runs():
         bad = "(?:[^" + drawable_class() + "]|[" + REMOVED_SCRIPTS + "])"
         run = bad + r"(?:\s*" + bad + ")*"
         _run_re = re.compile(run)
-        label = r"(?:(?<![A-Za-z])[A-Z][A-Za-z]*(?:[ -][A-Za-z]+){0,2}:\s?)?"
+        label = r"(?:(?<![A-Za-z])(?:(?:simplified|traditional|literally|romani[sz]ed|born|modern|classical|standard|colloquial|formal|archaic|native|also|formerly|abbreviated|pinyin) )?[A-Z][A-Za-z]*(?:[ -][A-Za-z]+){0,2}:\s?)?"
         _labelled_run_re = re.compile(label + run)
     return _run_re, _labelled_run_re
 
@@ -282,11 +338,14 @@ _EMPTY_LABEL_END = re.compile(
     r"(?<![A-Za-z0-9])[A-Za-z][A-Za-z.]*(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)]|$)"
 )
 # "(listen)": the audio link's text, with no audio to play
-_LISTEN = re.compile(r"\s?\(\s*listen\s*\)", re.I)
+_LISTEN = re.compile(r"\s?\(\s*(?:listen|more)\s*\)", re.I)
 _FUNCTION_WORDS = frozenset("from or and of the a an in at by to lit also see cf".split())
 _EMPTY_PAREN = re.compile(r"\s?\(\s*\)")
 # IPA between slashes or brackets, when the serif cannot draw it.
 _SLASHED = re.compile(r" ?/[^/]{1,80}/")
+# what a pronunciation carries that prose never does: IPA letters, modifier
+# letters, tone bars, or the spaced single letters of the dump's IPA
+_IPA_CHAR = re.compile(r"[\u0250-\u02ff\u1d00-\u1dbf]|(?: [a-z\u00e6\u00f0\u00f8\u03b8]){3}")
 _BRACKETED = re.compile(r" ?\[[^\[\]]{1,80}\]")
 
 _TIDY = (
@@ -330,7 +389,7 @@ def clean_text(s):
         s = html.unescape(s)  # "22 &amp;amp; 23 Geo. 5": the source escaped it twice
     if "." in s:
         s = _SENTENCE_GLUE.sub(r"\1 \2", s)
-    if "listen" in s:
+    if "(" in s:
         s = _LISTEN.sub("", s)
     if "," in s:
         s = _COMMA_GLUE.sub(", ", s)
@@ -342,9 +401,16 @@ def clean_text(s):
         s = _render_tex(s)
     if "\\" in s:
         s = _TEX_ENV.sub("", s)
-        s = _TEX_LOOSE.sub("", s)  # TeX the dump left outside any block
+        s = _strip_tex_residue(s)  # TeX the dump left outside any block
+        s = re.sub(r"  +", " ", _TEX_SCRIPT_GROUP.sub(" ", s))  # "A_{1}^{ }" left beside it
     if "(help)" in s:
         s = _TEMPLATE_ERROR.sub("", s)
+    if "<ref" in s:
+        s = _REF_TAG.sub("", s)
+    if ": p" in s or ":p" in s:
+        s = _CITE_PAGES.sub("", s)
+    if s.startswith("#"):
+        s = _NOTE_MARKER.sub("", s)
     if "{{" in s:
         s = _TEMPLATE.sub("", s)
     s = _CITE.sub("", s)
@@ -459,7 +525,7 @@ _HYPHEN_AFTER = re.compile(r"(?<=\w)([-\u2013\u2014])[ \u00a0]+(?=(?!(?:and|or)\
 # Wikipedia's respelling, "(TAM-ilz, TAHM-)": syllables in capitals joined by
 # hyphens, two of them or one ending in a hyphen, and nothing else in the
 # parentheses. "(US-based)" is one plain token and stays.
-_RESPELL_TOKEN = r"[A-Z]{1,6}(?:-[a-z]{1,8})*-?"
+_RESPELL_TOKEN = r"(?:[a-z]{1,4}-)?[A-Z]{1,6}(?:-[a-z]{1,8})*-?"
 _RESPELL = re.compile(
     r"[ \u00a0]*\((?:" + _RESPELL_TOKEN + r"(?:,? " + _RESPELL_TOKEN + r")+|[A-Z]{1,6}(?:-[a-z]{1,8})*-)\)"
 )
@@ -603,9 +669,12 @@ def _romanize_runs(text, run_re):
             return run
         latin = symbols.romanize(run)
         # "\u1f08\u03c1\u03b9\u03b8\u03bc\u03bf\u03af, Arithmoi": the source's own romanisation
-        # follows; the run goes and that one stays
+        # follows; the run goes and that one stays. "The Neretva (Serbian
+        # Cyrillic: \u041d\u0435\u0440\u0435\u0442\u0432\u0430)": the sentence has the word already
         after = _NEXT_WORD.match(text, m.end())
         if after and _plain(after.group(1)) == _plain(latin):
+            return run
+        if " " not in latin.strip() and re.search(r"(?<![A-Za-z])" + re.escape(_plain(latin)) + r"(?![A-Za-z])", _plain(text[: m.start()])):
             return run
         n += 1
         return latin
@@ -668,8 +737,8 @@ def strip_undrawable(text, stats, lead=False):
     def drop_span(m):
         nonlocal removed
         whole = m.group(0)
-        if not run_re.search(whole):
-            return whole
+        if not run_re.search(whole) or not _IPA_CHAR.search(whole):
+            return whole  # "10 μg/dL (10 μg/100 g)" is units, not a pronunciation
         removed += 1
         stats["spans_removed"] = stats.get("spans_removed", 0) + 1
         return ""
@@ -790,7 +859,7 @@ _SCRUB = (
     (re.compile(r"\s+\)"), ")"),
     (re.compile(r"^\s*[,;]\s*"), ""),
     (re.compile(r"\s*[,;]$"), ""),
-    (re.compile(r"[ \t]{2,}"), " "),
+    (re.compile(r"[ \t\u00a0]{2,}"), " "),
 )
 _SCRUB_HINT = re.compile(r"[()\[\]{}\"\u201c\u2018',;]")
 
@@ -902,11 +971,23 @@ _DATE_KEYS = frozenset(("born", "died", "birth date", "death date"))
 _NAME_GROUP = re.compile(r"\bnames?$", re.I)  # "Korean name", "Chinese name": every row carries it
 
 
-def _split_at_links(value, links):
+_LIST_ROWS = re.compile(
+    r"characters|members|names|children|relatives|works|genres|labels|occupations|known for|fields|institutions|"
+    r"awards|influences|languages|groups|religions|subdivisions|ideas|notable|alumni|students|advisors|parties|"
+    r"predecessor|successor|founders|owners|products|services|divisions|subsidiaries|partners|spouses|parents",
+    re.I,
+)
+
+
+def _split_at_links(value, links, name=""):
     """"Atossa Messenger Ghost of Darius Xerxes" with links for Atossa, Ghost
     of Darius and Xerxes is three items the dump glued; where one link's
-    text starts right after another ends, a "; " goes between them."""
+    text starts right after another ends, a "; " goes between them. Two
+    adjacent links in a row that is not a list ("Tortricoidea Latreille,
+    1803", a taxon and its authority) stay as they are."""
     if not links or len(links) < 2:
+        return value
+    if len(links) < 3 and not _LIST_ROWS.search(name or ""):
         return value
     texts = [lk.get("text") for lk in links if isinstance(lk, dict) and isinstance(lk.get("text"), str) and lk.get("text")]
     if len(texts) < 2:
@@ -969,10 +1050,17 @@ def _unit_exponent(m):
     return m.group(0)
 
 
+_WRAPPED = re.compile(r"^\(([^()]+)\)$")
+_SHELL = re.compile(r"\b(\d[spdf]) (\d{1,2})\b")
+
+
 def fact_value(name, value):
     if not value:
         return value
     value = _AGE.sub("", value)
+    value = _WRAPPED.sub(r"\1", value.strip())
+    if "configuration" in name.lower() or "shell" in name.lower():
+        value = _SHELL.sub(lambda m: m.group(1) + m.group(2).translate(_SUPER), value)
     value = _YEAR_PAGE.sub("", value)
     value = re.sub(r"(\d{4}) /(\d{4})\b", r"\1/\2", value)
     if _FORMULA_ROW.search(name):
@@ -1386,19 +1474,22 @@ class _Doc:
                 # a group is a short label; a "section" whose name is a whole
                 # medal table is the table, not a group
                 if name and name != self.title and len(name.split()) <= 8 and not name.lower().startswith("infobox"):
-                    group = name
+                    # "Transcriptions" under "Chinese name" keeps the group
+                    # that says which language the rows belong to
+                    if not (group and _NAME_GROUP.search(group)):
+                        group = name
             if t == "field" and isinstance(p.get("value"), str):
                 fname = p.get("name")
                 if p.get("images"):
                     return  # the field is an image and its value is the caption
-                value = _split_at_links(p["value"], p.get("links"))
+                value = _split_at_links(p["value"], p.get("links"), fname or "")
                 if group and _NAME_GROUP.search(group) and fname:
                     add(group + ", " + fname.strip(), value, group)
                     return
                 if not fname:
                     # "In office 1945 - 1950" under its office; a caption in a
                     # section that holds an image is the image's, not a fact
-                    if group and not has_image.get(group) and _NAMELESS_FACT.search(value):
+                    if group and (not has_image.get(group) or any(c.isdigit() for c in value)) and _NAMELESS_FACT.search(value):
                         add(group, value)
                 elif group and fname.strip().lower() in _GENERIC_FIELDS:
                     add(group + ", " + fname.strip().lower(), value)
@@ -1537,7 +1628,7 @@ def heading_bytes(text):
 
 
 
-_INLINE_DOUBLE_SPACE = re.compile(r"(?<=\S)  +(?=\S)")
+_INLINE_DOUBLE_SPACE = re.compile(r"(?<=\S)[ \u00a0]{2,}(?=\S)")
 _INLINE_EMPTY_LABEL = re.compile(
     r"(?<![A-Za-z0-9>])[A-Z][A-Za-z.]*(?:[ -][A-Za-z.]+){0,3}:\s*(?:</a>)?\s*(?=[;,)]|</)"
 )

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -400,7 +400,7 @@ _EMPTY_LABEL_END = re.compile(
 # "(listen)": the audio link's text, with no audio to play
 _LISTEN = re.compile(r"\s?\(\s*(?:listen|more)\s*\)", re.I)
 # "April 26, 1994 (1994-04-26)": the start-date template's hidden ISO copy
-_ISO_DATE_DUP = re.compile(r"(?<=[a-z0-9])\s?\(\d{4}-\d{2}(?:-\d{2})?\)")
+_ISO_DATE_DUP = re.compile(r"(?<=[a-z0-9])\s?\(\d{4}-\d{2}(?:-\d{1,2})?\)")  # "(2015-03-2)" too
 # "(Pub. L. Tooltip Public Law (United States)107-252 (text) (PDF))": an
 # abbreviation's tooltip and the law template's link labels
 _TOOLTIP = re.compile(r"\s?\bTooltip [A-Z][A-Za-z .]{0,60}(?:\([^()]{0,40}\))? ?(?=\d|$)")
@@ -482,8 +482,10 @@ def clean_text(s):
         s = _TOOLTIP.sub(" ", s)
     if "v" in s:
         s = _VTE.sub("", s)
-    if "\u00b0" in s and _LEAD_COORDS.match(s):
-        s = _LEAD_COORDS.sub("", s, count=1)
+    if "\u00b0" in s:
+        if _LEAD_COORDS.match(s):
+            s = _LEAD_COORDS.sub("", s, count=1)
+        s = _DECIMAL_COORDS.sub("", s)
     if "," in s:
         s = _COMMA_GLUE.sub(", ", s)
     s = _YEAR_GLUE.sub(r"\1 ", s)
@@ -1261,9 +1263,11 @@ _NAME_FOOTNOTE = re.compile(r"(?<=[A-Za-z)]) \d$|(?<=[A-Za-z)])\*$")
 # a table's header row that arrived as a field: "Years: Team", "Source: Rating"
 _HEADER_WORDS = frozenset("years year team club title role source rating apps gls goals pos nation player name no. date opponent result venue competition".split())
 _SLASH_GAP = re.compile(r"(?<=\S) /(?=[A-Za-z0-9])(?!\d{4}\b)")  # not "1564 /1563", a year either way
+_UNIT_FRACTION = re.compile(r"(?<=[a-z\u00b2\u00b3]) / (?=(?:s|h|min|kg|km|m|mol|L|yr|day|ha)\b)")  # "m³ / s", "km / h"
 _FACT_LABELS = frozenset(("Preceded by", "Succeeded by", "In office"))
 _GENERIC_FIELDS = frozenset((
     "total", "rank", "density", "land", "water", "urban", "metro", "estimate", "census", "preceded by",
+    "left", "right", "average", "mean", "minimum", "maximum", "min", "max", "length", "width", "depth",
     "succeeded by", "in office", "term", "chancellor", "vice-chancellor", "president", "prime minister",
     "monarch", "governor", "deputy", "leader", "members", "seats",
 ))
@@ -1320,6 +1324,7 @@ def fact_value(name, value):
         value = _FORMULA_GAP.sub("", value)
     value = _ION.sub(_ion_charge, value)
     value = _UNIT_EXPONENT.sub(_unit_exponent, value)
+    value = _UNIT_FRACTION.sub("/", value)
     value = _DEGREE_GAP.sub("\u00b0", value)
     if name.lower() in _DATE_KEYS:
         value = re.sub(r"\b([A-Za-z]+) (?=(?:c\. )?\d{4}\b)", _word_then_year, value)  # "Kirkpatrick III 1951"

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -433,7 +433,7 @@ _TIDY = (
     (re.compile(r"\(\s*[,;:]\s*"), "("),
     # a mark after a word, a closing quote or a bracket goes before ")"; after a
     # space or an opening quote it is the face of ":)" and stays
-    (re.compile(r"(?<=[A-Za-z0-9.')\]])[,;:]\s*\)|(?<=[A-Za-z0-9.]\")[,;:]\s*\)"), ")"),
+    (re.compile(r"(?<=[A-Za-z0-9.')\]\u201d\u2019])[,;:]\s*\)|(?<=[A-Za-z0-9.]\")[,;:]\s*\)"), ")"),
     (re.compile(r"\(\s*\)"), ""),
     (re.compile(r"\[\s*\]"), ""),
     (re.compile(r"\s+([,;?)]|!(?![=A-Za-z0-9])|:(?!\s?\d|-?[()]))"), r"\1"),  # "a != 0", "3 : 1", the click in "!Nanseb" and the face in ":)" keep their spaces
@@ -1044,6 +1044,8 @@ def _is_face(text, i):
         j -= 1
     if j < 0 or text[j] not in ":;":
         return False
+    if i + 1 < len(text) and text[i + 1].isalnum():
+        return False  # ":(1) Everyone" is a numbered clause
     return j == 0 or text[j - 1] in " \t\"\u201c\u2018"
 
 
@@ -1403,7 +1405,7 @@ class _Doc:
                     break
         if bold:
             bs, be = bold
-            return (
+            return _scrub_inline(
                 self._emit(text, 0, bs, links)
                 + "<b>"
                 + self._emit(text, bs, be, links)

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -1001,6 +1001,8 @@ _SCRUB = (
     (re.compile(r"(?<=\S)\s+([,;](?=\s|$))"), r"\1"),
     (re.compile(r"\(\s+"), "("),
     (re.compile(r"\s+\)"), ")"),
+    # a mark left before ")" once "; ;" collapsed ("trumpet"; )); not a face
+    (re.compile(r"(?<=[A-Za-z0-9.')\]\u201d\u2019])[,;:]\s*\)|(?<=[A-Za-z0-9.]\")[,;:]\s*\)"), ")"),
     (re.compile(r"^\s*(?:[,;]|:(?=\s|$))\s*"), ""),
     (re.compile(r"\s*[,;]$"), ""),
     (re.compile(r"[ \t\u00a0]{2,}"), " "),

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -107,7 +107,9 @@ _TEX_ENV = re.compile(r"\{?\\begin\{([a-z*]+)\}.*?\\end\{\1\}\}?\s*(?:\\right\.)
 # ": p.45–78 : p.1–46 : p.111–157": page ranges of citations in a row
 _CITE_PAGES = re.compile(r"(?:\s*:\s*p{1,2}\.\s?\d+(?:[\u2013-]\d+)?\b)+")
 # "## x:", "#; Key": a note marker the dump kept at a line's start
-_NOTE_MARKER = re.compile(r"^#+;?\s+")
+_NOTE_MARKER = re.compile(r"^#+[;:]?\s+")
+# a wikitext row marker the dump left as a paragraph of its own
+_ROW_MARKER = re.compile(r"^\s*(?:\|-|\|\}|\{\|)\s*$")
 # a raw reference tag the dump left in the prose
 _REF_TAG = re.compile(r"<ref\b[^>]*/>|<ref\b[^>]*>.*?</ref>|<ref\b[^>]*>|<ref\b[^<>]{0,160}$", re.S | re.I)
 # Parsoid's protection markers, leaked into a few articles: "\ufffdPROT139\ufffd"
@@ -511,6 +513,8 @@ def clean_text(s):
         s = _CITE_AFTER_WORD.sub("", _CITE_NUMERIC.sub("", _CITE_ROMAN.sub("", s)))
     if s.startswith("#"):
         s = _NOTE_MARKER.sub("", s)
+    if _ROW_MARKER.match(s):
+        return ""
     if "==" in s:
         s = _HEADING_MARKS.sub("", s)
     if "PROT" in s or "QINU" in s:

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -378,7 +378,7 @@ _LABEL_HEAD = r"(?:[A-Z][A-Za-z.]*|lit\\.|pl\\.|romani[sz]ed|pinyin|born|n\\u00e
 # ... and stands at the start of its segment: after "(", ";" or ","
 _SEGMENT_START = r"(?:^|(?<=[(\[;,])|(?<=[(\[;,] ))"
 _EMPTY_LABEL = re.compile(
-    _SEGMENT_START + _LABEL_HEAD + r"(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)])"
+    _SEGMENT_START + _LABEL_HEAD + r"(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)]|[A-Z][a-z]+(?:[ -][A-Za-z]+){0,2}:\s)"
 )
 # the same at the end of a parenthetical's segment ("from Sanskrit: , IPA:")
 _EMPTY_LABEL_END = re.compile(
@@ -636,7 +636,7 @@ _MIXED_NUMBER = re.compile(r"\b(\d+) \+ (\d+) ?[/\u2044] ?(\d+)\b")
 # "1 \u2044 4": the fraction slash the serif draws, spaced by the source.
 _FRACTION_GAP = re.compile(r"(?<=\d) ?\u2044 ?(?=\d)")
 # "3,855/km 2": the superscript came through as a spaced digit.
-_UNIT_POWER = re.compile(r"\b(km|m|cm|mm|mi|ft|yd|in|nmi)\s+([23])\b(?!,\d|\.\d| [a-z])")
+_UNIT_POWER = re.compile(r"\b(km|m|cm|mm|mi|ft|yd|in|nmi)\s+([23])\b(?![,.:]\d| [a-z])")
 _POWERS = {"2": "\u00b2", "3": "\u00b3"}
 
 
@@ -1072,6 +1072,12 @@ _CHEM_SUBLABEL = re.compile(r"^((?:Preferred |Systematic )?IUPAC name|Other name
 # "Length: 61: 49": a running time the dump spaced
 _TIME_FIELD = re.compile(r"^(?:Length|Duration|Running time|Time|Runtime)$", re.I)
 _TIME_GAP = re.compile(r"\b(\d{1,2}): (\d{2})\b")
+_YEAR_TWICE = re.compile(r"\b(\d{4}) \(\1\)")
+# "Coordinates: 41°37′N 44°00′E" as a nameless value: the label is the name
+_LABELLED_VALUE = re.compile(r"^([A-Z][a-z]+(?: [a-z]+){0,2}): (\S.*)$")
+# "team Former teams": a word of the row above leaked into the name
+_LEAKED_WORD = re.compile(r"^[a-z]+ (?=[A-Z][a-z]+)")
+_WEBSITE_VALUE = re.compile(r"^(?:official )?(?:web ?site|site|homepage|home page)$", re.I)
 _NAME_THEN_DATE = re.compile(
     r"([A-Za-z]+)\s+(?=(?:\d{1,2} [A-Z][a-z]+ \d{4}|[A-Z][a-z]+ \d{1,2}, \d{4})\b)"
 )
@@ -1206,6 +1212,7 @@ def fact_value(name, value):
         value = _SHELL.sub(lambda m: m.group(1) + m.group(2).translate(_SUPER), value)
     value = _YEAR_PAGE.sub("", value)
     value = _NAME_THEN_DATE.sub(_name_then_date, value)
+    value = _YEAR_TWICE.sub(r"\1", value)
     value = re.sub(r"(\d{4}) /(\d{4})\b", r"\1/\2", value)
     if _FORMULA_ROW.search(name):
         value = _ELEMENT_COUNT.sub(lambda m: m.group(1).translate(_SUB), value)
@@ -1622,6 +1629,8 @@ class _Doc:
                 fields.append((name, value, group))
                 groups.setdefault(name, set()).add(group)
 
+        base = re.sub(r"\s*\([^()]*\)\s*$", "", self.title)
+
         def walk(p, group=""):
             if isinstance(p, list):
                 for c in p:
@@ -1638,7 +1647,7 @@ class _Doc:
                     has_image[name] = True
                 # a group is a short label; a "section" whose name is a whole
                 # medal table is the table, not a group
-                if name and name != self.title and len(name.split()) <= 8 and not name.lower().startswith("infobox"):
+                if name and name != self.title and (not base or base not in name) and len(name.split()) <= 8 and not name.lower().startswith("infobox"):
                     # "Transcriptions" under "Chinese name" keeps the group
                     # that says which language the rows belong to
                     if not (group and _NAME_GROUP.search(group)):
@@ -1647,7 +1656,17 @@ class _Doc:
                 fname = p.get("name")
                 if p.get("images"):
                     return  # the field is an image and its value is the caption
+                if fname:
+                    fname = _LEAKED_WORD.sub("", fname)
                 value = _split_at_links(p["value"], p.get("links"), fname or "")
+                if fname and _WEBSITE_VALUE.match(fname.strip()) and _WEBSITE_VALUE.match(value.strip()):
+                    # "Official website" is a link's text; the reader has no link, so the address
+                    value = _website_host(p.get("links")) or value
+                if not fname:
+                    labelled = _LABELLED_VALUE.match(value)
+                    if labelled:
+                        add(labelled.group(1), labelled.group(2), group)
+                        return
                 if group and _NAME_GROUP.search(group) and fname:
                     add(group + ", " + fname.strip(), value, group)
                     return
@@ -1694,6 +1713,15 @@ class _Doc:
         for name, value in fields:
             self.out.append("<tr><th>" + esc(name) + "</th><td>" + esc(value) + "</td></tr>")
         self.out.append("</table>")
+
+
+def _website_host(links):
+    for lk in links or []:
+        url = lk.get("url") if isinstance(lk, dict) else None
+        if isinstance(url, str) and "://" in url:
+            host = url.split("://", 1)[1].split("/", 1)[0]
+            return host[4:] if host.startswith("www.") else host
+    return ""
 
 
 def _item_text(it):

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -639,7 +639,7 @@ _MIXED_NUMBER = re.compile(r"\b(\d+) \+ (\d+) ?[/\u2044] ?(\d+)\b")
 # "1 \u2044 4": the fraction slash the serif draws, spaced by the source.
 _FRACTION_GAP = re.compile(r"(?<=\d) ?\u2044 ?(?=\d)")
 # "3,855/km 2": the superscript came through as a spaced digit.
-_UNIT_POWER = re.compile(r"\b(km|m|cm|mm|mi|ft|yd|in|nmi)\s+([23])\b(?![,.:]\d| [a-z])")
+_UNIT_POWER = re.compile(r"\b(km|m|cm|mm|mi|ft|yd|in|nmi)\s+([23])\b(?![,.:]\d| [a-z]| ?\d|\u00bd)")
 _POWERS = {"2": "\u00b2", "3": "\u00b3"}
 
 
@@ -1122,6 +1122,8 @@ def _paren_then_item(m):
     # an initial is a botanical authority and keeps its shape
     if inner[:1].isupper() and " " not in inner and re.match(r"[A-Z]\.", nxt):
         return m.group(0)
+    if _COMPASS.match(nxt):
+        return m.group(0)  # "(118 mi) W of Sydney"
     return "(" + inner + "), "
 _DATE_KEYS = frozenset(("born", "died", "birth date", "death date"))
 
@@ -1145,9 +1147,12 @@ def _split_at_links(value, links, name=""):
     1803", a taxon and its authority) stay as they are."""
     if not links or len(links) < 2:
         return value
+    if _TAXON_RANK.match((name or "").strip()):
+        return value  # "Helonias L.": a genus and its authority
+    sep = ", " if not name or _ADDRESS_FIELD.search(name) else "; "
     texts = [lk.get("text") for lk in links if isinstance(lk, dict) and isinstance(lk.get("text"), str) and lk.get("text")]
     if len(texts) >= 2 and value.strip() == " ".join(texts) and all(t[:1].isupper() or t[:1].isdigit() for t in texts):
-        return "; ".join(texts)  # "Mark Waid Alex Ross": the links are the whole value
+        return sep.join(texts)  # "Mark Waid Alex Ross": the links are the whole value
     if len(links) < 3 and not _LIST_ROWS.search(name or ""):
         return value
     if len(texts) < 2:
@@ -1160,11 +1165,26 @@ def _split_at_links(value, links, name=""):
         if i < 0:
             continue
         if prev_end is not None and out[prev_end:i].strip() == "" and i - prev_end <= 1:
-            out = out[:prev_end] + "; " + out[i:]
-            i = prev_end + 2
+            out = out[:prev_end] + sep + out[i:]
+            i = prev_end + len(sep)
         prev_end = i + len(t)
         pos = prev_end
     return out
+
+
+_TAXON_RANK = re.compile(r"^(?:Genus|Species|Family|Order|Class|Kingdom|Phylum|Division|Tribe|Subfamily|Subgenus|Variety|Subspecies|Binomial name|Trinomial name|Synonyms|Authority)$", re.I)
+_ADDRESS_FIELD = re.compile(r"location|address|headquarters|residence|place|origin|coordinates", re.I)
+_COMPASS = re.compile(r"(?:N|S|E|W|NE|NW|SE|SW|NNE|ENE|ESE|SSE|SSW|WSW|WNW|NNW)$")
+_ISO_DATE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})$")
+_MONTHS = ("", "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December")
+
+
+def _spell_iso_date(s):
+    """A cell or value that is exactly a machine date reads "15 October 2014"."""
+    m = _ISO_DATE.match(s.strip())
+    if not m or not 1 <= int(m.group(2)) <= 12 or not 1 <= int(m.group(3)) <= 31:
+        return s
+    return "%d %s %s" % (int(m.group(3)), _MONTHS[int(m.group(2))], m.group(1))
 
 
 _FACT_SKIP_NAMES = frozenset(("Imperial conversion", "Metric conversion", "NFPA 704 (fire diamond)", "NFPA 704"))
@@ -1232,6 +1252,7 @@ def fact_value(name, value):
     value = _NAME_THEN_DATE.sub(_name_then_date, value)
     value = _YEAR_TWICE.sub(r"\1", value)
     value = _SLASH_GAP.sub(" / ", value)
+    value = _spell_iso_date(value)
     value = re.sub(r"\b([A-Z]):(?=\d)", r"\1: ", value)
     if "\u00b0" in value:
         value = _DECIMAL_COORDS.sub("", value)
@@ -1469,7 +1490,7 @@ class _Doc:
                     filled += 1
                     if run_re.search(raw):
                         with_runs += 1
-                cells.append(re.sub(r"\s#$", "", strip_undrawable(raw, self.stats)))
+                cells.append(_spell_iso_date(re.sub(r"\s#$", "", strip_undrawable(raw, self.stats))))
             if is_header and len(cells) > 1 and len(set(cells)) == 1:
                 continue  # a caption spanning the row ("Key (expand for notes)"), not column names
             grid.append((is_header, cells))
@@ -1545,6 +1566,9 @@ class _Doc:
                 c = re.sub(r"  +", " ", c).strip()
                 if c == "#":
                     c = "Number"
+                if not parts and re.match(r"^\d+\.$", c):
+                    c = c[:-1]  # "1." then "; Date: ..." read as "1.;"
+                c = _spell_iso_date(c)
                 if not c or c.endswith(":"):
                     continue  # empty, or a label whose script went
                 label = labels[j] if j < len(labels) else ""
@@ -1670,6 +1694,7 @@ class _Doc:
 
         base = re.sub(r"\s*\([^()]*\)\s*$", "", self.title)
         title_words = {w.lower() for w in base.split()}
+        recent = []  # named fields seen so far, for a generic one to hang on
 
         def walk(p, group=""):
             if isinstance(p, list):
@@ -1716,8 +1741,16 @@ class _Doc:
                     if group and (not has_image.get(group) or any(c.isdigit() for c in value)) and _NAMELESS_FACT.search(value):
                         add(group, value)
                 elif group and fname.strip().lower() in _GENERIC_FIELDS:
-                    add(group + ", " + fname.strip().lower(), value)
+                    key = fname.strip().lower()
+                    g = group
+                    if key in ("density", "total", "estimate", "census", "urban", "metro", "land", "water"):
+                        for prev in reversed(recent):
+                            if prev.lower().startswith(("population", "pop.", "area")):
+                                g = _NAME_FOOTNOTE.sub("", prev)
+                                break
+                    add(g + ", " + key, value)
                 else:
+                    recent.append(fname.strip())
                     add(fname, value, group)
             elif t == "list" and p.get("name"):
                 items = [

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -420,6 +420,7 @@ _COORDS_ONLY = re.compile(
 _FUNCTION_WORDS = frozenset("from or and of the a an in at by to lit also see cf".split())
 _EMPTY_PAREN = re.compile(r"\s?\(\s*[,;:\s]*\)")
 # "(pronounced French pronunciation:)": the IPA went with its slashes
+_LABEL_DIGITS = re.compile(r"(?<![A-Za-z])(?:[A-Z][a-z]+ )?(?:Persian|Arabic|Urdu|Hindi|Bengali|Nepali|Tamil|Telugu|Kannada|Malayalam|Marathi|Gujarati|Punjabi|Sinhala|Thai|Burmese|Khmer|Lao|Tibetan|Chinese|Japanese|Korean|Hebrew|Amharic|Georgian|Armenian): ?\d{1,4}(?=\s*[;,)])")
 _EMPTY_PRON = re.compile(r"(?:pronounced\s+)?(?:[A-Z][a-z]+\s+)?(?:pronunciation|IPA):\s*(?=[;,)]|$)")
 # "=== Neural is a discipline": heading marks the dump left on a line
 _HEADING_MARKS = re.compile(r"^\s*={2,}\s*|\s*={2,}\s*$")
@@ -964,7 +965,7 @@ def strip_undrawable(text, stats, lead=False):
             stats["runs_removed"] = stats.get("runs_removed", 0) + n
     if _MARK in text:
         text = _settle_marks(text)
-    for rx in (_EMPTY_PRON, _EMPTY_LABEL, _EMPTY_PAREN):
+    for rx in (_LABEL_DIGITS, _EMPTY_PRON, _EMPTY_LABEL, _EMPTY_PAREN):
         text, n = rx.subn("", text)
         if n:
             removed += n
@@ -1123,7 +1124,7 @@ _AGE = re.compile(r"\s*\(aged?\s+\d+(?:\s*[\u2013-]\s*\d+)?\)")
 # "Preferred IUPAC name Methyl methanesulfonate": the chembox's sub-label
 _CHEM_SUBLABEL = re.compile(r"^((?:Preferred |Systematic )?IUPAC name|Other names?|Chemical formula)\s+(?=\S)")
 # "Length: 61: 49": a running time the dump spaced
-_TIME_FIELD = re.compile(r"^(?:Length|Duration|Running time|Time|Runtime)$", re.I)
+_TIME_FIELD = re.compile(r"(?:^|, )(?:Length|Duration|Running time|Time|Runtime)$", re.I)
 _TIME_GAP = re.compile(r"\b(\d{1,2}): (\d{2})\b")
 _YEAR_TWICE = re.compile(r"\b(\d{4}) \(\1\)")
 _DECIMAL_COORDS = re.compile(r"\s*/\s*[\d.\u2212-]+\u00b0[NS]\s*[\d.\u2212-]+\u00b0[EW]")
@@ -1177,6 +1178,7 @@ def _word_then_year(m):
     return w + ", "
 
 
+_WORK_SUBTITLE = re.compile(r"^(?:[A-Za-z]+ )?(?:album|EP|single|song|soundtrack|mixtape|compilation|video|film|series|episode|novel|book) by\b", re.I)
 _NAME_GROUP = re.compile(r"\b[A-Za-z]+ names?$", re.I)  # "Korean name", "Chinese name": every row carries it; a bare "Names" group does not
 
 
@@ -1823,7 +1825,7 @@ class _Doc:
                     has_image[name] = True
                 # a group is a short label; a "section" whose name is a whole
                 # medal table is the table, not a group
-                if name and name != self.title and (not base or base not in name) and not (len(title_words) >= 2 and title_words <= {w.lower().strip(",") for w in name.split()}) and len(name.split()) <= 12 and not name.lower().startswith("infobox"):
+                if name and name != self.title and (not base or base not in name) and not (len(title_words) >= 2 and title_words <= {w.lower().strip(",") for w in name.split()}) and len(name.split()) <= 12 and not name.lower().startswith("infobox") and not _WORK_SUBTITLE.match(name):
                     # "Transcriptions" under "Chinese name" keeps the group
                     # that says which language the rows belong to
                     if not (group and _NAME_GROUP.search(group)):

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -1329,11 +1329,35 @@ def fact_value(name, value):
     return value.strip()
 
 
+def _cell_text(c):
+    v = c.get("value") if isinstance(c, dict) else c
+    return v if isinstance(v, str) else ""
+
+
+def _combined_header(header_rows):
+    """Of stacked header rows the lowest names the columns; a group row above
+    it ("Conference Conference Conference Overall Overall Overall") prefixes
+    each name ("Conference W"), so two W columns can be told apart."""
+    bottom = header_rows[-1]
+    if len(header_rows) < 2:
+        return bottom
+    top = header_rows[-2]
+    tops = [_cell_text(c).strip() for c in top]
+    if len(set(t for t in tops if t)) < 2:
+        return bottom  # one caption over everything, not groups
+    out = []
+    for i, c in enumerate(bottom):
+        b = _cell_text(c).strip()
+        t = tops[i] if i < len(tops) else ""
+        out.append({"value": (t + " " + b) if t and b and t != b and len(t.split()) <= 3 else (b or t)})
+    return out
+
+
 def cut_words(text, n):
     words = text.split(" ")
     if len(words) <= n:
         return text
-    return " ".join(words[:n]) + "..."
+    return " ".join(words[:n]).rstrip(".") + "..."
 
 
 class _Doc:
@@ -1532,7 +1556,7 @@ class _Doc:
 
     def table_html(self, tb):
         rows = [(True, r) for r in (tb.get("headers") or []) if isinstance(r, list)]
-        rows = rows[-1:]  # of stacked header rows, the lowest names the columns
+        rows = [(True, _combined_header([r for _, r in rows]))] if rows else []
         rows += [(False, r) for r in (tb.get("rows") or []) if isinstance(r, list)]
         rows = [(h, r) for h, r in rows if r]
         if not rows:
@@ -1666,6 +1690,14 @@ class _Doc:
         return s
 
     def parts(self, parts, depth, lead=False):
+        if lead and parts:
+            # a standings table the dump put before the lead sentence: the
+            # article opens on prose, the table follows it
+            first = next((i for i, p in enumerate(parts) if isinstance(p, dict) and p.get("type") == "paragraph"), None)
+            if first:
+                before = [p for p in parts[:first] if isinstance(p, dict) and p.get("type") == "table"]
+                if before:
+                    parts = [p for p in parts[:first] if not (isinstance(p, dict) and p.get("type") == "table")] + [parts[first]] + before + list(parts[first + 1 :])
         loose = []  # consecutive bare list_items become one <ul>
 
         def flush_loose():

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -100,7 +100,7 @@ _CITE = re.compile(r"\[\d+\]")
 # also "phone.: S643 : S643 : 8" and ". : 32, 33, 105 : 184" (rp templates in a row)
 _CITE_PAGE = re.compile(r"(?<=[.,;!?])(?:\s?:\s?[A-Z]?\d+(?:[\u2013-]\d+)?(?:,\s?\d+(?:[\u2013-]\d+)?)*)+(?=\s|$)")
 # "invasion,the territory": a comma the dump left without its space
-_COMMA_GLUE = re.compile(r"(?<=[a-z]),(?=[A-Za-z]{2,})")
+_COMMA_GLUE = re.compile(r"(?<=[a-z)]),(?=[A-Za-z]{2,})")
 # "A_{1}^{\\complement }\\quad": TeX the dump left outside any block
 _TEX_LOOSE = re.compile(r"(?:\\[A-Za-z]+\s*|[A-Za-z]?[_^]\{[^{}]*\}\s*){2,}")
 _TEX_ENV = re.compile(r"\{?\\begin\{([a-z*]+)\}.*?\\end\{\1\}\}?\s*(?:\\right\.)?", re.S)
@@ -127,7 +127,11 @@ _WIKI_QUOTE_LEFT = re.compile(r"'''(?=[A-Za-z])")
 _CULTIVAR_QUOTE = re.compile(r"(?<=[a-z])'(?=[A-Z][a-z])")
 # "(-infinity,infinity)": a comma between spelled words gets its space;
 # "epsilon,gamma-carotene" is a chemical name and stays tight
-_COMMA_WORDS = re.compile(r"\b([a-z]{2,}),(?=[a-z]{3,})")
+_COMMA_WORDS = re.compile(r"\b([a-z]{2,}),(?=[A-Za-z]{2,})")
+
+
+def _comma_words(m):
+    return m.group(0) if m.group(1) in _GREEK_WORDS else m.group(1) + ", "
 _GREEK_WORDS = frozenset(symbols.GREEK.values())
 # "{{rp}}" page references after a period: ".: ii. 161 : I.68 However"
 # the same with plain pages: "speciosa.: 86-95, 137)"
@@ -404,6 +408,10 @@ _LEAD_COORDS = re.compile(
 )
 _FUNCTION_WORDS = frozenset("from or and of the a an in at by to lit also see cf".split())
 _EMPTY_PAREN = re.compile(r"\s?\(\s*[,;:\s]*\)")
+# "(pronounced French pronunciation:)": the IPA went with its slashes
+_EMPTY_PRON = re.compile(r"(?:pronounced\s+)?(?:[A-Z][a-z]+\s+)?(?:pronunciation|IPA):\s*(?=[;,)]|$)")
+# "=== Neural is a discipline": heading marks the dump left on a line
+_HEADING_MARKS = re.compile(r"^\s*={2,}\s*|\s*={2,}\s*$")
 # IPA between slashes or brackets, when the serif cannot draw it.
 _SLASHED = re.compile(r" ?/[^/]{1,80}/")
 # what a pronunciation carries that prose never does: IPA letters, modifier
@@ -497,6 +505,8 @@ def clean_text(s):
         s = _CITE_NUMERIC.sub("", _CITE_ROMAN.sub("", s))
     if s.startswith("#"):
         s = _NOTE_MARKER.sub("", s)
+    if "==" in s:
+        s = _HEADING_MARKS.sub("", s)
     if "PROT" in s:
         s = _PROT.sub("", s)
     if "{{" in s:
@@ -901,7 +911,7 @@ def strip_undrawable(text, stats, lead=False):
     if "," in text:
         # a comma between spelled or folded words gets its space: "(-infinity,infinity)",
         # "clan,personal" (a full-width comma folded); "epsilon,gamma-carotene" stays
-        text = _COMMA_WORDS.sub(lambda m: m.group(0) if m.group(1) in _GREEK_WORDS else m.group(1) + ", ", text)
+        text = _COMMA_WORDS.sub(_comma_words, text)
     for k, n in folded.items():
         stats[k] = stats.get(k, 0) + n
     text, n = _fold_lookalikes(text)
@@ -934,7 +944,7 @@ def strip_undrawable(text, stats, lead=False):
             stats["runs_removed"] = stats.get("runs_removed", 0) + n
     if _MARK in text:
         text = _settle_marks(text)
-    for rx in (_EMPTY_LABEL, _EMPTY_PAREN):
+    for rx in (_EMPTY_PRON, _EMPTY_LABEL, _EMPTY_PAREN):
         text, n = rx.subn("", text)
         if n:
             removed += n
@@ -944,6 +954,8 @@ def strip_undrawable(text, stats, lead=False):
         removed += 1
         stats["quote_gaps_closed"] = stats.get("quote_gaps_closed", 0) + n
     text, n = _close_inline_gaps(text)
+    if "," in text:
+        text = _COMMA_WORDS.sub(_comma_words, text)  # a comma a removed run left glued
     if n:
         removed += 1
         stats["inline_gaps_closed"] = stats.get("inline_gaps_closed", 0) + n
@@ -1000,6 +1012,10 @@ def scrub_artifacts(text):
     if text.count("[") != text.count("]"):
         text, k = _balance(text, "[", "]")
         n += k
+    if n:
+        for rx, rep in _SCRUB:
+            text, k = rx.subn(rep, text)  # what a dropped mark left: (as in " ")
+            n += k
     return text.strip(), n
 
 

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -994,11 +994,12 @@ def scrub_artifacts(text):
 
 def _is_face(text, i):
     """text[i] is the mouth of ":)" or ";-(": an emoticon, not a parenthesis.
-    The eyes stand at a word boundary; "8)" is "(number 8)" far more often than a face."""
+    The eyes stand at a word boundary; "8)" is "(number 8)" and "=)" is "(P, <=)"
+    far more often than a face."""
     j = i - 1
     if j >= 0 and text[j] == "-":
         j -= 1
-    if j < 0 or text[j] not in ":;=":
+    if j < 0 or text[j] not in ":;":
         return False
     return j == 0 or text[j - 1] in " \t\"'\u201c\u2018"
 
@@ -1169,7 +1170,10 @@ _ION = re.compile(r"(?<=[A-Za-z]) (\d?[+\u2212-])(?=[\s),]|$)")
 _DEGREE_GAP = re.compile(r"(?<=\d) \u00b0")
 _SUPER = str.maketrans("0123456789+-\u2212", "\u2070\u00b9\u00b2\u00b3\u2074\u2075\u2076\u2077\u2078\u2079\u207a\u207b\u207b")
 _SUB = str.maketrans("0123456789", "\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u2087\u2088\u2089")
-_FACT_SKIP_VALUE = re.compile(r"^(?:[JFMASOND] ){11}[JFMASOND]$")  # a climate table's month row
+# a climate table's month row; a link's caption with no link to follow
+_FACT_SKIP_VALUE = re.compile(r"^(?:[JFMASOND] ){11}[JFMASOND]$|^(?:Listen live|Public file(?:; LMS)?|LMS|Website|Official website)$", re.I)
+_NAME_FOOTNOTE = re.compile(r"(?<=[A-Za-z)]) \d$")
+_SLASH_GAP = re.compile(r"(?<=\S) /(?=[A-Za-z0-9])(?!\d{4}\b)")  # not "1564 /1563", a year either way
 _FACT_LABELS = frozenset(("Preceded by", "Succeeded by", "In office"))
 _GENERIC_FIELDS = frozenset((
     "total", "rank", "density", "land", "water", "urban", "metro", "estimate", "census", "preceded by",
@@ -1213,6 +1217,7 @@ def fact_value(name, value):
     value = _YEAR_PAGE.sub("", value)
     value = _NAME_THEN_DATE.sub(_name_then_date, value)
     value = _YEAR_TWICE.sub(r"\1", value)
+    value = _SLASH_GAP.sub(" / ", value)
     value = re.sub(r"(\d{4}) /(\d{4})\b", r"\1/\2", value)
     if _FORMULA_ROW.search(name):
         value = _ELEMENT_COUNT.sub(lambda m: m.group(1).translate(_SUB), value)
@@ -1473,13 +1478,23 @@ class _Doc:
         if wide:
             return self.table_rows(grid)
         out = ["<table>"]
+        last = None
         for is_header, cells in grid:
             tag = "th" if is_header else "td"
+            if all(not c.strip() or c.rstrip().endswith(":") for c in cells):
+                continue  # "Source:" with nothing after it
+            if cells == last:
+                continue  # the same row twice ("Source: INSEE")
+            last = cells
+            if not is_header:
+                cells = [c for j, c in enumerate(cells) if not (j and c == cells[j - 1])]  # a spanning cell, once
             out.append(
                 "<tr>"
                 + "".join("<%s>%s</%s>" % (tag, esc("Number" if c.strip() == "#" else c), tag) for c in cells)
                 + "</tr>"
             )
+        if len(out) == 1:
+            return ""  # every row was a label with nothing after it
         out.append("</table>")
         return "".join(out)
 
@@ -1523,7 +1538,10 @@ class _Doc:
                 else:
                     parts.append(esc(c))
             if parts:
-                out.append("<p>" + re.sub(r"  +", " ", "; ".join(parts)) + "</p>")
+                para = "<p>" + re.sub(r"  +", " ", "; ".join(parts)) + "</p>"
+                if out and out[-1] == para:
+                    continue  # "Source: INSEE" once per table, not per row
+                out.append(para)
         if len(body) > TABLE_ROWS_LISTED:
             out.append("<p><i>(%d more rows)</i></p>" % (len(body) - TABLE_ROWS_LISTED))
         if out:
@@ -1612,6 +1630,7 @@ class _Doc:
                 return
             name = strip_undrawable(clean_text(name), self.stats)
             name = _NAME_DISAMBIG.sub("", name)
+            name = _SLASH_GAP.sub(" / ", _NAME_FOOTNOTE.sub("", name))
             value = cut_words(
                 fact_value(name, strip_undrawable(clean_text(value), self.stats)),
                 FACT_WORDS,
@@ -1647,7 +1666,7 @@ class _Doc:
                     has_image[name] = True
                 # a group is a short label; a "section" whose name is a whole
                 # medal table is the table, not a group
-                if name and name != self.title and (not base or base not in name) and len(name.split()) <= 8 and not name.lower().startswith("infobox"):
+                if name and name != self.title and (not base or base not in name) and len(name.split()) <= 12 and not name.lower().startswith("infobox"):
                     # "Transcriptions" under "Chinese name" keeps the group
                     # that says which language the rows belong to
                     if not (group and _NAME_GROUP.search(group)):

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -381,7 +381,7 @@ _LABEL_HEAD = r"(?:[A-Z][A-Za-z.]*|lit\\.|pl\\.|romani[sz]ed|pinyin|born|n\\u00e
 # ... and stands at the start of its segment: after "(", ";" or ","
 _SEGMENT_START = r"(?:^|(?<=[(\[;,])|(?<=[(\[;,] ))"
 _EMPTY_LABEL = re.compile(
-    _SEGMENT_START + _LABEL_HEAD + r"(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)]|[A-Z][a-z]+(?:[ -][A-Za-z]+){0,2}:\s)"
+    _SEGMENT_START + _LABEL_HEAD + r"(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)]|[A-Z][a-z]+(?:[ -][A-Za-z]+){0,2}:\s|lit\.\s|literally\s|romani[sz]ed:|pinyin:|IPA:|translit)"
 )
 # the same at the end of a parenthetical's segment ("from Sanskrit: , IPA:")
 _EMPTY_LABEL_END = re.compile(
@@ -390,7 +390,7 @@ _EMPTY_LABEL_END = re.compile(
 # "(listen)": the audio link's text, with no audio to play
 _LISTEN = re.compile(r"\s?\(\s*(?:listen|more)\s*\)", re.I)
 # "April 26, 1994 (1994-04-26)": the start-date template's hidden ISO copy
-_ISO_DATE_DUP = re.compile(r"(?<=[a-z0-9])\s?\(\d{4}-\d{2}-\d{2}\)")
+_ISO_DATE_DUP = re.compile(r"(?<=[a-z0-9])\s?\(\d{4}-\d{2}(?:-\d{2})?\)")
 # "(Pub. L. Tooltip Public Law (United States)107-252 (text) (PDF))": an
 # abbreviation's tooltip and the law template's link labels
 _TOOLTIP = re.compile(r"\s?\bTooltip [A-Z][A-Za-z .]{0,60}(?:\([^()]{0,40}\))? ?(?=\d|$)")
@@ -812,7 +812,7 @@ _MARK_COLON = re.compile(r":\s*" + _MARK + r"\s*,\s*")
 _MARK_ANY = re.compile(r"\s*" + _MARK + r"\s*")
 
 
-_MARK_ROMAN = re.compile(r"\s*" + _MARK + r"\s*,?\s*(?:romani[sz]ed|romani[sz]ation|translit\w*|pinyin):\s*", re.I)
+_MARK_ROMAN = re.compile(r":?\s*" + _MARK + r"\s*,?\s*(romani[sz]ed|romani[sz]ation|translit\w*|pinyin):\s*", re.I)
 
 
 def _settle_marks(text):
@@ -820,7 +820,7 @@ def _settle_marks(text):
     "Ancient Greek: X"; "Greek <run>, Arithmoi" drops the comma the run
     left before its romanisation; "Hebrew: <run>, Bemidbar" keeps the
     label."""
-    text = _MARK_ROMAN.sub(" ", text)
+    text = _MARK_ROMAN.sub(lambda m: ", " + m.group(1).lower() + ": ", text)
     text = _MARK_LABEL.sub("", text)
     text = _MARK_COMMA.sub(_mark_comma, text)
     text = _MARK_COLON.sub(": ", text)
@@ -875,6 +875,14 @@ def strip_undrawable(text, stats, lead=False):
             # "Moskva" alone is the romanisation of the word that went;
             # "from" alone, or "from or", is what a removal left behind
             words = rest.split()
+            label = _LEAD_LABEL.match(rest)
+            body_words = rest[label.end() :].split() if label else words
+            if lead and _TITLE_WORDS and {w.lower().strip(".,") for w in body_words[: len(_TITLE_WORDS)]} == _TITLE_WORDS:
+                # "(Japanese: Kitao Masaru, born ...)": the title's own words reordered
+                words = " ".join(body_words[len(_TITLE_WORDS) :]).lstrip(", ").split()
+                rest = " ".join(words)
+                if not words:
+                    continue
             if words and (len(words) >= 2 or words[0][:1].isupper()) and not all(w.lower().strip(".,") in _FUNCTION_WORDS for w in words):
                 kept.append(re.sub(r"  +", " ", rest))
         if not kept:
@@ -1077,6 +1085,8 @@ _CHEM_SUBLABEL = re.compile(r"^((?:Preferred |Systematic )?IUPAC name|Other name
 _TIME_FIELD = re.compile(r"^(?:Length|Duration|Running time|Time|Runtime)$", re.I)
 _TIME_GAP = re.compile(r"\b(\d{1,2}): (\d{2})\b")
 _YEAR_TWICE = re.compile(r"\b(\d{4}) \(\1\)")
+_DECIMAL_COORDS = re.compile(r"\s*/\s*[\d.\u2212-]+\u00b0[NS]\s*[\d.\u2212-]+\u00b0[EW]")
+_COORDS_AFTER_TEXT = re.compile(r"([a-z]) (?=\d{1,3}\u00b0\d)")  # "Pakistan 25°24′N", not the N of a pair
 # "Coordinates: 41°37′N 44°00′E" as a nameless value: the label is the name
 _LABELLED_VALUE = re.compile(r"^([A-Z][a-z]+(?: [a-z]+){0,2}): (\S.*)$")
 # "team Former teams": a word of the row above leaked into the name
@@ -1136,7 +1146,7 @@ def _split_at_links(value, links, name=""):
     if not links or len(links) < 2:
         return value
     texts = [lk.get("text") for lk in links if isinstance(lk, dict) and isinstance(lk.get("text"), str) and lk.get("text")]
-    if len(texts) >= 2 and value.strip() == " ".join(texts) and all(t[:1].isupper() for t in texts):
+    if len(texts) >= 2 and value.strip() == " ".join(texts) and all(t[:1].isupper() or t[:1].isdigit() for t in texts):
         return "; ".join(texts)  # "Mark Waid Alex Ross": the links are the whole value
     if len(links) < 3 and not _LIST_ROWS.search(name or ""):
         return value
@@ -1174,7 +1184,8 @@ _DEGREE_GAP = re.compile(r"(?<=\d) \u00b0")
 _SUPER = str.maketrans("0123456789+-\u2212", "\u2070\u00b9\u00b2\u00b3\u2074\u2075\u2076\u2077\u2078\u2079\u207a\u207b\u207b")
 _SUB = str.maketrans("0123456789", "\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u2087\u2088\u2089")
 # a climate table's month row; a link's caption with no link to follow
-_FACT_SKIP_VALUE = re.compile(r"^(?:[JFMASOND] ){11}[JFMASOND]$|^(?:Listen live|Public file(?:; LMS)?|LMS|Website|Official website)$", re.I)
+_FACT_SKIP_VALUE = re.compile(r"^(?:[JFMASOND] ){11}[JFMASOND]$|^(?:(?:Listen live|Public file(?:; LMS)?|LMS|Website|Official website)(?: \([^()]*\))?(?:[,;] )?)+$", re.I)
+_DEAD_CELL = re.compile(r"^(?:Report|Match report|Highlights|Video|Stats|Box score)$", re.I)
 _NAME_FOOTNOTE = re.compile(r"(?<=[A-Za-z)]) \d$")
 _SLASH_GAP = re.compile(r"(?<=\S) /(?=[A-Za-z0-9])(?!\d{4}\b)")  # not "1564 /1563", a year either way
 _FACT_LABELS = frozenset(("Preceded by", "Succeeded by", "In office"))
@@ -1221,6 +1232,10 @@ def fact_value(name, value):
     value = _NAME_THEN_DATE.sub(_name_then_date, value)
     value = _YEAR_TWICE.sub(r"\1", value)
     value = _SLASH_GAP.sub(" / ", value)
+    value = re.sub(r"\b([A-Z]):(?=\d)", r"\1: ", value)
+    if "\u00b0" in value:
+        value = _DECIMAL_COORDS.sub("", value)
+        value = _COORDS_AFTER_TEXT.sub(r"\1; ", value)
     value = re.sub(r"(\d{4}) /(\d{4})\b", r"\1/\2", value)
     if _FORMULA_ROW.search(name):
         value = _ELEMENT_COUNT.sub(lambda m: m.group(1).translate(_SUB), value)
@@ -1484,6 +1499,7 @@ class _Doc:
         last = None
         for is_header, cells in grid:
             tag = "th" if is_header else "td"
+            cells = ["" if _DEAD_CELL.match(c.strip()) else c for c in cells]  # "Report": a link's caption
             if all(not c.strip() or c.rstrip().endswith(":") for c in cells):
                 continue  # "Source:" with nothing after it
             if cells == last:
@@ -1640,8 +1656,9 @@ class _Doc:
             )
             if "coordinates" in name.lower() and " / " in value:
                 value = value.split(" / ")[0].strip()
-            if value in _FACT_LABELS:
-                return  # "Preceded by: Succeeded by": both values were flags
+            if value in _FACT_LABELS or value in (self.title, self.title.split(",")[0].strip(), base):
+                return  # "Preceded by: Succeeded by": both values were flags; "Azerbaijani: <title>"
+            name = name[:1].upper() + name[1:]
             if _FACT_JUNK_VALUE.match(value) or sum(1 for c in value if c.isalpha()) < 2 and not any(c.isdigit() for c in value):
                 return  # "* R ij’ kr -s": a reconstruction whose marks all went
             if name in _FACT_SKIP_NAMES:
@@ -1652,6 +1669,7 @@ class _Doc:
                 groups.setdefault(name, set()).add(group)
 
         base = re.sub(r"\s*\([^()]*\)\s*$", "", self.title)
+        title_words = {w.lower() for w in base.split()}
 
         def walk(p, group=""):
             if isinstance(p, list):
@@ -1669,7 +1687,7 @@ class _Doc:
                     has_image[name] = True
                 # a group is a short label; a "section" whose name is a whole
                 # medal table is the table, not a group
-                if name and name != self.title and (not base or base not in name) and len(name.split()) <= 12 and not name.lower().startswith("infobox"):
+                if name and name != self.title and (not base or base not in name) and not (len(title_words) >= 2 and title_words <= {w.lower().strip(",") for w in name.split()}) and len(name.split()) <= 12 and not name.lower().startswith("infobox"):
                     # "Transcriptions" under "Chinese name" keeps the group
                     # that says which language the rows belong to
                     if not (group and _NAME_GROUP.search(group)):
@@ -1884,11 +1902,18 @@ def _scrub_inline(html_text):
     return html_text
 
 
+_TITLE_WORDS = frozenset()
+_LEAD_LABEL = re.compile(r"[A-Z][A-Za-z -]{0,24}:\s*")
+
+
 def article_xhtml(row, stats=None):
     """(title, headings, xhtml_bytes). `stats`, if given, is a dict the
     counters (runs_removed, tables_omitted, ...) are added into."""
+    global _TITLE_WORDS
     if stats is None:
         stats = {}
+    base = re.sub(r"\s*\([^()]*\)\s*$", "", str(row.get("name") or ""))
+    _TITLE_WORDS = frozenset(w.lower().strip(".,") for w in base.split()) if len(base.split()) >= 2 else frozenset()
     before = dict(tex_stats)
     doc = _Doc(row, stats)
     if not doc.title:

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -381,7 +381,7 @@ _LABEL_HEAD = r"(?:[A-Z][A-Za-z.]*|lit\\.|pl\\.|romani[sz]ed|pinyin|born|n\\u00e
 # ... and stands at the start of its segment: after "(", ";" or ","
 _SEGMENT_START = r"(?:^|(?<=[(\[;,])|(?<=[(\[;,] ))"
 _EMPTY_LABEL = re.compile(
-    _SEGMENT_START + _LABEL_HEAD + r"(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)]|[A-Z][a-z]+(?:[ -][A-Za-z]+){0,2}:\s|lit\.\s|literally\s|romani[sz]ed:|pinyin:|IPA:|translit)"
+    _SEGMENT_START + _LABEL_HEAD + r"(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)]|[A-Z][a-z]+(?:[ -][A-Za-z]+){0,2}:\s|lit\.\s|literally\s|[Rr]omani[sz]ed[: ]|pinyin:|IPA:|translit|also [Rr]omani[sz]ed)"
 )
 # the same at the end of a parenthetical's segment ("from Sanskrit: , IPA:")
 _EMPTY_LABEL_END = re.compile(
@@ -434,7 +434,7 @@ def esc_attr(s):
 
 # "lasted 28 days.The truce": the source lost the space where a citation
 # stood. Three letters before the period so "e.g.The" and initials stay.
-_SENTENCE_GLUE = re.compile(r"([a-z]{3,}[.!?])([A-Z][a-z]{2,})")
+_SENTENCE_GLUE = re.compile(r"([a-z]{3,}[.!?]|\d{4}\.)([A-Z][a-z]{2,})")
 # "Bonaparte, 1835Tribe Acanthurini": nested list items the source ran together
 _YEAR_GLUE = re.compile(r"\b((?:1[5-9]|20)\d\d)(?=[A-Z][a-z]{2,})")
 # "{{ cite journal }}: CS1 maint: DOI inactive as of June 2024 (link)": a
@@ -1126,6 +1126,14 @@ def _paren_then_item(m):
         return m.group(0)  # "(118 mi) W of Sydney"
     return "(" + inner + "), "
 _DATE_KEYS = frozenset(("born", "died", "birth date", "death date"))
+_MONTH_WORDS = frozenset(m.lower() for m in ("January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December", "Jan", "Feb", "Mar", "Apr", "Jun", "Jul", "Aug", "Sep", "Sept", "Oct", "Nov", "Dec"))
+
+
+def _word_then_year(m):
+    w = m.group(1)
+    if w.lower() in _MONTH_WORDS or w.lower() in _DATE_LEAD_WORDS or not w[:1].isupper():
+        return m.group(0)
+    return w + ", "
 
 
 _NAME_GROUP = re.compile(r"\bnames?$", re.I)  # "Korean name", "Chinese name": every row carries it
@@ -1190,6 +1198,7 @@ def _spell_iso_date(s):
 _FACT_SKIP_NAMES = frozenset(("Imperial conversion", "Metric conversion", "NFPA 704 (fire diamond)", "NFPA 704"))
 _FACT_JUNK_VALUE = re.compile(r"^[\W_]*$|^\* ")
 _NAMELESS_FACT = re.compile(r"\d|^In office|^Term|^Reign")
+_FOOTNOTE_VALUE = re.compile(r"^\d [A-Z][a-z]+ [a-z]")  # "1 Playing statistics correct to ..."
 # "C 20 H 8 Br 2" in a formula row: the subscripts the dump spaced out
 _FORMULA_ROW = re.compile(r"formula", re.I)
 _ELEMENT_COUNT = re.compile(r"(?<=[A-Za-z\)\]]) (\d{1,3})(?=[A-Z(\[\s]|$)")
@@ -1228,8 +1237,8 @@ def _ion_charge(m):
 
 def _unit_exponent(m):
     head = m.string[: m.start()]
-    unit = re.search(r"[A-Za-z]+$", head)
-    if unit and _UNIT_BEFORE.search(unit.group(0)):
+    unit = re.search(r"(?:^|(?<=[\s(\u00b7/]))([A-Za-z]+)$", head)  # a unit stands alone: "5 m 2", "g\u00b7mol -1"; not "50s 0"
+    if unit and _UNIT_BEFORE.search(unit.group(1)) and not m.string.startswith("/", m.end()):
         return m.group(1).translate(_SUPER)
     return m.group(0)
 
@@ -1253,6 +1262,8 @@ def fact_value(name, value):
     value = _YEAR_TWICE.sub(r"\1", value)
     value = _SLASH_GAP.sub(" / ", value)
     value = _spell_iso_date(value)
+    if value.startswith("-> "):
+        value = "to " + value[3:]  # a loan arrow at the front of a cell
     value = re.sub(r"\b([A-Z]):(?=\d)", r"\1: ", value)
     if "\u00b0" in value:
         value = _DECIMAL_COORDS.sub("", value)
@@ -1265,6 +1276,7 @@ def fact_value(name, value):
     value = _UNIT_EXPONENT.sub(_unit_exponent, value)
     value = _DEGREE_GAP.sub("\u00b0", value)
     if name.lower() in _DATE_KEYS:
+        value = re.sub(r"\b([A-Za-z]+) (?=(?:c\. )?\d{4}\b)", _word_then_year, value)  # "Kirkpatrick III 1951"
         value = _DATE_THEN_PLACE.sub(r"\1, ", value)
     value = _PAREN_THEN_ITEM.sub(_paren_then_item, value)
     return value.strip()
@@ -1569,6 +1581,8 @@ class _Doc:
                 if not parts and re.match(r"^\d+\.$", c):
                     c = c[:-1]  # "1." then "; Date: ..." read as "1.;"
                 c = _spell_iso_date(c)
+                if c.startswith("-> "):
+                    c = "to " + c[3:]
                 if not c or c.endswith(":"):
                     continue  # empty, or a label whose script went
                 label = labels[j] if j < len(labels) else ""
@@ -1707,7 +1721,7 @@ class _Doc:
             if t == "section":
                 # "President of Austria", "Area", "Population": the group a
                 # field belongs to, which the flat grid would otherwise lose
-                name = clean_text(str(p.get("name") or ""))
+                name = _NAME_FOOTNOTE.sub("", clean_text(str(p.get("name") or "")))
                 if name and any(isinstance(c, dict) and c.get("type") == "image" for c in p.get("has_parts") or []):
                     has_image[name] = True
                 # a group is a short label; a "section" whose name is a whole
@@ -1738,6 +1752,8 @@ class _Doc:
                 if not fname:
                     # "In office 1945 - 1950" under its office; a caption in a
                     # section that holds an image is the image's, not a fact
+                    if _FOOTNOTE_VALUE.match(value):
+                        return
                     if group and (not has_image.get(group) or any(c.isdigit() for c in value)) and _NAMELESS_FACT.search(value):
                         add(group, value)
                 elif group and fname.strip().lower() in _GENERIC_FIELDS:
@@ -1748,7 +1764,7 @@ class _Doc:
                             if prev.lower().startswith(("population", "pop.", "area")):
                                 g = _NAME_FOOTNOTE.sub("", prev)
                                 break
-                    add(g + ", " + key, value)
+                    add(g if key == "total" and g.lower().startswith(("population", "pop.")) else g + ", " + key, value)
                 else:
                     recent.append(fname.strip())
                     add(fname, value, group)
@@ -1775,6 +1791,13 @@ class _Doc:
             (group + ", " + name if name in dup and group else name, value)
             for name, value, group in fields
         ]
+        merged = []
+        for name, value in fields:
+            if merged and merged[-1][0] == name:
+                merged[-1] = (name, cut_words(merged[-1][1] + "; " + value, FACT_WORDS))
+            else:
+                merged.append((name, value))
+        fields = merged
         self.stats["facts"] = self.stats.get("facts", 0) + len(fields)
         self.headings.append(QUICK_FACTS)
         self.out.append('<h2 id="s%d">%s</h2>' % (len(self.headings), QUICK_FACTS))

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -109,7 +109,41 @@ _CITE_PAGES = re.compile(r"(?:\s*:\s*p{1,2}\.\s?\d+(?:[\u2013-]\d+)?\b)+")
 # "## x:", "#; Key": a note marker the dump kept at a line's start
 _NOTE_MARKER = re.compile(r"^#+;?\s+")
 # a raw reference tag the dump left in the prose
-_REF_TAG = re.compile(r"<ref\b[^>]*/>|<ref\b[^>]*>.*?</ref>|<ref\b[^>]*>", re.S | re.I)
+_REF_TAG = re.compile(r"<ref\b[^>]*/>|<ref\b[^>]*>.*?</ref>|<ref\b[^>]*>|<ref\b[^<>]{0,160}$", re.S | re.I)
+# Parsoid's protection markers, leaked into a few articles: "\ufffdPROT139\ufffd"
+# stands where a reference or template was, and one can end an unclosed
+# template ("{{Pie chart| caption = ...\ufffdPROT199\ufffd Roughly ...")
+_PROT = re.compile(r"\{\{[^{}]*?\ufffdPROT\d+\ufffd\s*|\s?\ufffdPROT\d+\ufffd")
+# a footnote the dump left in the prose, and a template opener never closed
+# ("{{block indent| sigma: F -> F'"): the note goes, the opener alone goes
+_NOTE_TEMPLATE = re.compile(r"\s?\{\{(?:efn|sfn|refn|notetag|note)\|[^{}]{0,800}\}\}")
+_TEMPLATE_OPENER = re.compile(r"\{\{[A-Za-z][A-Za-z ]{0,30}\|\s*")
+_BRACE_OPENER = re.compile(r"\{\{(?=\s|$)")
+# wikitext marks the dump left: ''italic'' and '''bold'''; "f''(x)" is a
+# second derivative and stays, so a mark must open before a letter
+_WIKI_BOLD = re.compile(r"'''([A-Za-z][^'\n]{0,120}?)'''")
+_WIKI_ITALIC = re.compile(r"''([A-Za-z][^'\n]{0,120}?)''")
+_WIKI_QUOTE_LEFT = re.compile(r"'''(?=[A-Za-z])")
+_CULTIVAR_QUOTE = re.compile(r"(?<=[a-z])'(?=[A-Z][a-z])")
+# "(-infinity,infinity)": a comma between spelled words gets its space;
+# "epsilon,gamma-carotene" is a chemical name and stays tight
+_COMMA_WORDS = re.compile(r"\b([a-z]{2,}),(?=[a-z]{3,})")
+_GREEK_WORDS = frozenset(symbols.GREEK.values())
+# "{{rp}}" page references after a period: ".: ii. 161 : I.68 However"
+# the same with plain pages: "speciosa.: 86-95, 137)"
+_CITE_NUMERIC = re.compile(r"(?<=[a-z]{4}[.!?])(?::\s?\d{1,4}(?:[\u2013-]\d{1,4})?(?:, \d{1,4}(?:[\u2013-]\d{1,4})?)*)(?=[\s)]|$)")
+_CITE_ROMAN = re.compile(r"(?<=[.,;!?])(?:\s?:\s?[IVXLCivxlc]{1,7}\.\s?\d{1,4}(?:[\u2013-]\d{1,4})?)+(?=\s|$)")
+# what the residue scanner steps over: TeX spacing, align marks, empty groups
+_TEX_LEFTOVER = re.compile(r"\\[,;:!>]|\{\s*\}")
+_TEX_ALIGN = re.compile(r"\s*&=|(?<=\s)&(?=\s)")
+# "z w z^{w}": the dump's words for a formula, then the TeX of them
+_FLAT_THEN_TEX = re.compile(r"\b(\w) (\w) (?=\1\^\{\2\})")
+_SCRIPT_BRACES = re.compile(r"(\w)\^\{(\w)\}")
+# a formula the dump lost the middle of: "sigma = sigma_ij = = == ==,"
+_REPEATED_EQUALS = re.compile(r"([=\u2261]=?)(?:\s+[=\u2261]=?)+(?!\S)")
+_TRAILING_EQUALS = re.compile(r"(?:\s*[=\u2261]=?)+(?=\s*[,.;]?\s*$)")
+# two quoted lines the dump joined: "her.'""'Did you" gets its space back
+_QUOTE_GLUE = re.compile(r"([.!?][\"']{1,2})([\"']{1,2}[A-Z])")
 _TEX_START = re.compile(r"\\(?:\\|[A-Za-z]+)")
 _TEX_SCRIPT_GROUP = re.compile(r"\s?[A-Za-z]?(?:[_^]\{[^{}]*\}\s*)+")
 
@@ -320,7 +354,12 @@ def _runs():
         # not want on the panel (2026-09-11): a Cyrillic word in prose is
         # romanised, in a labelled aside it goes with its label
         bad = "(?:[^" + drawable_class() + "]|[" + REMOVED_SCRIPTS + "])"
-        run = bad + r"(?:\s*" + bad + ")*"
+        # a run carries the quotes around it and the commas, colons and
+        # quotes inside it, so a quoted Hebrew word, a list of Devanagari
+        # titles or a Chinese sentence with its commas goes whole, not as
+        # (") and (,)
+        quote = "[" + _RUN_QUOTES + "]"
+        run = "(?:" + quote + r"\s*)?" + bad + r"(?:[\s,;:\"'\u201c\u201d\u2018\u2019]*" + bad + r")*(?:\s*" + quote + ")?"
         _run_re = re.compile(run)
         label = r"(?:(?<![A-Za-z])(?:(?:simplified|traditional|literally|romani[sz]ed|born|modern|classical|standard|colloquial|formal|archaic|native|also|formerly|abbreviated|pinyin) )?[A-Z][A-Za-z]*(?:[ -][A-Za-z]+){0,2}:\s?)?"
         _labelled_run_re = re.compile(label + run)
@@ -330,17 +369,24 @@ def _runs():
 # Source remnants: the dataset already dropped pronunciation spans and native
 # scripts from some leads, leaving "(German:; 6 January 1850" and "Fernandel ()",
 # and it pads every quotation with spaces: the " beech ", lit. ' uncle '.
+_RUN_QUOTES = "\"'\u201c\u201d\u2018\u2019"
+# a label inside quotes ("House of the Mahdi:) is quoted text, not a label
+# a label opens with a capital or a word labels use ("lit.", "born",
+# "romanized"); "of the Mahdi:" inside a quotation is not one
+_LABEL_HEAD = r"(?:[A-Z][A-Za-z.]*|lit\\.|pl\\.|romani[sz]ed|pinyin|born|n\\u00e9e|also|abbreviated|simplified|traditional|literally|translit\\.|transliterated|from|or|in|meaning|formerly|native|modern|classical|standard|colloquial|formal|archaic)"
+# ... and stands at the start of its segment: after "(", ";" or ","
+_SEGMENT_START = r"(?:^|(?<=[(\[;,])|(?<=[(\[;,] ))"
 _EMPTY_LABEL = re.compile(
-    r"(?<![A-Za-z0-9])[A-Za-z][A-Za-z.]*(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)])"
+    _SEGMENT_START + _LABEL_HEAD + r"(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)])"
 )
 # the same at the end of a parenthetical's segment ("from Sanskrit: , IPA:")
 _EMPTY_LABEL_END = re.compile(
-    r"(?<![A-Za-z0-9])[A-Za-z][A-Za-z.]*(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)]|$)"
+    _SEGMENT_START + _LABEL_HEAD + r"(?:[ -][A-Za-z.]+){0,3}:\s*(?=[;,)]|$)"
 )
 # "(listen)": the audio link's text, with no audio to play
 _LISTEN = re.compile(r"\s?\(\s*(?:listen|more)\s*\)", re.I)
 _FUNCTION_WORDS = frozenset("from or and of the a an in at by to lit also see cf".split())
-_EMPTY_PAREN = re.compile(r"\s?\(\s*\)")
+_EMPTY_PAREN = re.compile(r"\s?\(\s*[,;:\s]*\)")
 # IPA between slashes or brackets, when the serif cannot draw it.
 _SLASHED = re.compile(r" ?/[^/]{1,80}/")
 # what a pronunciation carries that prose never does: IPA letters, modifier
@@ -350,7 +396,7 @@ _BRACKETED = re.compile(r" ?\[[^\[\]]{1,80}\]")
 
 _TIDY = (
     (re.compile(r"\(\s*[,;:]\s*"), "("),
-    (re.compile(r"\s*[,;:]\s*\)"), ")"),
+    (re.compile(r"(?<![\s(]\")(?<!^\")\s*[,;:]\s*\)"), ")"),  # not the face of ":)"
     (re.compile(r"\(\s*\)"), ""),
     (re.compile(r"\[\s*\]"), ""),
     (re.compile(r"\s+([,;?)]|!(?!=)|:(?!\s?\d))"), r"\1"),  # "a != 0" and "3 : 1" keep their spaces
@@ -394,25 +440,50 @@ def clean_text(s):
     if "," in s:
         s = _COMMA_GLUE.sub(", ", s)
     s = _YEAR_GLUE.sub(r"\1 ", s)
+    s = _QUOTE_GLUE.sub(r"\1 \2", s)
     if not s:
         return ""
     s = _CONTROL.sub("", s)
+    if "," in s:
+        s = _COMMA_GLUE.sub(", ", s)  # again: a zero-width space after the comma just went
     if "style" in s and _TEX_OPEN.search(s):
         s = _render_tex(s)
     if "\\" in s:
         s = _TEX_ENV.sub("", s)
         s = _strip_tex_residue(s)  # TeX the dump left outside any block
-        s = re.sub(r"  +", " ", _TEX_SCRIPT_GROUP.sub(" ", s))  # "A_{1}^{ }" left beside it
+        s = _TEX_SCRIPT_GROUP.sub(" ", s)  # "A_{1}^{ }" left beside it
+        s = _TEX_LEFTOVER.sub(" ", _TEX_LEFTOVER.sub(" ", s))
+        s = _TEX_ALIGN.sub(lambda m: " =" if "=" in m.group(0) else " ", s)
+        s = re.sub(r"  +", " ", _TEX_SCRIPT_GROUP.sub(" ", s))
+        s = re.sub(r"\s[_^](?=\s|$)", "", s)
+        if s.count("{") != s.count("}"):
+            s, _ = _balance(s, "{", "}")
+    if "^{" in s:
+        s = _SCRIPT_BRACES.sub(r"\1^\2", _FLAT_THEN_TEX.sub("", s))
+    if "=" in s or "\u2261" in s:
+        s = _TRAILING_EQUALS.sub("", _REPEATED_EQUALS.sub(r"\1", s))
     if "(help)" in s:
         s = _TEMPLATE_ERROR.sub("", s)
     if "<ref" in s:
         s = _REF_TAG.sub("", s)
     if ": p" in s or ":p" in s:
         s = _CITE_PAGES.sub("", s)
+    if ":" in s:
+        s = _CITE_NUMERIC.sub("", _CITE_ROMAN.sub("", s))
     if s.startswith("#"):
         s = _NOTE_MARKER.sub("", s)
+    if "PROT" in s:
+        s = _PROT.sub("", s)
     if "{{" in s:
         s = _TEMPLATE.sub("", s)
+        s = _NOTE_TEMPLATE.sub("", s)
+        s = _TEMPLATE_OPENER.sub(" ", s)
+        surplus = s.count("{") - s.count("}")
+        if surplus > 0:
+            s = _BRACE_OPENER.sub("", s, count=surplus)
+    if "''" in s:
+        s = _WIKI_ITALIC.sub(r"\1", _WIKI_BOLD.sub(r"\1", s))
+        s = _CULTIVAR_QUOTE.sub(" '", _WIKI_QUOTE_LEFT.sub("'", s))
     s = _CITE.sub("", s)
     s = _CITE_PAGE.sub("", s)
     s = _GREEK_ALONE.sub(lambda m: _GREEK_NAMES.get(m.group(1), m.group(1)), s)
@@ -458,6 +529,10 @@ def _close_quote_gaps(text):
                     continue
             if c == "'" and (word_before and word_after or _CLITIC_AFTER.match(text, i + 1)):
                 out.append(c)  # an apostrophe inside a word, or a padded clitic: McGregor 's
+                i += 1
+                continue
+            if c == '"' and before in "'\u2019" and after.isspace() and text[i + 2 : i + 3] in ('"', "'"):
+                out.append(c)  # a closing quote before the next line's opening one: her.'" "'Did
                 i += 1
                 continue
             closes = inside == c and (word_before or not word_after)
@@ -787,6 +862,10 @@ def strip_undrawable(text, stats, lead=False):
     if n:
         stats["symbols_translated"] = stats.get("symbols_translated", 0) + n
     text, folded = _fold_chars(text)
+    if "," in text:
+        # a comma between spelled or folded words gets its space: "(-infinity,infinity)",
+        # "clan,personal" (a full-width comma folded); "epsilon,gamma-carotene" stays
+        text = _COMMA_WORDS.sub(lambda m: m.group(0) if m.group(1) in _GREEK_WORDS else m.group(1) + ", ", text)
     for k, n in folded.items():
         stats[k] = stats.get(k, 0) + n
     text, n = _fold_lookalikes(text)
@@ -804,7 +883,8 @@ def strip_undrawable(text, stats, lead=False):
         census = stats.setdefault("removed_chars", {})
         for m in run_re.finditer(text):
             for ch in m.group(0):
-                if not ch.isspace():
+                # the quotes and commas a run carries are its own, not a loss
+                if not ch.isspace() and ord(ch) >= 128 and ch not in _RUN_QUOTES:
                     census[ch] = census.get(ch, 0) + 1
         if lead:
             for _ in range(3):
@@ -850,18 +930,18 @@ def strip_undrawable(text, stats, lead=False):
 # not close the outer one.
 _SCRUB = (
     (re.compile(r"\s?(?:\"\s*\"|\u201c\s*\u201d|''|\u2018\s*\u2019)(?=\s|[,.;:)]|$)"), ""),
-    (re.compile(r"\s?[(\[{]\s*[)\]}]"), ""),
+    (re.compile(r"\s?[(\[{]\s*[,;:\s]*[)\]}]"), ""),
     (re.compile(r"\(\(([^()]*)\)\)"), r"(\1)"),
     (re.compile(r"\[\[([^\[\]]*)\]\]"), r"[\1]"),
     (re.compile(r"([,;])\s*(?:[,;]\s*)+"), r"\1 "),
     (re.compile(r"(?<=\S)\s+([,;](?=\s|$))"), r"\1"),
     (re.compile(r"\(\s+"), "("),
     (re.compile(r"\s+\)"), ")"),
-    (re.compile(r"^\s*[,;]\s*"), ""),
+    (re.compile(r"^\s*(?:[,;]|:(?=\s|$))\s*"), ""),
     (re.compile(r"\s*[,;]$"), ""),
     (re.compile(r"[ \t\u00a0]{2,}"), " "),
 )
-_SCRUB_HINT = re.compile(r"[()\[\]{}\"\u201c\u2018',;]")
+_SCRUB_HINT = re.compile(r"[()\[\]{}\"\u201c\u2018',;]|^\s*:")
 
 
 def scrub_artifacts(text):
@@ -887,12 +967,25 @@ def scrub_artifacts(text):
     return text.strip(), n
 
 
+def _is_face(text, i):
+    """text[i] is the mouth of ":)" or ";-(": an emoticon, not a parenthesis.
+    The eyes stand at a word boundary; "8)" is "(number 8)" far more often than a face."""
+    j = i - 1
+    if j >= 0 and text[j] == "-":
+        j -= 1
+    if j < 0 or text[j] not in ":;=":
+        return False
+    return j == 0 or text[j - 1] in " \t\"'\u201c\u2018"
+
+
 def _balance(text, opener, closer):
     """Drops closers with no opener before them and openers never closed."""
     out = []
     stack = []
     drop = set()
     for i, ch in enumerate(text):
+        if ch in "()" and _is_face(text, i):
+            continue  # ":)" and ":-(" are faces, not parentheses
         if ch == opener:
             stack.append(i)
         elif ch == closer:
@@ -1106,7 +1199,7 @@ class _Doc:
                 self.stats["links_dropped"] = self.stats.get("links_dropped", 0) + 1
                 continue
             t = strip_undrawable(clean_text(raw), {}, lead=False)
-            if not t:
+            if not t.strip():
                 self.stats["links_dropped"] = self.stats.get("links_dropped", 0) + 1
                 continue
             i = text.find(t)
@@ -1174,8 +1267,18 @@ class _Doc:
         for s, e, href in links:
             if s < lo or e > hi:
                 continue
-            out.append(esc(text[i:s]))
-            out.append('<a href="' + esc_attr(href) + '">' + esc(text[s:e]) + "</a>")
+            # the dump's link text can carry the space that stood beside a
+            # lost icon ("China "): the space stays outside the anchor
+            inner = text[s:e]
+            if not inner.strip():
+                out.append(esc(text[i:e]))
+                i = e
+                continue
+            lead = inner[: len(inner) - len(inner.lstrip())]
+            trail = inner[len(inner.rstrip()) :]
+            out.append(esc(text[i:s] + lead))
+            out.append('<a href="' + esc_attr(href) + '">' + esc(inner.strip()) + "</a>")
+            out.append(esc(trail))
             i = e
         out.append(esc(text[i:hi]))
         return "".join(out)
@@ -1285,12 +1388,16 @@ class _Doc:
                     if run_re.search(raw):
                         with_runs += 1
                 cells.append(strip_undrawable(raw, self.stats))
+            if is_header and len(cells) > 1 and len(set(cells)) == 1:
+                continue  # a caption spanning the row ("Key (expand for notes)"), not column names
             grid.append((is_header, cells))
         if filled and with_runs * 2 >= filled:
             # a phoneme chart, a table of native names: without its script it
             # is a grid of holes, so the notice is the honest rendering
             self.stats["script_tables_omitted"] = self.stats.get("script_tables_omitted", 0) + 1
             return TABLE_OMITTED
+        if not grid:
+            return ""  # a caption and nothing under it
         # A navbox is a table of links to other pages with its own controls in
         # it; on this device it is three columns of "This box: view talk edit".
         # It is navigation, not content, so it leaves no notice behind.
@@ -1311,7 +1418,7 @@ class _Doc:
             tag = "th" if is_header else "td"
             out.append(
                 "<tr>"
-                + "".join("<%s>%s</%s>" % (tag, esc(c), tag) for c in cells)
+                + "".join("<%s>%s</%s>" % (tag, esc("Number" if c.strip() == "#" else c), tag) for c in cells)
                 + "</tr>"
             )
         out.append("</table>")
@@ -1324,7 +1431,7 @@ class _Doc:
         "1984; Category: Best Comedy Recording; Work: Eat It; Result: Won"
         instead of a notice that a table stood here."""
         headers = [cells for is_header, cells in grid if is_header]
-        labels = headers[-1] if headers else []
+        labels = ["Number" if c.strip() == "#" else c for c in (headers[-1] if headers else [])]
         body = [cells for is_header, cells in grid if not is_header]
         if not body:
             return ""
@@ -1340,6 +1447,8 @@ class _Doc:
                 if len(c.split(" ")) >= TABLE_ROW_CELL_WORDS:
                     c, _ = scrub_artifacts(c)  # a cut can leave a parenthesis open
                 c = re.sub(r"  +", " ", c).strip()
+                if c == "#":
+                    c = "Number"
                 if not c or c.endswith(":"):
                     continue  # empty, or a label whose script went
                 label = labels[j] if j < len(labels) else ""
@@ -1629,9 +1738,13 @@ def heading_bytes(text):
 
 
 _INLINE_DOUBLE_SPACE = re.compile(r"(?<=\S)[ \u00a0]{2,}(?=\S)")
+# the label may sit in a link ("Chinese</a>: ,"); the closing tag stays.
+# The piece ends at a block's closing tag, never at the link's own ("Vizing's
+# Theorem:</a> A graph" is a label with its content after it)
 _INLINE_EMPTY_LABEL = re.compile(
-    r"(?<![A-Za-z0-9>])[A-Z][A-Za-z.]*(?:[ -][A-Za-z.]+){0,3}:\s*(?:</a>)?\s*(?=[;,)]|</)"
+    r"(?<![A-Za-z0-9>\"'\u201c\u2018])[A-Z][A-Za-z.]*(?:[ -][A-Za-z.]+){0,3}(</a>)?:\s*(</a>)?\s*(?=[;,)]|</(?:p|li|td|th|dd|dt|h[1-6])>)"
 )
+_EMPTY_ANCHOR = re.compile(r'<a href="[^"]*">\s*</a>')
 _INLINE_TIDY = (
     (re.compile(r"\(\s*[;,]\s*"), "("),
     (re.compile(r"\s*[;,]\s*\)"), ")"),
@@ -1646,7 +1759,8 @@ def _scrub_inline(html_text):
     left two spaces at a piece boundary. One pass over the assembled line."""
     if "  " in html_text or ":" in html_text:
         html_text = _INLINE_DOUBLE_SPACE.sub(" ", html_text)
-        html_text = _INLINE_EMPTY_LABEL.sub("", html_text)
+        html_text = _INLINE_EMPTY_LABEL.sub(lambda m: (m.group(1) or "") + (m.group(2) or ""), html_text)
+        html_text = _EMPTY_ANCHOR.sub("", html_text)
         for rx, rep_ in _INLINE_TIDY:
             html_text = rx.sub(rep_, html_text)
     return html_text

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -329,6 +329,7 @@ _HATNOTE = re.compile(
     r"(?:Main articles?:|See also:|Further information:|For other uses\b|For the [^.]{0,80}, see\b|"
     r"Not to be confused with\b|\"[^\"]{1,80}\" redirects here\b|[^.\n]{1,80} redirects here\.)"
 )
+_NAME_DISAMBIG = re.compile(r" \((?:band|album|singer|group|musician|rapper|artist|film|TV series|series)\)(?= (?:chronology|discography|singles))")
 _NAVBOX = re.compile(r"This box:|\bview\s+talk\s+edit\b|\bv\s*[\u00b7.]\s*t\s*[\u00b7.]\s*e\b")
 # One level of nesting, so "(UK: OH-s(h)ee-AH-nee-<schwa>)" is one parenthetical.
 _PAREN = re.compile(r" ?\((?:[^()]|\([^()]*\))*\)")
@@ -385,6 +386,19 @@ _EMPTY_LABEL_END = re.compile(
 )
 # "(listen)": the audio link's text, with no audio to play
 _LISTEN = re.compile(r"\s?\(\s*(?:listen|more)\s*\)", re.I)
+# "April 26, 1994 (1994-04-26)": the start-date template's hidden ISO copy
+_ISO_DATE_DUP = re.compile(r"(?<=[a-z0-9])\s?\(\d{4}-\d{2}-\d{2}\)")
+# "(Pub. L. Tooltip Public Law (United States)107-252 (text) (PDF))": an
+# abbreviation's tooltip and the law template's link labels
+_TOOLTIP = re.compile(r"\s?\bTooltip [A-Z][A-Za-z .]{0,60}(?:\([^()]{0,40}\))? ?(?=\d|$)")
+_TEXT_PDF = re.compile(r"\s?\(text\)(?:\s?\(PDF\))?")
+# "Team v t e": a navbox's view-talk-edit inside a table header
+_VTE = re.compile(r"\s?\bv\s+t\s+e\b")
+# a coordinate pair the infobox left at the front of a paragraph
+_LEAD_COORDS = re.compile(
+    r"^\s*\d{1,3}\u00b0[\d\u2032\u2033'\"\s.]*[NS]\s*\d{1,3}\u00b0[\d\u2032\u2033'\"\s.]*[EW]"
+    r"(?:\s*/\s*[\d.\u2212-]+\u00b0[NS]\s*[\d.\u2212-]+\u00b0[EW])?(?:\s*/\s*[\d.\u2212-]+;\s*[\d.\u2212-]+)?\s*(?=[A-Z])"
+)
 _FUNCTION_WORDS = frozenset("from or and of the a an in at by to lit also see cf".split())
 _EMPTY_PAREN = re.compile(r"\s?\(\s*[,;:\s]*\)")
 # IPA between slashes or brackets, when the serif cannot draw it.
@@ -437,6 +451,14 @@ def clean_text(s):
         s = _SENTENCE_GLUE.sub(r"\1 \2", s)
     if "(" in s:
         s = _LISTEN.sub("", s)
+        s = _ISO_DATE_DUP.sub("", s)
+        s = _TEXT_PDF.sub("", s)
+    if "Tooltip" in s:
+        s = _TOOLTIP.sub(" ", s)
+    if "v" in s:
+        s = _VTE.sub("", s)
+    if "\u00b0" in s and _LEAD_COORDS.match(s):
+        s = _LEAD_COORDS.sub("", s, count=1)
     if "," in s:
         s = _COMMA_GLUE.sub(", ", s)
     s = _YEAR_GLUE.sub(r"\1 ", s)
@@ -755,6 +777,8 @@ def _romanize_runs(text, run_re):
         return latin
 
     out = run_re.sub(sub, text)
+    if n and "(" in out:
+        out = _ROMAN_PAREN.sub(lambda m: m.group(2) if _plain(m.group(1)) == _plain(m.group(2)) else m.group(0), out)
     if n >= 2:
         # "\u1f55\u03b2\u03bf\u03c2 or \u1f51\u03b2\u03cc\u03c2": two accentuations, one spelling
         out = _SAME_TWICE.sub(r"\1", out)
@@ -762,6 +786,7 @@ def _romanize_runs(text, run_re):
 
 
 _NEXT_WORD = re.compile(r"\s*,\s*([A-Z][A-Za-z\u00c0-\u024f]+)")
+_ROMAN_PAREN = re.compile(r"\b([A-Za-z]+) \(([A-Za-z\u00c0-\u024f\u1e00-\u1eff]+)\)")
 _SAME_TWICE = re.compile(r"\b([A-Za-z]+) (?:or|and|/) \1\b")
 
 
@@ -1042,6 +1067,26 @@ def link_target(url):
 # snapshot and wrong from the next day; the place gets its comma back after
 # a date, and one item after another gets one after its parenthesis.
 _AGE = re.compile(r"\s*\(aged?\s+\d+(?:\s*[\u2013-]\s*\d+)?\)")
+# "Preferred IUPAC name Methyl methanesulfonate": the chembox's sub-label
+_CHEM_SUBLABEL = re.compile(r"^((?:Preferred |Systematic )?IUPAC name|Other names?|Chemical formula)\s+(?=\S)")
+# "Length: 61: 49": a running time the dump spaced
+_TIME_FIELD = re.compile(r"^(?:Length|Duration|Running time|Time|Runtime)$", re.I)
+_TIME_GAP = re.compile(r"\b(\d{1,2}): (\d{2})\b")
+_NAME_THEN_DATE = re.compile(
+    r"([A-Za-z]+)\s+(?=(?:\d{1,2} [A-Z][a-z]+ \d{4}|[A-Z][a-z]+ \d{1,2}, \d{4})\b)"
+)
+_DATE_LEAD_WORDS = frozenset(
+    "born died c ca circa on in since until from to before after about by at the of and or between as".split()
+)
+
+
+def _name_then_date(m):
+    word = m.group(1)
+    if word.lower() in _DATE_LEAD_WORDS or not word[:1].isupper():
+        return m.group(0)
+    return word + ", "
+
+
 _DATE_THEN_PLACE = re.compile(
     r"(\b(?:\d{1,2} [A-Z][a-z]+ \d{4}|[A-Z][a-z]+ \d{1,2}, \d{4}|\d{4}))\s+(?=[A-Z])"
 )
@@ -1080,9 +1125,11 @@ def _split_at_links(value, links, name=""):
     1803", a taxon and its authority) stay as they are."""
     if not links or len(links) < 2:
         return value
+    texts = [lk.get("text") for lk in links if isinstance(lk, dict) and isinstance(lk.get("text"), str) and lk.get("text")]
+    if len(texts) >= 2 and value.strip() == " ".join(texts) and all(t[:1].isupper() for t in texts):
+        return "; ".join(texts)  # "Mark Waid Alex Ross": the links are the whole value
     if len(links) < 3 and not _LIST_ROWS.search(name or ""):
         return value
-    texts = [lk.get("text") for lk in links if isinstance(lk, dict) and isinstance(lk.get("text"), str) and lk.get("text")]
     if len(texts) < 2:
         return value
     out = value
@@ -1108,7 +1155,7 @@ _FORMULA_ROW = re.compile(r"formula", re.I)
 _ELEMENT_COUNT = re.compile(r"(?<=[A-Za-z\)\]]) (\d{1,3})(?=[A-Z(\[\s]|$)")
 _FORMULA_GAP = re.compile(r"(?<=[A-Za-z\u2080-\u2089)\]]) (?=[A-Z(\[])")
 # "g·mol −1", "m s −2": a unit's exponent
-_UNIT_EXPONENT = re.compile(r"(?<=[a-zA-Z]) ([\u2212-]?\d)(?=\b)")
+_UNIT_EXPONENT = re.compile(r"(?<=[a-zA-Z]) ([\u2212-]?\d)(?=\b)(?![\u00b0\u2032\u2033\d])")
 _UNIT_BEFORE = re.compile(r"^(?:mol|kg|g|m|cm|mm|km|s|K|J|Hz|Pa|N|V|A|W|C|L|dm|cd|sr|rad|h|min|yr|Bq|Gy|Sv|T|H|F|S|Wb|lm|lx)$")
 _ELEMENT_BEFORE = re.compile(r"(?:^|[\s(])([A-Z][a-z]?)$")
 # "Zn 2+", "S 2−": an ion's charge
@@ -1152,9 +1199,13 @@ def fact_value(name, value):
         return value
     value = _AGE.sub("", value)
     value = _WRAPPED.sub(r"\1", value.strip())
+    value = _CHEM_SUBLABEL.sub(r"\1: ", value)
+    if _TIME_FIELD.search(name):
+        value = _TIME_GAP.sub(r"\1:\2", value)
     if "configuration" in name.lower() or "shell" in name.lower():
         value = _SHELL.sub(lambda m: m.group(1) + m.group(2).translate(_SUPER), value)
     value = _YEAR_PAGE.sub("", value)
+    value = _NAME_THEN_DATE.sub(_name_then_date, value)
     value = re.sub(r"(\d{4}) /(\d{4})\b", r"\1/\2", value)
     if _FORMULA_ROW.search(name):
         value = _ELEMENT_COUNT.sub(lambda m: m.group(1).translate(_SUB), value)
@@ -1371,6 +1422,7 @@ class _Doc:
 
     def table_html(self, tb):
         rows = [(True, r) for r in (tb.get("headers") or []) if isinstance(r, list)]
+        rows = rows[-1:]  # of stacked header rows, the lowest names the columns
         rows += [(False, r) for r in (tb.get("rows") or []) if isinstance(r, list)]
         rows = [(h, r) for h, r in rows if r]
         if not rows:
@@ -1387,7 +1439,7 @@ class _Doc:
                     filled += 1
                     if run_re.search(raw):
                         with_runs += 1
-                cells.append(strip_undrawable(raw, self.stats))
+                cells.append(re.sub(r"\s#$", "", strip_undrawable(raw, self.stats)))
             if is_header and len(cells) > 1 and len(set(cells)) == 1:
                 continue  # a caption spanning the row ("Key (expand for notes)"), not column names
             grid.append((is_header, cells))
@@ -1443,7 +1495,10 @@ class _Doc:
                 # arrives as the same text in every column: say it once
                 cells = cells[:1]
             for j, c in enumerate(cells):
+                if j and c == cells[j - 1]:
+                    continue  # a spanning cell ("did not advance"), once per column it covered
                 c = cut_words(c.strip(), TABLE_ROW_CELL_WORDS)
+                c = re.sub(r"\s#$", "", c)  # a footnote marker
                 if len(c.split(" ")) >= TABLE_ROW_CELL_WORDS:
                     c, _ = scrub_artifacts(c)  # a cut can leave a parenthesis open
                 c = re.sub(r"  +", " ", c).strip()
@@ -1549,6 +1604,7 @@ class _Doc:
                 self.stats["pronunciation_facts_dropped"] = self.stats.get("pronunciation_facts_dropped", 0) + 1
                 return
             name = strip_undrawable(clean_text(name), self.stats)
+            name = _NAME_DISAMBIG.sub("", name)
             value = cut_words(
                 fact_value(name, strip_undrawable(clean_text(value), self.stats)),
                 FACT_WORDS,
@@ -1606,7 +1662,7 @@ class _Doc:
                     add(fname, value, group)
             elif t == "list" and p.get("name"):
                 items = [
-                    clean_text(it.get("value"))
+                    _item_text(it)
                     for it in p.get("has_parts") or []
                     if isinstance(it, dict) and isinstance(it.get("value"), str)
                 ]
@@ -1638,6 +1694,18 @@ class _Doc:
         for name, value in fields:
             self.out.append("<tr><th>" + esc(name) + "</th><td>" + esc(value) + "</td></tr>")
         self.out.append("</table>")
+
+
+def _item_text(it):
+    """A list item's text; a definition term carries its definitions
+    ("Gold 0"), which the dump nests under it."""
+    v = clean_text(it.get("value") or "")
+    if it.get("type") == "definition_term":
+        defs = [clean_text(d.get("value") or "") for d in it.get("has_parts") or [] if isinstance(d, dict)]
+        defs = [d for d in defs if d]
+        if defs:
+            v = v + " " + ", ".join(defs)
+    return v
 
 
 # "Wolfgang Amadeus Mozart" is found by "mozart" only through an index entry

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -2036,6 +2036,11 @@ _INLINE_EMPTY_LABEL = re.compile(
     r"(?<![A-Za-z0-9>\"'\u201c\u2018])[A-Z][A-Za-z.]*(?:[ -][A-Za-z.]+){0,3}(</a>)?:\s*(</a>)?\s*(?=[;,)]|</(?:p|li|td|th|dd|dt|h[1-6])>)"
 )
 _EMPTY_ANCHOR = re.compile(r'<a href="[^"]*">\s*</a>')
+# a label that is the whole of a link ("<a>Hebrew</a>:;"): the lookbehind
+# above cannot see past the ">", so the anchor and its colon go together
+_INLINE_LINKED_LABEL = re.compile(
+    r'<a href="[^"]*">' + _LABEL_HEAD + r"(?:[ -][A-Za-z.]+){0,3}</a>:\s*(?=[;,)]|</(?:p|li|td|th|dd|dt|h[1-6])>)"
+)
 _INLINE_TIDY = (
     (re.compile(r"\(\s*[;,:]\s*"), "("),
     (re.compile(r"(?<![\s(]\")\s*[;,:]\s*\)"), ")"),
@@ -2050,6 +2055,7 @@ def _scrub_inline(html_text):
     left two spaces at a piece boundary. One pass over the assembled line."""
     if "  " in html_text or ":" in html_text:
         html_text = _INLINE_DOUBLE_SPACE.sub(" ", html_text)
+        html_text = _INLINE_LINKED_LABEL.sub("", html_text)
         html_text = _INLINE_EMPTY_LABEL.sub(lambda m: (m.group(1) or "") + (m.group(2) or ""), html_text)
         html_text = _EMPTY_ANCHOR.sub("", html_text)
         for rx, rep_ in _INLINE_TIDY:

--- a/tools_local/wikipedia/article_html.py
+++ b/tools_local/wikipedia/article_html.py
@@ -413,6 +413,7 @@ _LEAD_COORDS = re.compile(
     r"(?:\s*/\s*[\d.\u2212-]+\u00b0[NS]\s*[\d.\u2212-]+\u00b0[EW])?(?:\s*/\s*[\d.\u2212-]+;\s*[\d.\u2212-]+)?\s*(?=[A-Z])"
 )
 # a paragraph that is only a coordinate pair (a fact's value may be one)
+_CAPS_TOKEN = re.compile(r"^[A-Z]{2,4}$")  # "KGT" on a line of its own after every match: a fixture template's time zone
 _COORDS_ONLY = re.compile(
     r"^\s*\d{1,3}\u00b0[\d\u2032\u2033'\"\s.]*[NS]\s*\d{1,3}\u00b0[\d\u2032\u2033'\"\s.]*[EW](?:\s*/.*)?$"
 )
@@ -490,6 +491,8 @@ def clean_text(s):
     if not s:
         return ""
     s = _CONTROL.sub("", s)
+    if "\u2011" in s or "\u2010" in s:
+        s = s.replace("\u2011", "-").replace("\u2010", "-")
     if "," in s:
         s = _COMMA_GLUE.sub(", ", s)  # again: a zero-width space after the comma just went
     if "style" in s and _TEX_OPEN.search(s):
@@ -1254,7 +1257,9 @@ _SUB = str.maketrans("0123456789", "\u2080\u2081\u2082\u2083\u2084\u2085\u2086\u
 # a climate table's month row; a link's caption with no link to follow
 _FACT_SKIP_VALUE = re.compile(r"^(?:[JFMASOND] ){11}[JFMASOND]$|^(?:(?:Listen live|Public file(?:; LMS)?|LMS|Website|Official website)(?: \([^()]*\))?(?:[,;] )?)+$", re.I)
 _DEAD_CELL = re.compile(r"^(?:Report|Match report|Highlights|Video|Stats|Box score)$", re.I)
-_NAME_FOOTNOTE = re.compile(r"(?<=[A-Za-z)]) \d$")
+_NAME_FOOTNOTE = re.compile(r"(?<=[A-Za-z)]) \d$|(?<=[A-Za-z)])\*$")
+# a table's header row that arrived as a field: "Years: Team", "Source: Rating"
+_HEADER_WORDS = frozenset("years year team club title role source rating apps gls goals pos nation player name no. date opponent result venue competition".split())
 _SLASH_GAP = re.compile(r"(?<=\S) /(?=[A-Za-z0-9])(?!\d{4}\b)")  # not "1564 /1563", a year either way
 _FACT_LABELS = frozenset(("Preceded by", "Succeeded by", "In office"))
 _GENERIC_FIELDS = frozenset((
@@ -1395,7 +1400,7 @@ class _Doc:
         text = strip_undrawable(
             clean_text(part.get("value") or ""), self.stats, lead=lead
         )
-        if not text or _COORDS_ONLY.match(text):
+        if not text or _COORDS_ONLY.match(text) or (not lead and _CAPS_TOKEN.match(text)):
             return ""
         links = self._place_links(text, part.get("links"), lead)
         bold = self._subject(text) if subject else None
@@ -1618,6 +1623,8 @@ class _Doc:
                 if len(c.split(" ")) >= TABLE_ROW_CELL_WORDS:
                     c, _ = scrub_artifacts(c)  # a cut can leave a parenthesis open
                 c = re.sub(r"  +", " ", c).strip()
+                if c in ("-", "\u2013", "\u2014", "\u2212"):
+                    continue  # an empty cell the dump wrote as a dash
                 if c == "#":
                     c = "Number"
                 if not parts and re.match(r"^\d+\.$", c):
@@ -1743,6 +1750,8 @@ class _Doc:
                 add(name, glued.group(1), group)
                 add(glued.group(2), glued.group(3), group)
                 return
+            if name.strip().lower() in _HEADER_WORDS and value.strip().lower() in _HEADER_WORDS:
+                return  # "Years: Team": a header row the dump made a field
             if name in (self.title, base) or _HEADER_VALUE.match(value):
                 return  # a taxobox's "<title>: Scientific classification", a link caption "Official Results"
             if value in _FACT_LABELS or value in (self.title, self.title.split(",")[0].strip(), base):

--- a/tools_local/wikipedia/quality.py
+++ b/tools_local/wikipedia/quality.py
@@ -624,6 +624,7 @@ _INLINE = re.compile(r"</?(?:a|b|i)\b[^>]*>")
 _BLOCK_SPLIT = re.compile(r"<(h[1-6]|p|li|table)\b[^>]*>(.*?)</\1>", re.S)
 _TAG = re.compile(r"<[^>]+>")
 _ROW = re.compile(r"<tr><th>(.*?)</th><td>(.*?)</td></tr>", re.S)
+_NESTED_LIST = re.compile(r"<(?:ul|ol)>")  # where a nested list starts inside an item
 
 
 def plain(xhtml):
@@ -656,6 +657,9 @@ def blocks(xhtml):
             ]
             out.append(("table", rows))
         else:
+            # a list item's own text and a list nested under it are two
+            # lines on the panel, not one word: "Ice cream" + "Chapman's"
+            inner = _NESTED_LIST.sub(": ", inner)
             out.append((kind, html.unescape(_TAG.sub("", inner)).strip()))
     return out
 

--- a/tools_local/wikipedia/quality.py
+++ b/tools_local/wikipedia/quality.py
@@ -186,7 +186,7 @@ DETECTORS = [
         "headings",
         "heading_edit",
         "head",
-        re.compile(r"\[edit\]|\bedit\b$"),
+        re.compile(r"\[edit\]|^edit$"),
         "the edit link survived",
     ),
     # --- words and spacing
@@ -222,7 +222,7 @@ DETECTORS = [
         "words",
         "comma_glue",
         "para",
-        re.compile(r"\b(?!(?:alpha|beta|gamma|delta|omega|sigma|kappa|theta|lambda|cis|trans),)[a-z]{3,},[A-Za-z]{3,}"),
+        re.compile(r"\b(?!(?:alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|omicron|rho|sigma|tau|upsilon|phi|chi|psi|omega|cis|trans|sec|tert|iso|neo|ortho|meta|para),)[a-z]{3,},[A-Za-z]{3,}"),
         "a comma with no space after it",
     ),
     ("words", "double_punct", "para", re.compile(r"[,;:]{2}|[,;] ?[,;]|, \.|; \.|\?\?|!!"), "doubled punctuation"),
@@ -230,8 +230,8 @@ DETECTORS = [
         "words",
         "space_before_punct",
         "para",
-        re.compile(r"\w [,.;:!?](?=\s|$)"),
-        "a space before a comma or period: something between them went",
+        re.compile(r"\w [,.;!?](?=\s|$)|[A-Za-z] :(?=\s[a-z]|$)"),
+        "a space before a comma or period: something between them went (a colon after a digit is a ratio or a title)",
     ),
     (
         "words",
@@ -333,7 +333,7 @@ DETECTORS = [
         "balance",
         "orphan_quote",
         "para",
-        re.compile(r"(?<![\w.,!?\"])\"\s*\"(?![\w\"])|\(\s*\"\s*\)|(?<![\w.,!?])\u201c\s*\u201d"),
+        re.compile(r"(?<![\w.,!?\"'])\"\s*\"(?![\w\"'])|(?<!mark )(?<!marks )(?<!quote )(?<!quotes )(?<!character )\(\s*\"\s*\)|(?<![\w.,!?])\u201c\s*\u201d"),
         "an empty quotation",
     ),
     (
@@ -356,7 +356,7 @@ DETECTORS = [
         "stray_markup",
         "text",
         re.compile(
-            r"\{\{(?![a-z0-9 ,]{1,12}\})|\[\[|\]\]|<ref\b|&lt;|&gt;|&nbsp;|&amp;|&#\d+;|&[a-z]{2,8};"
+            r"\{\{(?!\s*[A-Za-z0-9 ,]{1,12}\s*\})|\[\[(?!\d)|\]\]|<ref\b|&lt;|&gt;|&nbsp;|&amp;|&#\d+;|&[a-z]{2,8};"
         ),
         "wikitext or HTML that should not be in the text",
     ),
@@ -364,7 +364,7 @@ DETECTORS = [
         "remnants",
         "wikitext_line",
         "para",
-        re.compile(r"^\s*[#:;]{1,3}\s|'''|^==|==$|\|-|\|\}|\{\|"),
+        re.compile(r"^\s*[#:;]{1,3}\s|'''|^==|==$|^\s*\|[-}]|^\s*\{\|"),
         "a wikitext list marker, bold marks or table syntax",
     ),
     (
@@ -432,10 +432,17 @@ DETECTORS = [
     ("remnants", "url_in_text", "text", re.compile(r"https?://|\bwww\.[a-z]"), "a URL"),
     (
         "remnants",
+        "page_ref_glue",
+        "para",
+        re.compile(r"(?<=[a-z]{4}[.!?]):\s?(?:[ivxlc]{1,7}\.\s?)?\d{1,4}(?:[\u2013-]\d{1,4})?(?=[\s)]|$)"),
+        "a page reference glued to the sentence's period: the rp template's output (\"Pop.: 249,626\" is a label)",
+    ),
+    (
+        "remnants",
         "tex_remnant",
         "text",
         re.compile(
-            r"\\displaystyle|\\frac|\\sqrt|\\mathbf|\\mathrm|\\left|\\right|\{\\|\^\{|_\{|\\[a-zA-Z]{2,}\{|\\[a-zA-Z]{2,}\b"
+            r"\\displaystyle|\\frac|\\sqrt|\\mathbf|\\mathrm|\\left|\\right|(?<!\\)\{\\|\^\{|_\{|\\[a-zA-Z]{2,}\{|(?<![A-Za-z])\\[a-zA-Z]{2,}\b"
         ),
         "TeX in the text",
     ),
@@ -472,7 +479,7 @@ DETECTORS = [
         "encoding",
         "replacement_char",
         "text",
-        re.compile(r"\ufffd"),
+        re.compile(r"(?<!U\+FFFD )(?<!character )\ufffd(?! REPLACEMENT)"),
         "U+FFFD: a byte that was not text",
     ),
     (
@@ -657,6 +664,9 @@ def _words(t):
     return len(t.split())
 
 
+_FACE = re.compile(r"(?<![A-Za-z0-9])[:;=]-?[()]")
+
+
 def struct_hits(name, bl):
     """Structural detectors over the block list. Returns [context, ...]."""
     hits = []
@@ -747,6 +757,7 @@ def struct_hits(name, bl):
                     hits.append(sent[:160])
     elif name == "unbalanced_parens":
         for k, t in paras:
+            t = _FACE.sub("", t)  # ":)" is a face, not a parenthesis
             if t.count("(") != t.count(")"):
                 hits.append(t[:160])
     elif name == "unbalanced_quotes":
@@ -1121,7 +1132,7 @@ def main(argv=None):
     ap.add_argument("--workers", type=int, default=0, help="worker processes (default: cores minus two)")
     ap.add_argument("--every", type=int, default=1, help="scan every Nth article (the full pack)")
     args = ap.parse_args(argv)
-    gate_failed = False
+    gate_failed = []
     if args.summary:
         with open(args.summary, encoding="utf-8") as f:
             summary = json.load(f)
@@ -1132,7 +1143,7 @@ def main(argv=None):
         for name, (cnt, chars) in sorted(refused.items(), key=lambda kv: -kv[1][0]):
             print(f"  REFUSED  {name:28s} {cnt:10,}  {' '.join(chars)}   (must be drawn or spelled, not dropped)")
         if refused:
-            gate_failed = True
+            gate_failed.append("characters that carry meaning were dropped")
         print(f"symbols spelled: {summary.get('symbols_translated', 0):,}; diacritics reduced to base letters: {summary.get('diacritics_dropped', 0):,}")
     report, sample = scan(args.pack, args.sample, args.seed, limit=args.limit, workers=args.workers or None, every=args.every)
     # Mario, 2026-09-11: at the end nothing that reads as an artifact may
@@ -1140,7 +1151,7 @@ def main(argv=None):
     artifacts = {name: report["signatures"][name]["articles"] for name in ARTIFACT_DETECTORS if report["signatures"][name]["hits"]}
     if artifacts:
         print("ARTIFACTS STILL PRESENT: " + ", ".join("%s in %d articles" % kv for kv in sorted(artifacts.items(), key=lambda kv: -kv[1])))
-        gate_failed = True
+        gate_failed.append("artifacts remain in %d classes" % len(artifacts))
     print(f"{report['articles']:,} articles; body chars median {report['body_chars']['median']:,}, "
           f"p10 {report['body_chars']['p10']:,}, p1 {report['body_chars']['p1']:,}; "
           f"near-empty (<{NEAR_EMPTY}): {report['near_empty_count']}")
@@ -1163,7 +1174,7 @@ def main(argv=None):
                 f.write("## " + title + "\n\n" + t[:args.chars] + ("\n\n[...]\n\n" if len(t) > args.chars else "\n\n"))
         print(f"sample of {len(sample)} articles -> {args.plain}")
     if gate_failed:
-        print("QUALITY GATE: FAILED, characters that carry meaning were dropped")
+        print("QUALITY GATE: FAILED, " + " and ".join(gate_failed))
         return 1
     print("QUALITY GATE: passed (every removed character is in an accepted script)")
     return 0

--- a/tools_local/wikipedia/quality.py
+++ b/tools_local/wikipedia/quality.py
@@ -222,7 +222,7 @@ DETECTORS = [
         "words",
         "comma_glue",
         "para",
-        re.compile(r"(?<!alpha)(?<!beta)(?<!gamma)(?<!delta)(?<!omega)(?<!sigma)(?<!kappa)(?<!theta)(?<!lambda)[a-z]{3,},[A-Za-z]{3,}"),
+        re.compile(r"\b(?!(?:alpha|beta|gamma|delta|omega|sigma|kappa|theta|lambda|cis|trans),)[a-z]{3,},[A-Za-z]{3,}"),
         "a comma with no space after it",
     ),
     ("words", "double_punct", "para", re.compile(r"[,;:]{2}|[,;] ?[,;]|, \.|; \.|\?\?|!!"), "doubled punctuation"),
@@ -879,12 +879,14 @@ def _scan_chunk(args):
     return out
 
 
-def scan(pack_dir, sample_n=0, seed=20260911, examples_per=6, limit=0, workers=None):
+def scan(pack_dir, sample_n=0, seed=20260911, examples_per=6, limit=0, workers=None, every=1):
     """Every article through every detector, on a pool of workers; each
     worker reads its own contiguous slice so the block cache stays warm."""
     p = pf.Pack(pack_dir)
     entries = [(e.title, e.locator) for e in p.iter_entries() if not e.redirect]
     p.close()
+    if every > 1:
+        entries = entries[::every]  # the full pack: every Nth article, still in title order
     if limit:
         entries = entries[:limit]
     n = len(entries)
@@ -1117,6 +1119,7 @@ def main(argv=None):
     ap.add_argument("--report", help="write the full detector report (markdown) here")
     ap.add_argument("--limit", type=int, default=0, help="scan only the first N articles")
     ap.add_argument("--workers", type=int, default=0, help="worker processes (default: cores minus two)")
+    ap.add_argument("--every", type=int, default=1, help="scan every Nth article (the full pack)")
     args = ap.parse_args(argv)
     gate_failed = False
     if args.summary:
@@ -1131,7 +1134,7 @@ def main(argv=None):
         if refused:
             gate_failed = True
         print(f"symbols spelled: {summary.get('symbols_translated', 0):,}; diacritics reduced to base letters: {summary.get('diacritics_dropped', 0):,}")
-    report, sample = scan(args.pack, args.sample, args.seed, limit=args.limit, workers=args.workers or None)
+    report, sample = scan(args.pack, args.sample, args.seed, limit=args.limit, workers=args.workers or None, every=args.every)
     # Mario, 2026-09-11: at the end nothing that reads as an artifact may
     # remain, whoever left it. These classes must be empty for the gate.
     artifacts = {name: report["signatures"][name]["articles"] for name in ARTIFACT_DETECTORS if report["signatures"][name]["hits"]}

--- a/tools_local/wikipedia/quality.py
+++ b/tools_local/wikipedia/quality.py
@@ -222,7 +222,7 @@ DETECTORS = [
         "words",
         "comma_glue",
         "para",
-        re.compile(r"[a-z]{3,},[A-Za-z]{3,}"),
+        re.compile(r"(?<!alpha)(?<!beta)(?<!gamma)(?<!delta)(?<!omega)(?<!sigma)(?<!kappa)(?<!theta)(?<!lambda)[a-z]{3,},[A-Za-z]{3,}"),
         "a comma with no space after it",
     ),
     ("words", "double_punct", "para", re.compile(r"[,;:]{2}|[,;] ?[,;]|, \.|; \.|\?\?|!!"), "doubled punctuation"),
@@ -356,7 +356,7 @@ DETECTORS = [
         "stray_markup",
         "text",
         re.compile(
-            r"\{\{(?![a-z0-9 ,]{1,12}\})|(?<!\})\}\}(?![,}])|\[\[|\]\]|<ref\b|&lt;|&gt;|&nbsp;|&amp;|&#\d+;|&[a-z]{2,8};"
+            r"\{\{(?![a-z0-9 ,]{1,12}\})|\[\[|\]\]|<ref\b|&lt;|&gt;|&nbsp;|&amp;|&#\d+;|&[a-z]{2,8};"
         ),
         "wikitext or HTML that should not be in the text",
     ),

--- a/tools_local/wikipedia/quality.py
+++ b/tools_local/wikipedia/quality.py
@@ -664,7 +664,7 @@ def _words(t):
     return len(t.split())
 
 
-_FACE = re.compile(r"(?<![A-Za-z0-9])[:;=]-?[()]")
+_FACE = re.compile(r"(?<![A-Za-z0-9<>=])[:;]-?[()]")
 
 
 def struct_hits(name, bl):

--- a/tools_local/wikipedia/quality.py
+++ b/tools_local/wikipedia/quality.py
@@ -664,7 +664,9 @@ def _words(t):
     return len(t.split())
 
 
-_FACE = re.compile(r"(?<![A-Za-z0-9<>=.'])[:;]-?[()]")
+# a face stands after a space or an opening quote; ":(" glued to a word or a
+# parenthesis ("(A+C):(B+D)", "states):(I)") is punctuation and counts
+_FACE = re.compile(r"(?<![^\s\"\u201c\u2018])[:;]-?[()](?![A-Za-z0-9])")
 
 
 def struct_hits(name, bl):

--- a/tools_local/wikipedia/quality.py
+++ b/tools_local/wikipedia/quality.py
@@ -364,7 +364,7 @@ DETECTORS = [
         "remnants",
         "wikitext_line",
         "para",
-        re.compile(r"^\s*[#:;]{1,3}\s|'''|^={2,}[^=\n]*={2,}\s*$|^={3,}\s|^\s*\|[-}]|^\s*\{\|"),
+        re.compile(r"^\s*[#:;]{1,3}\s|'''|^={2,}[^=\n]*={2,}\s*$|^={3,}\s|^\s*\|-\s*$|^\s*\|\}|^\s*\{\|"),
         "a wikitext list marker, bold marks or table syntax",
     ),
     (
@@ -664,7 +664,7 @@ def _words(t):
     return len(t.split())
 
 
-_FACE = re.compile(r"(?<![A-Za-z0-9<>=])[:;]-?[()]")
+_FACE = re.compile(r"(?<![A-Za-z0-9<>=.'])[:;]-?[()]")
 
 
 def struct_hits(name, bl):

--- a/tools_local/wikipedia/quality.py
+++ b/tools_local/wikipedia/quality.py
@@ -364,7 +364,7 @@ DETECTORS = [
         "remnants",
         "wikitext_line",
         "para",
-        re.compile(r"^\s*[#:;]{1,3}\s|'''|^==|==$|^\s*\|[-}]|^\s*\{\|"),
+        re.compile(r"^\s*[#:;]{1,3}\s|'''|^={2,}[^=\n]*={2,}\s*$|^={3,}\s|^\s*\|[-}]|^\s*\{\|"),
         "a wikitext list marker, bold marks or table syntax",
     ),
     (

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -981,6 +981,32 @@ class Rules(unittest.TestCase):
         self.assertIn("<tr><th>Website</th><td>comune.frascineto.cs.it</td></tr>", x)
         self.assertIn("<tr><th>Coordinates</th><td>41°37′00″N 44°00′00″E</td></tr>", x)
         self.assertNotIn("GCB", x.split("Quick facts")[1])
+        # a third read: a table row of labels with nothing after them goes
+        # ("Source:"), a row repeated goes, a table left with no rows goes; a
+        # footnote digit on a fact's name ("Area 1") goes; " /" gets its
+        # spaces except between two years; a link's caption with no link
+        # ("Listen live") is no fact; an office of nine words is still a group
+        row = {"name": "Bergbieten", "infoboxes": [{"name": "Infobox", "has_parts": [
+            {"type": "section", "name": "Judge of the Washington Court of Appeals, Division One", "has_parts": [{"type": "field", "name": "Preceded by", "value": "Ronald Cox"}]},
+            {"type": "field", "name": "Area 1", "value": "5.2 km2"}, {"type": "field", "name": "INSEE /Postal code", "value": "67030 /67310"},
+            {"type": "field", "name": "Webcast", "value": "Listen live"}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]},
+                {"type": "section", "name": "Population", "has_parts": [{"type": "table", "table_references": [{"identifier": "t1"}, {"identifier": "t2"}]}]}],
+            "tables": json.dumps([
+                {"identifier": "t1", "headers": [[{"value": "Year"}, {"value": "Pop."}]],
+                 "rows": [[{"value": "1968"}, {"value": "394"}], [{"value": "Source: INSEE"}, {"value": "Source: INSEE"}],
+                          [{"value": "Source: INSEE"}, {"value": "Source: INSEE"}], [{"value": "Source:"}, {"value": ""}]]},
+                {"identifier": "t2", "headers": [[{"value": "Election"}, {"value": "Election"}]], "rows": [[{"value": "Source:"}, {"value": ""}]]}])}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<tr><th>Judge of the Washington Court of Appeals, Division One, preceded by</th><td>Ronald Cox</td></tr>", x)
+        self.assertIn("<tr><th>Area</th><td>5.2 km2</td></tr>", x)
+        self.assertIn("<tr><th>INSEE / Postal code</th><td>67030 / 67310</td></tr>", x)
+        self.assertNotIn("Listen live", x)
+        self.assertEqual(x.count("Source: INSEE"), 1)
+        self.assertNotIn("<td>Source:</td>", x)
+        self.assertNotIn("Election", x)
+        self.assertEqual(ah.fact_value("Born", "26 May 1564 /1563, Sirhind"), "26 May 1564/1563, Sirhind")
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("set (P, ≤) forms and x =(y+1) and a face :) here"), {}), "set (P, <=) forms and x =(y+1) and a face :) here")
 
     def test_round_eleven_the_last_classes(self):
         # What round ten's measurement still flagged, each traced to the dump

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -649,7 +649,7 @@ class Rules(unittest.TestCase):
             lead=True,
         )
         # the Arabic goes with its label; the romanisation is information
-        self.assertEqual(got, "Mahmud II (Ottoman Turkish: X; 20 July 1785 - 1 July 1839) was the sultan")
+        self.assertEqual(got, "Mahmud II (Ottoman Turkish, romanized: X; 20 July 1785 - 1 July 1839) was the sultan")
         self.assertEqual(st["parentheticals_removed"], 1)
 
     def test_source_remnants(self):
@@ -721,7 +721,7 @@ class Rules(unittest.TestCase):
             # goes whole before any spelling, so its theta is not "theta" and
             # its schwa is not a letter; a respelling's "-\u0259-" is not a word.
             ("C\u0259lil M\u0259mm\u0259dquluzad\u0259 wrote; laamii\u0257o; Bum\u00efn qa\u0263an; \u01c3Nanseb", "Celil Memmedquluzade wrote; laamiido; Bum\u00efn qa\u011fan; !Nanseb"),
-            ("Theophrastus (/ \u02cc \u03b8 i\u02d0. \u0259 /; Ancient Greek: \u0398\u03b5\u03cc\u03c6\u03c1\u03b1\u03c3\u03c4\u03bf\u03c2, romanized: Theophrastos) was", "Theophrastus (Ancient Greek: Theophrastos) was"),
+            ("Theophrastus (/ \u02cc \u03b8 i\u02d0. \u0259 /; Ancient Greek: \u0398\u03b5\u03cc\u03c6\u03c1\u03b1\u03c3\u03c4\u03bf\u03c2, romanized: Theophrastos) was", "Theophrastus (Ancient Greek, romanized: Theophrastos) was"),
             ("Camogie (/ k \u0259 \u02c8 m o\u028a \u0261 i / k\u0259- MOH -ghee; Irish: cam\u00f3ga\u00edocht) is", "Camogie (Irish: cam\u00f3ga\u00edocht) is"),
             # Mario, 2026-09-11: Greek is defensible, Cyrillic is not, and no
             # removal may butcher the sentence. A Greek or Cyrillic word with
@@ -730,7 +730,7 @@ class Rules(unittest.TestCase):
             # and all; two accentuations of one word are one spelling.
             ("comes from the Greek word \u1f55\u03b2\u03bf\u03c2 or \u1f51\u03b2\u03cc\u03c2 meaning hump and \u1f40\u03b4\u03bf\u03cd\u03c2, meaning tooth.", "comes from the Greek word hybos meaning hump and odous, meaning tooth."),
             ("(from Greek \u1f08\u03c1\u03b9\u03b8\u03bc\u03bf\u03af, Arithmoi, lit. 'numbers'; Biblical Hebrew: \u05d1\u05b0\u05bc\u05de\u05b4\u05d3\u05b0\u05d1\u05b7\u05bc\u05e8, B\u0259m\u012b\u1e0fbar, lit. 'In desert'; Latin: Liber Numeri) is", "(from Greek Arithmoi, lit. 'numbers'; Biblical Hebrew: Bem\u012bdbar, lit. 'In desert'; Latin: Liber Numeri) is"),
-            ("Seventeen Moments (Russian: \u0421\u0435\u043c\u043d\u0430\u0434\u0446\u0430\u0442\u044c, romanized: Semnadtsat') is a series about \u041c\u043e\u0441\u043a\u0432\u0430 and (\u0422\u043e\u043b\u0441\u0442\u043e\u0439).", "Seventeen Moments (Russian: Semnadtsat') is a series about Moskva and (Tolstoy)."),
+            ("Seventeen Moments (Russian: \u0421\u0435\u043c\u043d\u0430\u0434\u0446\u0430\u0442\u044c, romanized: Semnadtsat') is a series about \u041c\u043e\u0441\u043a\u0432\u0430 and (\u0422\u043e\u043b\u0441\u0442\u043e\u0439).", "Seventeen Moments (Russian, romanized: Semnadtsat') is a series about Moskva and (Tolstoy)."),
             # the romanisation is the English word itself: the aside says nothing
             ("The pentathlon (Greek: \u03c0\u03ad\u03bd\u03c4\u03b1\u03b8\u03bb\u03bf\u03bd) was", "The pentathlon was"),
             ("The contest (Greek: \u03c0\u03ad\u03bd\u03c4\u03b1\u03b8\u03bb\u03bf\u03bd) was", "The contest (Greek: pentathlon) was"),
@@ -847,7 +847,7 @@ class Rules(unittest.TestCase):
             ("Karma (/ \u02c8 k \u0251\u02d0r m \u0259 /, from Sanskrit: \u0915\u0930\u094d\u092e, IPA:; Pali: kamma) is an ancient", "Karma (Pali: kamma) is an ancient"),
             ("A raga (/ \u02c8 r \u0251\u02d0 \u0261 \u0259 / RAH-g\u0259; IAST: r\u0101ga, Sanskrit:; lit. ' colouring', 'tingeing ' or ' dyeing ') is", "A raga (IAST: r\u0101ga; lit. 'colouring', 'tingeing' or 'dyeing') is"),
             ("won in Athens ' City Dionysia festival in 472 BC. It is Aeschylus' oldest play, the \" best \" one.", "won in Athens' City Dionysia festival in 472 BC. It is Aeschylus' oldest play, the \"best\" one."),
-            ("The Persians (Ancient Greek: \u03a0\u03ad\u03c1\u03c3\u03b1\u03b9, romanized: P\u00e9rsai, Latinised as Persae) is", "The Persians (Ancient Greek: P\u00e9rsai, Latinised as Persae) is"),
+            ("The Persians (Ancient Greek: \u03a0\u03ad\u03c1\u03c3\u03b1\u03b9, romanized: P\u00e9rsai, Latinised as Persae) is", "The Persians (Ancient Greek, romanized: P\u00e9rsai, Latinised as Persae) is"),
             ("A samosa (listen) is a fried pastry with epsilon : Permittivity", "A samosa is a fried pastry with epsilon: Permittivity"),
         ]
         for src, want in cases:
@@ -898,6 +898,42 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Nepali", "(muntala)"), "muntala")
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
+
+    def test_round_thirteen_fourth_read(self):
+        # A fourth cold read of the full pack: a romanised aside keeps the
+        # word "romanized" so the Latin string is not taken for the native
+        # spelling; the title's own words reordered in a lead aside go with
+        # the script; the start-date template's month copy; a label before
+        # "lit."; the infobox header with a middle initial is not a group; a
+        # row whose value is the title says nothing; "H:20" gets its space;
+        # coordinates set off from an address, one notation; dead captions
+        # and "Report" cells; links that start with a digit are a list.
+        cases = [
+            ("Seventeen Moments (Russian: Семнадцать, romanized: Semnadtsat') is a series", "Seventeen Moments (Russian, romanized: Semnadtsat') is a series"),
+            ("Aryavarta (Sanskrit: आर्यावर्त, lit. 'Land of the Aryans') is", "Aryavarta (lit. 'Land of the Aryans') is"),
+            ("released March 1922 (1922-03) in", "released March 1922 in"),
+        ]
+        for src, want in cases:
+            self.assertEqual(ah.strip_undrawable(ah.clean_text(src), {}, lead=True), want, src)
+        self.assertEqual(ah.fact_value("Dimensions", "H:20 cm × L:19 cm"), "H: 20 cm × L: 19 cm")
+        self.assertEqual(ah.fact_value("Location", "Jamshoro, Sindh, 76062, Pakistan 25°24′29″N 68°15′37″E / 25.4081°N 68.2603°E"), "Jamshoro, Sindh, 76062, Pakistan; 25°24′29″N 68°15′37″E")
+        self.assertEqual(ah._split_at_links("Joint Artificial Intelligence Center 3rd Radio Battalion", [{"text": "Joint Artificial Intelligence Center"}, {"text": "3rd Radio Battalion"}], "Commands"), "Joint Artificial Intelligence Center; 3rd Radio Battalion")
+        row = {"name": "Masaru Kitao", "infoboxes": [{"name": "Infobox", "has_parts": [
+            {"type": "section", "name": "Masaru S. Kitao", "has_parts": [{"type": "field", "name": "Rank", "value": "General"}]},
+            {"type": "field", "value": "Japanese: Masaru Kitao"},
+            {"type": "field", "name": "Webcast", "value": "Listen live (Southern gospel), Listen live (Oldies)"}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [
+                {"type": "paragraph", "value": "Masaru Kitao (Japanese: 北尾 勝, Kitao Masaru, born July 15, 1961) is a Japanese animator."}]},
+                {"type": "section", "name": "Matches", "has_parts": [{"type": "table", "table_references": [{"identifier": "t1"}]}]}],
+            "tables": json.dumps([{"identifier": "t1", "headers": [[{"value": "Home"}, {"value": "Score"}, {"value": "Away"}]],
+                "rows": [[{"value": "Linfield"}, {"value": "1-1"}, {"value": "Distillery"}], [{"value": "Report"}, {"value": ""}, {"value": ""}]]}])}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<p><b>Masaru Kitao</b> (born July 15, 1961) is a Japanese animator.</p>", x)
+        self.assertIn("<tr><th>Rank</th><td>General</td></tr>", x)
+        self.assertNotIn("Japanese", x.split("Quick facts")[1])
+        self.assertNotIn("Listen live", x)
+        self.assertNotIn("Report", x)
+        self.assertIn("<tr><td>Linfield</td><td>1-1</td><td>Distillery</td></tr>", x)
 
     def test_round_twelve_from_the_full_pack_sample(self):
         # A cold read of thirty articles from the full pack (stubs with
@@ -1121,7 +1157,7 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Born", "3 May 1959 (aged 45) Chicago"), "3 May 1959, Chicago")
         self.assertEqual(
             ah.strip_undrawable("A madhhab (Arabic: \u0645\u0630\u0647\u0628, romanized: madhhab, lit. 'way to act', pl. \u0645\u0630\u0627\u0647\u0628, madh\u0101hib) refers", {}, lead=True),
-            "A madhhab (Arabic: madhhab, lit. 'way to act', pl. madh\u0101hib) refers",
+            "A madhhab (Arabic, romanized: madhhab, lit. 'way to act', pl. madh\u0101hib) refers",
         )
 
     def test_round_seven_remnants(self):

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -899,6 +899,20 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
 
+    def test_round_seventeen_eighth_read(self):
+        # An eighth cold read: a "Title card" caption is no fact; a bare
+        # "Names" group does not prefix the rows under it ("Names, House"),
+        # while "Chinese name" still does.
+        row = {"name": "Princess Januária", "infoboxes": [{"name": "Infobox", "has_parts": [
+            {"type": "field", "name": "Title card", "value": "The island's skyline stands beyond the forest."},
+            {"type": "section", "name": "Names", "has_parts": [{"type": "field", "name": "House", "value": "Braganza"}, {"type": "field", "name": "Father", "value": "Pedro I of Brazil"}]},
+            {"type": "section", "name": "Chinese name", "has_parts": [{"type": "field", "name": "Hanyu Pinyin", "value": "Quanlian Fuli Zhongxin"}]}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertNotIn("Title card", x)
+        self.assertIn("<tr><th>House</th><td>Braganza</td></tr><tr><th>Father</th><td>Pedro I of Brazil</td></tr>", x)
+        self.assertIn("<tr><th>Chinese name, Hanyu Pinyin</th><td>Quanlian Fuli Zhongxin</td></tr>", x)
+
     def test_round_sixteen_seventh_read(self):
         # A seventh cold read: rp page references after a parenthesis, with
         # "fn. 2", or after a bare word go; a combining author keeps its

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -899,6 +899,32 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
 
+    def test_round_fourteen_fifth_read(self):
+        # A fifth cold read: "6 ft 3 1/2 in" is not six cubic feet; a taxon
+        # row keeps its authority; an address joins its links with commas; a
+        # compass point after a parenthesis is not an item; a row number
+        # "1." and a machine date in a cell; "Density" under the dump's
+        # "Government" section belongs to the population row before it.
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("1.92 m (6 ft 3 1/2 in) tall"), {}), "1.92 m (6 ft 3 1/2 in) tall")
+        self.assertEqual(ah._split_at_links("Helonias L.", [{"text": "Helonias"}, {"text": "L."}], "Genus"), "Helonias L.")
+        self.assertEqual(
+            ah._split_at_links("2, Bank Plot, Dhakuria Kali Bari Lane Kolkata, West Bengal India", [{"text": "Kolkata"}, {"text": "West Bengal"}, {"text": "India"}], ""),
+            "2, Bank Plot, Dhakuria Kali Bari Lane Kolkata, West Bengal, India",
+        )
+        self.assertEqual(ah.fact_value("Location", "190 km (118 mi) W of Sydney; 33 km (21 mi) SSE of Bathurst"), "190 km (118 mi) W of Sydney; 33 km (21 mi) SSE of Bathurst")
+        self.assertEqual(ah.fact_value("Date", "2014-10-15"), "15 October 2014")
+        row = {"name": "Aincourt", "infoboxes": [{"name": "Infobox", "has_parts": [{"type": "section", "name": "Government", "has_parts": [
+            {"type": "field", "name": "Mayor", "value": "Emmanuel Couesnon"}, {"type": "field", "name": "Area 1", "value": "10.03 km 2 (3.87 sq mi)"},
+            {"type": "field", "name": "Population (2023)", "value": "854"}, {"type": "field", "name": "Density", "value": "85.1/km 2 (221/sq mi)"}]}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]},
+                {"type": "section", "name": "Goals", "has_parts": [{"type": "table", "table_references": [{"identifier": "t1"}]}]}],
+            "tables": json.dumps([{"identifier": "t1", "headers": [[{"value": "No."}, {"value": "Date"}, {"value": "Venue"}, {"value": "Opponent"}, {"value": "Score"}, {"value": "Result"}, {"value": "Competition"}, {"value": "Ref"}]],
+                "rows": [[{"value": "1."}, {"value": "2014-10-15"}, {"value": "Luanda"}, {"value": "Lesotho"}, {"value": "2–0"}, {"value": "4–0"}, {"value": "Friendly"}, {"value": ""}]]}])}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<tr><th>Population (2023), density</th><td>85.1/km² (221/sq mi)</td></tr>", x)
+        self.assertNotIn("Government, density", x)
+        self.assertIn("<p><b>1</b>; Date: 15 October 2014; Venue: Luanda; Opponent: Lesotho; Score: 2–0; Result: 4–0; Competition: Friendly</p>", x)
+
     def test_round_thirteen_fourth_read(self):
         # A fourth cold read of the full pack: a romanised aside keeps the
         # word "romanized" so the Latin string is not taken for the native

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -926,6 +926,21 @@ class Rules(unittest.TestCase):
         self.assertIn("<tr><th>Career statistics</th><td>Matches 14 39; Runs scored 46 462</td></tr>", x)
         self.assertIn("<tr><th>Population (2006)</th><td>1,234</td></tr><tr><th>Population (2006), density</th><td>3/km2</td></tr>", x)
         self.assertNotIn("Playing statistics", x)
+        # from the ess-q15 gate: a full-width comma before a capital, a comma
+        # after a parenthesis, and a comma a removed run left glued get their
+        # space; "French pronunciation:" whose IPA went with its slashes is
+        # empty; heading marks the dump left on a line go; a quote pair left
+        # around a dropped bracket goes
+        more = [
+            ("massacre\uff0cAnti-bourgeois liberalization", "massacre, Anti-bourgeois liberalization"),
+            ("carbonic acid, (H2CO3),characterized by", "carbonic acid, (H2CO3), characterized by"),
+            ("Cl\u00e9mentine (pronounced French pronunciation: /klem\u0251\u0303tin/) is a 1985", "Cl\u00e9mentine is a 1985"),
+            ("The Choctaw (Choctaw: Chahta Choctaw pronunciation: [t\u0283ahta]) people", "The Choctaw (Choctaw: Chahta) people"),
+            ("=== Neural engineering is a discipline", "Neural engineering is a discipline"),
+            ("another clause (as in \" ] \"). Human language", "another clause (as in). Human language"),
+        ]
+        for src, want in more:
+            self.assertEqual(ah.strip_undrawable(ah.clean_text(src), {}, lead=True), want, src)
 
     def test_round_fourteen_fifth_read(self):
         # A fifth cold read: "6 ft 3 1/2 in" is not six cubic feet; a taxon

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -899,6 +899,83 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
 
+    def test_round_eleven_the_last_classes(self):
+        # What round ten's measurement still flagged, each traced to the dump
+        # or to a rule: Parsoid's protection markers; an unclosed ref tag; a
+        # footnote template and an unclosed opener; a quoted script run and a
+        # run with commas inside it go whole, not as (") and (,); a block
+        # that starts with a colon; rp page references; a formula whose
+        # middle the dump lost; the dump's words beside the TeX of them; the
+        # residue of an align block; two quoted lines joined.
+        cases = [
+            ("1,432,820 \ufffdPROT139\ufffd 1910-2020\ufffdPROT140\ufffd 2024 \ufffdPROT141\ufffd", "1,432,820 1910-2020 2024"),
+            ("Religion: {{Pie chart| thumb = right| caption = Religion (2014)\ufffdPROT199\ufffd Roughly one-quarter identify as unaffiliated.", "Religion: Roughly one-quarter identify as unaffiliated."),
+            ("the interstellar medium. <ref name=\"abundance of chemical elements3", "the interstellar medium."),
+            ("in exceptional circumstances.{{efn|For example, travel was restricted in 2020.}} Federations, and{{block indent| sigma: F -> F are natural", "in exceptional circumstances. Federations, and sigma: F -> F are natural"),
+            ("The Hebrew Bible is also known by the name Tanakh (Hebrew: \u05ea\u05e0\"\u05da). This reflects", "The Hebrew Bible is also known by the name Tanakh. This reflects"),
+            ("the foundation of \"this mosque\" (Arabic: \"\u0647\u0630\u0627 \u0627\u0644\u0645\u0633\u062c\u062f\") by Dawud", "the foundation of \"this mosque\" by Dawud"),
+            ("Two Systems (Chinese: \u201c\u4e00\u56fd\u4e24\u5236\u201d\u6770\u51fa\u8d21\u732e\u8005) national honorary title", "Two Systems national honorary title"),
+            ("were for solo vocal ('\u0938\u094d\u0935\u0930\u094d\u0917\u0915\u0940 \u0930\u093e\u0928\u0940', '\u092d\u094b \u092d\u094b') and two were for duet", "were for solo vocal and two were for duet"),
+            ("you can not create a new career. (\u6539\u9769\u5f00\u653e\u80c6\u5b50\uff0c\u6562\u4e8e\u8bd5\u9a8c)", "you can not create a new career."),
+            (": An offering table with a secondary dedication", "An offering table with a secondary dedication"),
+            ("\u0543\u0561\u0576\u0561\u0579\u0565\u056c \u0566\u056b\u0574\u0561\u057d\u057f\u0578\u0582\u0569\u056b\u0582\u0576: \u010cana\u010d\u02bfel zimastut\u02bfiun yev zxrat. To know wisdom", "\u010cana\u010d\u2018el zimastut\u2018iun yev zxrat. To know wisdom"),
+            ("secured their submission.: ii. 161 : I.68 However, this", "secured their submission. However, this"),
+            ("sigma = sigma_ij = = \u2261 \u2261,", "sigma = sigma_ij"),
+            ("many possible values for z w z^{w}. So", "many possible values for z^w. So"),
+            ("in her.'\"\"'Did you see", "in her.'\" \"'Did you see"),
+        ]
+        for src, want in cases:
+            self.assertEqual(ah.strip_undrawable(ah.clean_text(src), {}, lead=True), want, src)
+        # from the round-eleven essentials gate: an emoticon in quotes keeps
+        # its face; a quoted phrase ending in a colon is not a label; the
+        # dump's wikitext quotes go, a second derivative stays; a "{{" with
+        # nothing after it goes, set-builder braces stay; a comma between
+        # spelled words gets its space (a chemical name stays tight); the
+        # full-width comma the dump uses folds to a comma with its space; rp
+        # page numbers after a period go; "(number 8)" is not a face
+        more = [
+            ("including 14 instances of \":) \" in Richard", "including 14 instances of \":)\" in Richard"),
+            ("the Ahl ad-dār (\"House of the Mahdi:), composed of", "the Ahl ad-dār (\"House of the Mahdi:), composed of"),
+            ("cultivars are ''Prunus serrulata'''Grandiflora' A. Wagner and ''Prunus serrulata'''Gioiko' Koidz", "cultivars are Prunus serrulata 'Grandiflora' A. Wagner and Prunus serrulata 'Gioiko' Koidz"),
+            ("Notable out-fighters include '''Sydney Greve''', Muhammad Ali", "Notable out-fighters include Sydney Greve, Muhammad Ali"),
+            ("the derivative f''(x) and f'''(x) of f", "the derivative f''(x) and f'''(x) of f"),
+            ("reduced to one-third of what it was at independence.{{", "reduced to one-third of what it was at independence."),
+            ("the filter {{k:k >= N}:N in D} is a filter", "the filter {{k:k >= N}:N in D} is a filter"),
+            ("the spatial domain is (−∞,∞). In others", "the spatial domain is (−infinity, infinity). In others"),
+            ("7',8'-Dihydro-ε,γ-carotene and the Zheng clan，personal name", "7',8'-Dihydro-epsilon,gamma-carotene and the Zheng clan, personal name"),
+            ("hybrids based on Prunus speciosa.: 86–95, 137 and others", "hybrids based on Prunus speciosa. and others"),
+            ("H (number 8) means add 8 hours", "H (number 8) means add 8 hours"),
+        ]
+        for src, want in more:
+            self.assertEqual(ah.strip_undrawable(ah.clean_text(src), {}, lead=True), want, src)
+        # a link whose text is only a space is no link, and the space stands once
+        row = {"name": "T", "sections": [{"type": "section", "name": "Abstract", "has_parts": [
+            {"type": "paragraph", "value": "The modern alphabet used by Bashkir.", "links": [{"url": "https://en.wikipedia.org/wiki/Space", "text": " "}]}]}]}
+        self.assertIn("<p>The modern alphabet used by Bashkir.</p>", ah.article_xhtml(row, {})[2].decode())
+        residue = ah.clean_text("= E.1 { }&= }{ }} _{=\\,1{ }G}1 { }{ } . }}")
+        for mark in ("{", "}", "&", "_{", "\\"):
+            self.assertNotIn(mark, residue, residue)
+        # a link's text keeps its label ("Vizing's Theorem:" is not an empty
+        # label because its own closing tag follows), and the space a lost
+        # icon left in a link's text stands outside the anchor
+        row = {"name": "T", "sections": [{"type": "section", "name": "Abstract", "has_parts": [
+            {"type": "paragraph", "value": "Vizing's Theorem: A graph of maximal degree has edge-chromatic number.", "links": [{"url": "https://en.wikipedia.org/wiki/Vizing's_theorem", "text": "Vizing's Theorem:"}]},
+            {"type": "paragraph", "value": "China  Merrill's Marauders and OSS Detachment 101.", "links": [{"url": "https://en.wikipedia.org/wiki/China_Burma_India_Theater", "text": "China "}, {"url": "https://en.wikipedia.org/wiki/Merrill's_Marauders", "text": "Merrill's Marauders"}]},
+        ]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<a href=\"Vizing's theorem\">Vizing's Theorem:</a> A graph", x)
+        self.assertIn("<a href=\"China Burma India Theater\">China</a> <a href=\"Merrill's Marauders\">Merrill's Marauders</a>", x)
+        # a table header whose cells all say the same thing is a caption, not
+        # column names, and "#" is a number (in a table, and in the row
+        # paragraphs a wide table becomes)
+        tables = [{"identifier": "t1", "headers": [[{"value": "Key (expand for notes)"}, {"value": "Key (expand for notes)"}]],
+                   "rows": [[{"value": "Location"}, {"value": "Where the match was played"}], [{"value": "#"}, {"value": "Goal of total goals"}]]}]
+        secs = [{"type": "section", "name": "Goals", "has_parts": [{"type": "table", "table_references": [{"identifier": "t1"}]}]}]
+        _, _, x, st = self.lead({"type": "paragraph", "value": "Test."}, sections=secs, tables=json.dumps(tables))
+        self.assertIn("<tr><td>Location</td><td>Where the match was played</td></tr>", x)
+        self.assertIn("<tr><td>Number</td><td>Goal of total goals</td></tr>", x)
+        self.assertNotIn("Key (expand", x)
+
     def test_round_nine_residue(self):
         # TeX the dump left outside any block, in any shape, goes and the
         # prose around it stays; citation page ranges in a row go; a note

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -913,6 +913,21 @@ class Rules(unittest.TestCase):
             "The tuba (Latin, \"trumpet\") is a large",
         )
 
+    def test_round_twenty_one_twelfth_read(self):
+        # A twelfth cold read: a decimal copy of a DMS pair goes wherever it
+        # stands; a malformed hidden date "(2015-03-2)" goes; "left",
+        # "average" and the like carry their group; a unit fraction closes.
+        self.assertEqual(ah.clean_text("rises at 40°02′59″N 93°48′26″W / 40.04972°N 93.80722°W and flows"), "rises at 40°02′59″N 93°48′26″W and flows")
+        self.assertEqual(ah.clean_text("Released March 2, 2015 (2015-03-2) by"), "Released March 2, 2015 by")
+        self.assertEqual(ah.fact_value("Average", "13 m 3 / s (460 cu ft/s)"), "13 m³/s (460 cu ft/s)")
+        self.assertEqual(ah.fact_value("Ratio", "4 / 5"), "4 / 5")
+        row = {"name": "Wimmera River", "infoboxes": [{"name": "Infobox", "has_parts": [
+            {"type": "section", "name": "Tributaries", "has_parts": [{"type": "field", "name": "left", "value": "Mount Cole Creek; Six Mile Creek"}]},
+            {"type": "section", "name": "Discharge", "has_parts": [{"type": "field", "name": "average", "value": "13 m 3 / s (460 cu ft/s)"}]}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<tr><th>Tributaries, left</th><td>Mount Cole Creek; Six Mile Creek</td></tr><tr><th>Discharge, average</th><td>13 m³/s (460 cu ft/s)</td></tr>", x)
+
     def test_round_twenty_eleventh_read(self):
         # An eleventh cold read: a standings table the dump puts before the
         # lead sentence follows it; stacked header rows combine ("Conference

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -913,6 +913,18 @@ class Rules(unittest.TestCase):
             "The tuba (Latin, \"trumpet\") is a large",
         )
 
+    def test_round_twenty_eleventh_read(self):
+        # An eleventh cold read: a standings table the dump puts before the
+        # lead sentence follows it; stacked header rows combine ("Conference
+        # W", "Overall W") so two W columns can be told apart; a cut never
+        # doubles a period.
+        self.assertEqual(ah.cut_words("a b c Auctt. d e", 4), "a b c Auctt...")
+        tables = [{"identifier": "t1", "headers": [[{"value": "Team"}, {"value": "Conference"}, {"value": "Conference"}, {"value": "Overall"}, {"value": "Overall"}], [{"value": "Team"}, {"value": "W"}, {"value": "L"}, {"value": "W"}, {"value": "L"}]],
+                   "rows": [[{"value": "Nebraska"}, {"value": "4"}, {"value": "0"}, {"value": "8"}, {"value": "0"}]]}]
+        row = {"name": "1915 Iowa State", "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "table", "table_references": [{"identifier": "t1"}]}, {"type": "paragraph", "value": "The 1915 Iowa State Cyclones football team represented Iowa State."}]}], "tables": json.dumps(tables)}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<p>The <b>1915 Iowa State</b> Cyclones football team represented Iowa State.</p><p><b>Nebraska</b>; Conference W: 4; Conference L: 0; Overall W: 8; Overall L: 0</p>", x)
+
     def test_round_nineteen_tenth_read(self):
         # A tenth cold read: a Unicode hyphen is a hyphen; a table's header
         # row that arrived as a field ("Years: Team") is no fact; a footnote
@@ -1134,7 +1146,7 @@ class Rules(unittest.TestCase):
                             [{"value": "Felipo"}, {"value": "100 m"}, {"value": "did not advance"}, {"value": "did not advance"}]]}]
         secs = [{"type": "section", "name": "Athletics", "has_parts": [{"type": "table", "table_references": [{"identifier": "t1"}]}]}]
         _, _, x, st = self.lead({"type": "paragraph", "value": "Test."}, sections=secs, tables=json.dumps(tables))
-        self.assertIn("<tr><th>Athlete</th><th>Event</th><th>Result</th><th>Rank</th></tr>", x)
+        self.assertIn("<tr><th>Athlete</th><th>Event</th><th>Final Result</th><th>Final Rank</th></tr>", x)  # the group row prefixes the names
         self.assertNotIn("<th>Final</th>", x)
         wide = [{"identifier": "t2",
                  "headers": [[{"value": "Athlete"}, {"value": "Event"}, {"value": "Heat"}, {"value": "Rank"}, {"value": "Semi"}, {"value": "Rank"}, {"value": "Final"}, {"value": "Rank"}]],

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -913,6 +913,20 @@ class Rules(unittest.TestCase):
             "The tuba (Latin, \"trumpet\") is a large",
         )
 
+    def test_round_twenty_two_thirteenth_read(self):
+        # A thirteenth cold read: an album infobox's subtitle ("Studio album
+        # by Dragon") is not a group, so "length" stands alone and its time
+        # closes; a language label whose script folded to a digit goes.
+        row = {"name": "Body and the Beat", "infoboxes": [{"name": "Infobox album", "has_parts": [{"type": "section", "name": "Studio album by Dragon", "has_parts": [
+            {"type": "field", "name": "Released", "value": "1984"}, {"type": "field", "name": "Length", "value": "38: 02"}]}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<tr><th>Released</th><td>1984</td></tr><tr><th>Length</th><td>38:02</td></tr>", x)
+        self.assertEqual(
+            ah.strip_undrawable(ah.clean_text("Aliabad-e Yek (Persian: \u0639\u0644\u06cc \u0622\u0628\u0627\u062f \u06f1, also Romanized as Aliabad-e Yek; also known as Aliabad) is a village"), {}, lead=True),
+            "Aliabad-e Yek (also Romanized as Aliabad-e Yek; also known as Aliabad) is a village",
+        )
+
     def test_round_twenty_one_twelfth_read(self):
         # A twelfth cold read: a decimal copy of a DMS pair goes wherever it
         # stands; a malformed hidden date "(2015-03-2)" goes; "left",

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -877,6 +877,38 @@ class Rules(unittest.TestCase):
         self.assertNotIn("Arabic", x)
         self.assertNotIn("  ", x)
 
+    def test_round_eight_seams(self):
+        # From the fourth cold read: a comma inserted after a botanical
+        # authority's parenthesis, and a comma left after "pl." when the
+        # Arabic plural went.
+        self.assertEqual(ah.fact_value("Species", "Phytelephas tenuicaulis (Barfod) A.J.Hend."), "Phytelephas tenuicaulis (Barfod) A.J.Hend.")
+        self.assertEqual(ah.fact_value("Born", "3 May 1959 (aged 45) Chicago"), "3 May 1959, Chicago")
+        self.assertEqual(
+            ah.strip_undrawable("A madhhab (Arabic: \u0645\u0630\u0647\u0628, romanized: madhhab, lit. 'way to act', pl. \u0645\u0630\u0627\u0647\u0628, madh\u0101hib) refers", {}, lead=True),
+            "A madhhab (Arabic: madhhab, lit. 'way to act', pl. madh\u0101hib) refers",
+        )
+
+    def test_round_seven_remnants(self):
+        # a colon padded at the end of a phrase closes, a ratio keeps its
+        # spaces even when the paragraph had gaps to close; "({})" is nothing
+        # after two passes; an environment the dump left outside a block
+        # goes whole; a citation template's error goes.
+        cases = [
+            ("The responsibilities include : water. The Mayor : is here, a ratio of 3 : 1 and m/z : 291.0 (Greek: \u03b1\u03bb\u03c6\u03b1)",
+             "The responsibilities include: water. The Mayor: is here, a ratio of 3 : 1 and m/z: 291.0 (Greek: alpha)"),
+            ("curly brackets ({}) and (,) here", "curly brackets and here"),
+            ("B 1 B 2 B n {\\begin{array}{cccc}&&\\dots &\\\\&&\\dots &\\end{array}}\\right. Let us consider", "B 1 B 2 B n Let us consider"),
+            (": ISBN / Date incompatibility (help) Next", "Next"),
+        ]
+        for src, want in cases:
+            self.assertEqual(ah.strip_undrawable(ah.clean_text(src), {}, lead=True), want, src)
+        # a listed table row: a cell that is only a label goes, spaces settle
+        tables = [{"identifier": "t1", "headers": [[{"value": "Letter"}, {"value": "Cyrillic"}, {"value": "Phonemic Value (IPA)"}, {"value": "2021"}, {"value": "2018"}]],
+                   "rows": [[{"value": "A"}, {"value": "\u0430"}, {"value": "\u2205"}, {"value": "x"}, {"value": "y"}]]}]
+        secs = [{"type": "section", "name": "Letters", "has_parts": [{"type": "table", "table_references": [{"identifier": "t1"}]}]}]
+        _, _, x, _ = self.lead({"type": "paragraph", "value": "Test."}, sections=secs, tables=json.dumps(tables))
+        self.assertIn("<p><b>A</b>; Cyrillic: a; Phonemic Value (IPA): empty set; 2021: x; 2018: y</p>", x)
+
     def test_infobox_images_names_and_glued_lists(self):
         boxes = [{"type": "infobox", "name": "Infobox settlement", "has_parts": [
             {"type": "section", "name": "City", "has_parts": [

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -899,6 +899,34 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
 
+    def test_round_fifteen_sixth_read(self):
+        # A sixth cold read: the s of a cricket "50s" is not a second; a label
+        # before "also Romanized as" is empty; "Population (2006), total" is
+        # "Population (2006)"; consecutive facts with one name are one row; a
+        # footnote digit on a group and a footnote as a nameless value go; a
+        # bare year after a birth name gets its comma, a month does not; a
+        # loan arrow at the front of a cell reads "to"; "2002.They" is glued.
+        self.assertEqual(ah.fact_value("Stat", "100s/50s 0/0 0/2"), "100s/50s 0/0 0/2")
+        self.assertEqual(ah.fact_value("Molar mass", "750.658 g·mol −1 and 3 m 2"), "750.658 g·mol⁻¹ and 3 m²")
+        self.assertEqual(
+            ah.strip_undrawable(ah.clean_text("Hareh Shun Dasht (Persian: هره شون دشت, also Romanized as Hareh Shūn Dasht; also known as X) is"), {}, lead=True),
+            "Hareh Shun Dasht (also Romanized as Hareh Shūn Dasht; also known as X) is",
+        )
+        self.assertEqual(ah.fact_value("Born", "Harry Louis Kirkpatrick III 1951, Beckley"), "Harry Louis Kirkpatrick III, 1951, Beckley")
+        self.assertEqual(ah.fact_value("Born", "13 June 1645, Higo Province"), "13 June 1645, Higo Province")
+        self.assertEqual(ah.fact_value("Team", "-> Kent (on loan)"), "to Kent (on loan)")
+        self.assertEqual(ah.clean_text("were released on January 3, 2002.They reported that"), "were released on January 3, 2002. They reported that")
+        row = {"name": "Mia Rogers", "infoboxes": [{"name": "Infobox", "has_parts": [
+            {"type": "section", "name": "Playing career 1", "has_parts": [{"type": "field", "name": "Years", "value": "2017–present"}]},
+            {"type": "section", "name": "Career statistics", "has_parts": [{"type": "field", "value": "Matches 14 39"}, {"type": "field", "value": "Runs scored 46 462"}, {"type": "field", "value": "1 Playing statistics correct to the end of 2023."}]},
+            {"type": "section", "name": "Population (2006)", "has_parts": [{"type": "field", "name": "Total", "value": "1,234"}, {"type": "field", "name": "Density", "value": "3/km2"}]}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<tr><th>Years</th><td>2017–present</td></tr>", x)
+        self.assertIn("<tr><th>Career statistics</th><td>Matches 14 39; Runs scored 46 462</td></tr>", x)
+        self.assertIn("<tr><th>Population (2006)</th><td>1,234</td></tr><tr><th>Population (2006), density</th><td>3/km2</td></tr>", x)
+        self.assertNotIn("Playing statistics", x)
+
     def test_round_fourteen_fifth_read(self):
         # A fifth cold read: "6 ft 3 1/2 in" is not six cubic feet; a taxon
         # row keeps its authority; an address joins its links with commas; a
@@ -1300,7 +1328,7 @@ class Rules(unittest.TestCase):
         )
         self.assertEqual(
             ah.fact_value("Born", "Mala Helfgott 1930 (age 95 \u2013 96) Piotrkow Trybunalski"),
-            "Mala Helfgott 1930, Piotrkow Trybunalski",
+            "Mala Helfgott, 1930, Piotrkow Trybunalski",
         )
         self.assertEqual(
             ah.fact_value("Children", "Mikinosuke (adopted) Kurotaro (adopted) Iori (adopted)"),

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -899,6 +899,60 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
 
+    def test_round_twelve_from_the_full_pack_sample(self):
+        # A cold read of thirty articles from the full pack (stubs with
+        # infoboxes, which the essentials rarely are): hidden template spans
+        # and navigation words leaking as text, a name glued to its date, a
+        # spanning cell repeated per column, stacked header rows, a unit
+        # rule that superscripted a longitude.
+        cases = [
+            ("58°37′25″N 8°55′40″E / 58.623675°N 08.927698°E The church is", "The church is"),
+            ("released April 26, 1994 (1994-04-26) by", "released April 26, 1994 by"),
+            ("6 April (2001-04-06) – 29 June 2001 (2001-06-29)", "6 April – 29 June 2001"),
+            ("(Pub. L. Tooltip Public Law (United States)107–252 (text) (PDF))", "(Pub. L. 107–252)"),
+            ("Team v t e", "Team"),
+        ]
+        for src, want in cases:
+            self.assertEqual(ah.strip_undrawable(ah.clean_text(src), {}, lead=True), want, src)
+        self.assertEqual(ah.fact_value("Born", "Weslyn Melva Dunford October 2, 1945 Lethbridge, Alberta"), "Weslyn Melva Dunford, October 2, 1945, Lethbridge, Alberta")
+        self.assertEqual(ah.fact_value("Born", "Innokenty Mikhailovich Smoktunovich 28 March 1925 Tatyanovka"), "Innokenty Mikhailovich Smoktunovich, 28 March 1925, Tatyanovka")
+        self.assertEqual(ah.fact_value("Died", "born 3 May 1959 Chicago"), "born 3 May 1959, Chicago")
+        self.assertEqual(ah.fact_value("Coordinates", "58°37′25″N 8°55′40″E"), "58°37′25″N 8°55′40″E")
+        tables = [{"identifier": "t1",
+                   "headers": [[{"value": "Athlete"}, {"value": "Event"}, {"value": "Final"}, {"value": "Final"}],
+                               [{"value": "Athlete"}, {"value": "Event"}, {"value": "Result"}, {"value": "Rank"}]],
+                   "rows": [[{"value": "Antoni"}, {"value": "Marathon"}, {"value": "2:55:23"}, {"value": "57"}],
+                            [{"value": "Felipo"}, {"value": "100 m"}, {"value": "did not advance"}, {"value": "did not advance"}]]}]
+        secs = [{"type": "section", "name": "Athletics", "has_parts": [{"type": "table", "table_references": [{"identifier": "t1"}]}]}]
+        _, _, x, st = self.lead({"type": "paragraph", "value": "Test."}, sections=secs, tables=json.dumps(tables))
+        self.assertIn("<tr><th>Athlete</th><th>Event</th><th>Result</th><th>Rank</th></tr>", x)
+        self.assertNotIn("<th>Final</th>", x)
+        wide = [{"identifier": "t2",
+                 "headers": [[{"value": "Athlete"}, {"value": "Event"}, {"value": "Heat"}, {"value": "Rank"}, {"value": "Semi"}, {"value": "Rank"}, {"value": "Final"}, {"value": "Rank"}]],
+                 "rows": [[{"value": "Felipo"}, {"value": "100 m"}, {"value": "11.2"}, {"value": "7"}, {"value": "did not advance"}, {"value": "did not advance"}, {"value": "did not advance"}, {"value": "did not advance"}]]}]
+        secs = [{"type": "section", "name": "Athletics", "has_parts": [{"type": "table", "table_references": [{"identifier": "t2"}]}]}]
+        _, _, x, st = self.lead({"type": "paragraph", "value": "Test."}, sections=secs, tables=json.dumps(wide))
+        self.assertIn("<p><b>Felipo</b>; Event: 100 m; Heat: 11.2; Rank: 7; Semi: did not advance</p>", x)
+        # the same read, traced on the dump's own rows: "v t e" arrives on
+        # three lines; a chembox sub-label is glued to its value; a running
+        # time is spaced; two links that are the whole value are a list; a
+        # definition list keeps its values; a romanisation in parentheses
+        # beside the Greek word stands alone once the word is romanised
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("Team\nv\nt\ne"), {}), "Team")
+        self.assertEqual(ah.fact_value("Names", "Preferred IUPAC name Methyl methanesulfonate"), "Preferred IUPAC name: Methyl methanesulfonate")
+        self.assertEqual(ah.fact_value("Length", "61: 49"), "61:49")
+        self.assertEqual(ah.fact_value("Score", "61: 49"), "61: 49")
+        self.assertEqual(ah._split_at_links("Mark Waid Alex Ross", [{"text": "Mark Waid"}, {"text": "Alex Ross"}], "Created by"), "Mark Waid; Alex Ross")
+        self.assertEqual(
+            ah.strip_undrawable(ah.clean_text("related to Greek ἄγγελος (ángelos) – \"messenger\". The poets"), {}, lead=True),
+            "related to Greek ángelos – \"messenger\". The poets",
+        )
+        row = {"name": "T", "infoboxes": [{"name": "Infobox", "has_parts": [{"type": "list", "name": "Medals", "has_parts": [
+            {"type": "definition_term", "value": "Gold", "has_parts": [{"type": "definition", "value": "0"}]},
+            {"type": "definition_term", "value": "Silver", "has_parts": [{"type": "definition", "value": "1"}]}]}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]}]}
+        self.assertIn("<tr><th>Medals</th><td>Gold 0; Silver 1</td></tr>", ah.article_xhtml(row, {})[2].decode())
+
     def test_round_eleven_the_last_classes(self):
         # What round ten's measurement still flagged, each traced to the dump
         # or to a rule: Parsoid's protection markers; an unclosed ref tag; a

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -899,6 +899,27 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
 
+    def test_round_eighteen_ninth_read(self):
+        # A ninth cold read: a taxobox's "<title>: Scientific classification"
+        # row and a link caption "Official Results" are no facts; an infobox's
+        # previous/next arrows go; a semicolon before an aside and two asides
+        # where a line broke read as one; a coordinate line alone goes.
+        row = {"name": "Caladenia cleistantha", "infoboxes": [{"name": "Infobox", "has_parts": [{"type": "section", "has_parts": [
+            {"type": "field", "name": "Caladenia cleistantha", "value": "Scientific classification"},
+            {"type": "field", "name": "Kingdom", "value": "Plantae"}, {"type": "field", "name": "Results", "value": "Official Results"},
+            {"type": "field", "name": "Previous", "value": "<- 1962"}, {"type": "field", "name": "Next", "value": "1964 ->"},
+            {"type": "field", "name": "Owner", "value": "Townsquare Media; (Townsquare License, LLC)"},
+            {"type": "field", "name": "Champions", "value": "Illinois (Vacated) (1st title, 2nd title game)"}]}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [
+                {"type": "paragraph", "value": "51°51′58″N 0°22′16″E / 51.866°N 0.371°E"}, {"type": "paragraph", "value": "Test."}]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<h2 id=\"s1\">Quick facts</h2><table><tr><th>Kingdom</th><td>Plantae</td></tr>", x)
+        for gone in ("Scientific classification", "Official Results", "1962", "1964"):
+            self.assertNotIn(gone, x)
+        self.assertIn("<td>Townsquare Media (Townsquare License, LLC)</td>", x)
+        self.assertIn("<td>Illinois (Vacated; 1st title, 2nd title game)</td>", x)
+        self.assertNotIn("51°", x)
+
     def test_round_seventeen_eighth_read(self):
         # An eighth cold read: a "Title card" caption is no fact; a bare
         # "Names" group does not prefix the rows under it ("Names, House"),
@@ -920,6 +941,9 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.strip_undrawable(ah.clean_text("Deppenapostroph ('idiot's apostrophe';). Next"), {}), "Deppenapostroph ('idiot's apostrophe'). Next")
         self.assertEqual(ah.strip_undrawable(ah.clean_text("14 instances of \":) \" in"), {}), "14 instances of \":)\" in")
         self.assertNotIn("UNIQ", ah.clean_text("\"`UNIQ--templatestyles-000000C0-QINU`\" Shanghainese is"))
+        # an IPv6 prefix keeps its double colon; a doubled colon before a space collapses
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("this purpose (fec0::/10, dubbed site-local) and 2001:db8::1 here"), {}), "this purpose (fec0::/10, dubbed site-local) and 2001:db8::1 here")
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("Note:: the text,, and;, more"), {}), "Note: the text, and, more")
 
     def test_round_sixteen_seventh_read(self):
         # A seventh cold read: rp page references after a parenthesis, with

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -731,7 +731,9 @@ class Rules(unittest.TestCase):
             ("comes from the Greek word \u1f55\u03b2\u03bf\u03c2 or \u1f51\u03b2\u03cc\u03c2 meaning hump and \u1f40\u03b4\u03bf\u03cd\u03c2, meaning tooth.", "comes from the Greek word hybos meaning hump and odous, meaning tooth."),
             ("(from Greek \u1f08\u03c1\u03b9\u03b8\u03bc\u03bf\u03af, Arithmoi, lit. 'numbers'; Biblical Hebrew: \u05d1\u05b0\u05bc\u05de\u05b4\u05d3\u05b0\u05d1\u05b7\u05bc\u05e8, B\u0259m\u012b\u1e0fbar, lit. 'In desert'; Latin: Liber Numeri) is", "(from Greek Arithmoi, lit. 'numbers'; Biblical Hebrew: Bem\u012bdbar, lit. 'In desert'; Latin: Liber Numeri) is"),
             ("Seventeen Moments (Russian: \u0421\u0435\u043c\u043d\u0430\u0434\u0446\u0430\u0442\u044c, romanized: Semnadtsat') is a series about \u041c\u043e\u0441\u043a\u0432\u0430 and (\u0422\u043e\u043b\u0441\u0442\u043e\u0439).", "Seventeen Moments (Russian: Semnadtsat') is a series about Moskva and (Tolstoy)."),
-            ("The pentathlon (Greek: \u03c0\u03ad\u03bd\u03c4\u03b1\u03b8\u03bb\u03bf\u03bd) was", "The pentathlon (Greek: pentathlon) was"),
+            # the romanisation is the English word itself: the aside says nothing
+            ("The pentathlon (Greek: \u03c0\u03ad\u03bd\u03c4\u03b1\u03b8\u03bb\u03bf\u03bd) was", "The pentathlon was"),
+            ("The contest (Greek: \u03c0\u03ad\u03bd\u03c4\u03b1\u03b8\u03bb\u03bf\u03bd) was", "The contest (Greek: pentathlon) was"),
         ]
         for src, want in cases:
             self.assertEqual(ah.strip_undrawable(src, {}, lead=True), want, src)
@@ -876,6 +878,42 @@ class Rules(unittest.TestCase):
         self.assertIn('("the quarter") and U+0374 <a href="Greek">GREEK</a> sign.', x)
         self.assertNotIn("Arabic", x)
         self.assertNotIn("  ", x)
+
+    def test_round_ten_from_the_fifth_read(self):
+        # a slashed span is a pronunciation only when it holds IPA: "10
+        # μg/dL (10 μg/100 g)" is units; a label may open with a lowercase
+        # word ("simplified Chinese:"); a romanisation the sentence already
+        # has goes with its label; "(more)" is a dead link; a value left as
+        # "(muntala)" is its romanisation; electron shells keep their powers;
+        # two adjacent links in a taxon row stay as they are.
+        cases = [
+            ("adults at 10 \u03bcg/dL (10 \u03bcg/100 g) and children at 3.5 \u03bcg/dL. Next", "adults at 10 \u00b5g/dL (10 \u00b5g/100 g) and children at 3.5 \u00b5g/dL. Next"),
+            ("\"Southern China\" (simplified Chinese: \u4e2d\u56fd\u5357\u65b9; traditional Chinese: \u4e2d\u570b\u5357\u65b9) is geographically", "\"Southern China\" is geographically"),
+            ("The Neretva (Serbian Cyrillic: \u041d\u0435\u0440\u0435\u0442\u0432\u0430), also known as Narenta, is a river", "The Neretva, also known as Narenta, is a river"),
+            ("1st: 740 kJ/mol; (more) (all but first estimated)", "1st: 740 kJ/mol; (all but first estimated)"),
+            ("Myiasis (/ m a\u026a \u02c8 a\u026a \u0259 s \u0259 s / my- EYE -\u0259-s\u0259ss) is a fly", "Myiasis is a fly"),
+        ]
+        for src, want in cases:
+            self.assertEqual(ah.strip_undrawable(ah.clean_text(src), {}, lead=True), want, src)
+        self.assertEqual(ah.fact_value("Nepali", "(muntala)"), "muntala")
+        self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
+        self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
+
+    def test_round_nine_residue(self):
+        # TeX the dump left outside any block, in any shape, goes and the
+        # prose around it stays; citation page ranges in a row go; a note
+        # marker at a line's start goes; a raw ref tag goes; a no-break
+        # space beside a removed character is one space.
+        cases = [
+            ("the equations read nabla v = R nabla u \\nabla v=R\\nabla u where R is the rotation", "the equations read nabla v = R nabla u where R is the rotation"),
+            ("R 1 = A 1 A 2 B n \\right. Let us consider", "R 1 = A 1 A 2 B n. Let us consider"),
+            ("shear stresses: p.45\u201378 : p.1\u201346 : p.111\u2013157 The normal stress", "shear stresses The normal stress"),
+            ("## x: Nickel\u2013Strunz mineral/group number", "x: Nickel\u2013Strunz mineral/group number"),
+            ("the medium. <ref name=\"a3\">cite</ref> Next and <ref name=\"x\"/> end", "the medium. Next and end"),
+            ("China\u00a0 Merrill's Marauders", "China Merrill's Marauders"),
+        ]
+        for src, want in cases:
+            self.assertEqual(ah.strip_undrawable(ah.clean_text(src), {}, lead=True), want, src)
 
     def test_round_eight_seams(self):
         # From the fourth cold read: a comma inserted after a botanical

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -899,6 +899,32 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
 
+    def test_round_sixteen_seventh_read(self):
+        # A seventh cold read: rp page references after a parenthesis, with
+        # "fn. 2", or after a bare word go; a combining author keeps its
+        # shape ("(D.Don) Merr."); a template parameter leaked as a value is
+        # no fact; two fields the dump glued ("Batted: Right Threw: Right")
+        # are two rows; a nameless "Coordinates (Trzcinica): ..." takes its
+        # label, parenthesis and all.
+        cases = [
+            ("with indigenous (pre-European) literary traditions.: 112, fn. 2 The next", "with indigenous (pre-European) literary traditions. The next"),
+            ("science, mathematics, or medicine.): xii The", "science, mathematics, or medicine.) The"),
+            ("during the 1838 Battle of the Windmill: 288 George's brother Angus", "during the 1838 Battle of the Windmill George's brother Angus"),
+            ("the ratio is 3: 1 in the", "the ratio is 3: 1 in the"),
+        ]
+        for src, want in cases:
+            self.assertEqual(ah.clean_text(src), want, src)
+        self.assertEqual(ah.fact_value("Binomial name", "Wightia speciosissima (D.Don) Merr."), "Wightia speciosissima (D.Don) Merr.")
+        row = {"name": "Ray Herbert", "infoboxes": [{"name": "Infobox", "has_parts": [{"type": "section", "name": "Gmina", "has_parts": [
+            {"type": "field", "value": "Batted: Right Threw: Right"}, {"type": "field", "value": "Coordinates (Trzcinica): 51°10′2″N 18°0′17″E"}]},
+            {"type": "field", "name": "Products", "value": "share_of_grocery_market_in_Taiwan =41.3%"}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<tr><th>Batted</th><td>Right</td></tr><tr><th>Threw</th><td>Right</td></tr>", x)
+        self.assertIn("<tr><th>Coordinates (Trzcinica)</th><td>51°10′2″N 18°0′17″E</td></tr>", x)
+        self.assertNotIn("share_of", x)
+        self.assertNotIn("<th>Gmina</th>", x)
+
     def test_round_fifteen_sixth_read(self):
         # A sixth cold read: the s of a cricket "50s" is not a second; a label
         # before "also Romanized as" is empty; "Population (2006), total" is

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -899,6 +899,16 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
 
+    def test_lead_with_bold_subject_is_scrubbed_too(self):
+        # The lead's bold-subject branch returned before the inline scrub, so
+        # "(Latin, "trumpet"; UK: /.../)" kept a ";)" once its pronunciation
+        # went. Both branches scrub now.
+        row = {"name": "Tuba", "sections": [{"type": "section", "name": "Abstract", "has_parts": [
+            {"type": "paragraph", "value": "The tuba (Latin, \"trumpet\"; UK: / \u02c8 tju\u02d0b\u0259 /) is a large brass instrument.", "links": [{"url": "https://en.wikipedia.org/wiki/Latin", "text": "Latin"}]}]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<p>The <b>tuba</b> (<a href=\"Latin\">Latin</a>, \"trumpet\") is a large brass instrument.</p>", x)
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("Article 26 :(1) Everyone has the right"), {}), "Article 26 :(1) Everyone has the right")
+
     def test_round_eighteen_ninth_read(self):
         # A ninth cold read: a taxobox's "<title>: Scientific classification"
         # row and a link caption "Official Results" are no facts; an infobox's

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -899,6 +899,20 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Electron configuration", "5f 14 6d 5 7s 2"), "5f\u00b9\u2074 6d\u2075 7s\u00b2")
         self.assertEqual(ah._split_at_links("Tortricoidea Latreille, 1803", [{"text": "Tortricoidea"}, {"text": "Latreille"}], "Superfamily"), "Tortricoidea Latreille, 1803")
 
+    def test_label_that_is_a_whole_link_goes_with_its_colon(self):
+        # Scrubbing the bold-subject lead exposed a label living inside a link
+        # ("<a>Hebrew</a>:;" once the Hebrew script went): the inline rule's
+        # lookbehind cannot see past the ">", so the anchor goes with its
+        # colon. A label with content after it keeps both.
+        row = {"name": "Ariel Sharon", "sections": [{"type": "section", "name": "Abstract", "has_parts": [
+            {"type": "paragraph", "value": "Ariel \"Arik\" Sharon (Hebrew: \u05d0\u05e8\u05d9\u05d0\u05dc \u05e9\u05e8\u05d5\u05df; 26 February 1928 \u2013 11 January 2014) was an Israeli general.",
+             "links": [{"url": "https://en.wikipedia.org/wiki/Hebrew_language", "text": "Hebrew"}]}]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<p><b>Ariel</b> \"Arik\" Sharon (26 February 1928 \u2013 11 January 2014) was an Israeli general.</p>", x)
+        row = {"name": "T", "sections": [{"type": "section", "name": "Abstract", "has_parts": [
+            {"type": "paragraph", "value": "Vizing's Theorem: A graph of maximal degree.", "links": [{"url": "https://en.wikipedia.org/wiki/Vizing's_theorem", "text": "Vizing's Theorem:"}]}]}]}
+        self.assertIn("<a href=\"Vizing's theorem\">Vizing's Theorem:</a> A graph", ah.article_xhtml(row, {})[2].decode())
+
     def test_lead_with_bold_subject_is_scrubbed_too(self):
         # The lead's bold-subject branch returned before the inline scrub, so
         # "(Latin, "trumpet"; UK: /.../)" kept a ";)" once its pronunciation

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -913,6 +913,24 @@ class Rules(unittest.TestCase):
             "The tuba (Latin, \"trumpet\") is a large",
         )
 
+    def test_round_nineteen_tenth_read(self):
+        # A tenth cold read: a Unicode hyphen is a hyphen; a table's header
+        # row that arrived as a field ("Years: Team") is no fact; a footnote
+        # asterisk on a group goes; an empty cell the dump wrote as a dash
+        # goes; a fixture template's time zone on a line of its own goes.
+        self.assertEqual(ah.clean_text("a 2022 Indian Bengali\u2011language romantic drama"), "a 2022 Indian Bengali-language romantic drama")
+        row = {"name": "Joseph Nixon", "infoboxes": [{"name": "Infobox", "has_parts": [{"type": "section", "name": "Senior career*", "has_parts": [
+            {"type": "field", "name": "Years", "value": "Team"}, {"type": "field", "name": "1957\u20131960", "value": "Niort"}, {"type": "field", "name": "Total", "value": "29 (1)"}]}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]},
+                {"type": "section", "name": "Matches", "has_parts": [{"type": "table", "table_references": [{"identifier": "t1"}]}, {"type": "paragraph", "value": "KGT"}, {"type": "paragraph", "value": "NASA launched."}]}],
+            "tables": json.dumps([{"identifier": "t1", "headers": [[{"value": "Date"}, {"value": "Home"}, {"value": "Score"}, {"value": "Away"}, {"value": "Venue"}, {"value": "Att."}, {"value": "Ref"}, {"value": "Notes"}]],
+                "rows": [[{"value": "30 May 2021"}, {"value": "Alay"}, {"value": "BYE"}, {"value": "-"}, {"value": "Osh"}, {"value": "-"}, {"value": ""}, {"value": ""}]]}])}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<table><tr><th>1957\u20131960</th><td>Niort</td></tr><tr><th>Senior career, total</th><td>29 (1)</td></tr></table>", x)
+        self.assertNotIn("<th>Years</th>", x)
+        self.assertIn("<p><b>30 May 2021</b>; Home: Alay; Score: BYE; Venue: Osh</p><p>NASA launched.</p>", x)
+        self.assertNotIn("<p>KGT</p>", x)
+
     def test_round_eighteen_ninth_read(self):
         # A ninth cold read: a taxobox's "<title>: Scientific classification"
         # row and a link caption "Official Results" are no facts; an infobox's

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -952,6 +952,35 @@ class Rules(unittest.TestCase):
             {"type": "definition_term", "value": "Silver", "has_parts": [{"type": "definition", "value": "1"}]}]}]}],
             "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "Test."}]}]}
         self.assertIn("<tr><th>Medals</th><td>Gold 0; Silver 1</td></tr>", ah.article_xhtml(row, {})[2].decode())
+        # a second cold read of a fresh full sample: "in 2:11:53" is a time,
+        # not square inches; a label before another label is empty; the
+        # end-date template's copy of the year; a nameless "Coordinates: ..."
+        # value takes its label as its name and keeps one notation; the
+        # infobox's own header is not a group; a word leaked into a name;
+        # "Official website" becomes the address the reader can type
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("who broke the world record in 2:11:53 at"), {}), "who broke the world record in 2:11:53 at")
+        self.assertEqual(
+            ah.strip_undrawable(ah.clean_text("Namgyal (Tibetan: Wylie: zhabs drung ngag dbang rnam rgyal; 1594) was"), {}, lead=True),
+            "Namgyal (Wylie: zhabs drung ngag dbang rnam rgyal; 1594) was",
+        )
+        self.assertEqual(ah.fact_value("Defunct", "1939 (1939)"), "1939")
+        self.assertEqual(ah.fact_value("Founded", "1939 (1940)"), "1939 (1940)")
+        row = {"name": "John Bloomfield (British Army officer)", "infoboxes": [{"name": "Infobox military person", "has_parts": [
+            {"type": "section", "name": "General Sir John Bloomfield GCB", "has_parts": [
+                {"type": "field", "name": "Rank", "value": "General"},
+                {"type": "field", "name": "team Former teams", "value": "Retired"},
+                {"type": "field", "name": "Website", "value": "Official website", "links": [{"url": "https://www.comune.frascineto.cs.it/", "text": "Official website"}]},
+            ]},
+            {"type": "section", "name": "Plateau", "has_parts": [
+                {"type": "field", "value": "Coordinates: 41°37′00″N 44°00′00″E / 41.61667°N 44.00000°E"},
+            ]}]}],
+            "sections": [{"type": "section", "name": "Abstract", "has_parts": [{"type": "paragraph", "value": "John Bloomfield was a general."}]}]}
+        x = ah.article_xhtml(row, {})[2].decode()
+        self.assertIn("<tr><th>Rank</th><td>General</td></tr>", x)
+        self.assertIn("<tr><th>Former teams</th><td>Retired</td></tr>", x)
+        self.assertIn("<tr><th>Website</th><td>comune.frascineto.cs.it</td></tr>", x)
+        self.assertIn("<tr><th>Coordinates</th><td>41°37′00″N 44°00′00″E</td></tr>", x)
+        self.assertNotIn("GCB", x.split("Quick facts")[1])
 
     def test_round_eleven_the_last_classes(self):
         # What round ten's measurement still flagged, each traced to the dump

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -908,6 +908,10 @@ class Rules(unittest.TestCase):
         x = ah.article_xhtml(row, {})[2].decode()
         self.assertIn("<p>The <b>tuba</b> (<a href=\"Latin\">Latin</a>, \"trumpet\") is a large brass instrument.</p>", x)
         self.assertEqual(ah.strip_undrawable(ah.clean_text("Article 26 :(1) Everyone has the right"), {}), "Article 26 :(1) Everyone has the right")
+        self.assertEqual(
+            ah.strip_undrawable(ah.clean_text("The tuba (Latin, \"trumpet\"; UK: / \u02c8 tju\u02d0b\u0259 /; US: / \u02c8 tu\u02d0b\u0259 /) is a large"), {}, lead=True),
+            "The tuba (Latin, \"trumpet\") is a large",
+        )
 
     def test_round_eighteen_ninth_read(self):
         # A ninth cold read: a taxobox's "<title>: Scientific classification"

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -912,6 +912,14 @@ class Rules(unittest.TestCase):
         self.assertNotIn("Title card", x)
         self.assertIn("<tr><th>House</th><td>Braganza</td></tr><tr><th>Father</th><td>Pedro I of Brazil</td></tr>", x)
         self.assertIn("<tr><th>Chinese name, Hanyu Pinyin</th><td>Quanlian Fuli Zhongxin</td></tr>", x)
+        # from the ess-q18 gate: the tidy rules run on untouched text too, so
+        # the dump's own "(e.g.:)" and "apostrophe';)" close cleanly; an
+        # apostrophe closing a quoted word is not an emoticon's eye; Parsoid's
+        # strip markers go
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("zero-day exploits (e.g.:) in Windows"), {}), "zero-day exploits (e.g.) in Windows")
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("Deppenapostroph ('idiot's apostrophe';). Next"), {}), "Deppenapostroph ('idiot's apostrophe'). Next")
+        self.assertEqual(ah.strip_undrawable(ah.clean_text("14 instances of \":) \" in"), {}), "14 instances of \":)\" in")
+        self.assertNotIn("UNIQ", ah.clean_text("\"`UNIQ--templatestyles-000000C0-QINU`\" Shanghainese is"))
 
     def test_round_sixteen_seventh_read(self):
         # A seventh cold read: rp page references after a parenthesis, with
@@ -1201,7 +1209,7 @@ class Rules(unittest.TestCase):
         # page numbers after a period go; "(number 8)" is not a face
         more = [
             ("including 14 instances of \":) \" in Richard", "including 14 instances of \":)\" in Richard"),
-            ("the Ahl ad-dār (\"House of the Mahdi:), composed of", "the Ahl ad-dār (\"House of the Mahdi:), composed of"),
+            ("the Ahl ad-dār (\"House of the Mahdi:), composed of", "the Ahl ad-dār (\"House of the Mahdi), composed of"),
             ("cultivars are ''Prunus serrulata'''Grandiflora' A. Wagner and ''Prunus serrulata'''Gioiko' Koidz", "cultivars are Prunus serrulata 'Grandiflora' A. Wagner and Prunus serrulata 'Gioiko' Koidz"),
             ("Notable out-fighters include '''Sydney Greve''', Muhammad Ali", "Notable out-fighters include Sydney Greve, Muhammad Ali"),
             ("the derivative f''(x) and f'''(x) of f", "the derivative f''(x) and f'''(x) of f"),

--- a/tools_local/wikipedia/tests/test_article_html.py
+++ b/tools_local/wikipedia/tests/test_article_html.py
@@ -1008,6 +1008,18 @@ class Rules(unittest.TestCase):
         self.assertEqual(ah.fact_value("Born", "26 May 1564 /1563, Sirhind"), "26 May 1564/1563, Sirhind")
         self.assertEqual(ah.strip_undrawable(ah.clean_text("set (P, ≤) forms and x =(y+1) and a face :) here"), {}), "set (P, <=) forms and x =(y+1) and a face :) here")
 
+    def test_rules_finish_on_long_runs(self):
+        # A rule of 36 "=" stalled the full build: the trailing-equals rule
+        # was ambiguous and backtracked exponentially. Every rule must finish
+        # a long run of one character in well under a second.
+        import time
+        for ch in "=-_*.'\"()[]{}|/\\#:;,<>~^ ":
+            for src in ("x " + ch * 400 + " y", ch * 400, "x " + (ch + " ") * 200 + "y"):
+                t = time.time()
+                ah.strip_undrawable(ah.clean_text(src), {}, lead=True)
+                ah.fact_value("Name", src)
+                self.assertLess(time.time() - t, 1.0, repr(ch))
+
     def test_round_eleven_the_last_classes(self):
         # What round ten's measurement still flagged, each traced to the dump
         # or to a rule: Parsoid's protection markers; an unclosed ref tag; a

--- a/tools_local/wikipedia/tests/test_tex_text.py
+++ b/tools_local/wikipedia/tests/test_tex_text.py
@@ -67,6 +67,13 @@ class Render(unittest.TestCase):
             self.assertEqual(tex_text.loose(tex_text.leaves(tex, skip_matrices=skip)), tex_text.loose(words), tex)
 
 
+class TextArguments(unittest.TestCase):
+    def test_comma_in_text_gets_its_space(self):
+        text, complete = tex_text.render(r"W_{A\to B}^{\text{adiabatic,quasi-static}}")
+        self.assertTrue(complete)
+        self.assertEqual(text, "W_(A -> B)^(adiabatic, quasi-static)")
+
+
 class Integration(unittest.TestCase):
     def test_words_replaced_by_the_rendering(self):
         src = ("Then using J z 0 = − J z 1 {\\displaystyle J_{z}^{0}=-J_{z}^{1}} and L 2, S 2, J 2 "

--- a/tools_local/wikipedia/tests/test_tex_text.py
+++ b/tools_local/wikipedia/tests/test_tex_text.py
@@ -42,6 +42,7 @@ class Render(unittest.TestCase):
             (r"\binom {n}{k}", "C(n, k)"),
             (r"\sqrt[3]{x}", "root(3, x)"),
             (r"x_{i+1}", "x_(i + 1)"),
+            (r"x_{i}\in X_{i}{\text{ for every }}i\in \{1,\dots ,n\}", "x_i in X_i for every i in {1, ..., n}"),
         ]
         for tex, want in cases:
             text, complete = tex_text.render(tex)

--- a/tools_local/wikipedia/tex_text.py
+++ b/tools_local/wikipedia/tex_text.py
@@ -896,8 +896,10 @@ class Renderer:
             self.complete = False
             return " " + name + " "
         if kind == "plain":
-            # words are words: "otherwise", "gain-db", "in"; no token spacing
+            # words are words: "otherwise", "gain-db", "in"; no token spacing,
+            # but a comma between words gets its space ("adiabatic,quasi-static")
             text = "".join(c[1] if c[0] == "char" else self.node(c) for c in n[2])
+            text = re.sub(r"(?<=[A-Za-z]),(?=[A-Za-z])", ", ", text)
             if n[1] in (
                 "operatorname",
                 "operatorname*",

--- a/tools_local/wikipedia/tex_text.py
+++ b/tools_local/wikipedia/tex_text.py
@@ -581,6 +581,22 @@ class Parser:
             self.i += 1
         return nodes
 
+    def raw_group(self):
+        """At "{": the text inside, past the matching "}", spaces kept."""
+        depth = 0
+        j = self.i
+        while j < len(self.s):
+            if self.s[j] == "{":
+                depth += 1
+            elif self.s[j] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            j += 1
+        raw = self.s[self.i + 1 : j]
+        self.i = j + 1
+        return raw
+
     def argument(self):
         """One argument: a group, or the next single token."""
         self.skip_space()
@@ -669,6 +685,13 @@ class Parser:
         if name in PLAIN_ARG:
             if name in ("color", "textcolor"):
                 self.argument()  # the colour
+            if name in ("text", "textrm", "textbf", "textit", "textsf", "texttt", "mbox", "hbox", "operatorname", "operatorname*", "mathrm"):
+                self.skip_space()
+                if self.peek() == "{":
+                    raw = self.raw_group()
+                    if "\\" not in raw:
+                        return ("plain", name, [("char", raw)])
+                    self.i -= len(raw) + 2  # a command inside: parse it after all
             return ("plain", name, self.argument())
         if name in (
             "phantom",


### PR DESCRIPTION
Text-only English Wikipedia for the X4 Pro: the conversion rules, the measuring
instruments, and the build and publish pipeline.

**What is live.** `en-2026-05-full6` at packs.ma-r-s.com/wikipedia/en:
7,183,042 articles in 41 shards (10.35 GB by card reader) with an essentials
tier of 49,717 articles (0.47 GB by cable). The page at
crossplay.ma-r-s.com/wikipedia/ serves both routes.

**How the text is made.** `tools_local/wikipedia/article_html.py` turns one row
of Wikimedia's structured dump into the XHTML the reader shows. Every rule in
it was written from a measurement, never from a guess:

- `census.py` counts every code point above ASCII, what the pipeline does to it
  and what the article loses;
- `quality.py` runs 69 detectors over a built pack (structure, headings, words,
  balance, remnants, encoding, formulas, tables, links) and refuses to bless a
  pack while any zero-tolerance class is non-empty;
- `tex_text.py` renders formulas from the dump's TeX into linear text the serif
  can draw, and replaces the dump's flattened words only when the two agree.

**How it was verified.** Twenty-three rounds on the night of 2026-09-11/12.
Each round: sample thirty random articles from the pack that ships, render
them, hand them to a reviewer who has never seen the converter, trace every
finding back to the raw row before writing a rule, then rebuild and re-gate.
Fourteen such reads. What the reads still find is the dump's own losses (line
breaks inside a cell arriving as a space, group headers absent, subscripts
gone, values that were images) rather than damage we do.

**Not verified.** The card-in-reader route on real hardware. Everything else
was checked on the simulator and against the live pack.

Tests: 115 host tests in `tools_local/wikipedia/tests`, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
