### PR TITLE
wikipedia: the nested-list separator must not start a line

### DIFF
--- a/tools_local/wikipedia/quality.py
+++ b/tools_local/wikipedia/quality.py
@@ -640,6 +640,18 @@ def plain(xhtml):
     return re.sub(r"\n\s*\n+", "\n", t).strip()
 
 
+def _unnest(inner):
+    """A list item's own text and the list nested under it are two lines on
+    the panel, not one word. The separator goes in only when the item has
+    text of its own: a line that STARTS with ": " is wikitext list syntax to
+    the remnant detectors, which is how 164 articles were flagged once."""
+
+    def sep(m):
+        before = _TAG.sub("", inner[: m.start()]).strip()
+        return ": " if before else " "
+
+    return _NESTED_LIST.sub(sep, inner)
+
 def blocks(xhtml):
     """[(kind, text)] in document order; kind is h1..h6, p, li or table.
     A table's text is its rows as (name, value) pairs."""
@@ -659,7 +671,7 @@ def blocks(xhtml):
         else:
             # a list item's own text and a list nested under it are two
             # lines on the panel, not one word: "Ice cream" + "Chapman's"
-            inner = _NESTED_LIST.sub(": ", inner)
+            inner = _unnest(inner)
             out.append((kind, html.unescape(_TAG.sub("", inner)).strip()))
     return out
 


### PR DESCRIPTION
Yesterday's instrument fix traded one false positive for a worse one. A list
item whose only content is a nested list came out as `: Chapman's`, and a line
starting with `: ` is wikitext list syntax to the remnant detectors, so
`wikitext_line` went from 3 articles to 164 while `camel_glue` went from 1,108
to 0. The separator now goes in only when the item has text of its own.

Measured on one built pack, so the three rows are comparable:

| | camel_glue | wikitext_line |
|---|---:|---:|
| before | 1108 | 3 |
| broken | 0 | 164 |
| now | 0 | 3 |

With that the gate passes a real pack for the first time, and the same scan
confirms the empty-label fix from #193's sibling commit: 47 articles down to 2.

    ARTIFACT SCORE: 19 articles across 7 classes (at most 25 allowed)
    QUALITY GATE: passed (19 of at most 25 articles carry an artifact; ...)

Tests: 115 host tests, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)